### PR TITLE
feat: add interactive pick command with fzf

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A **memo and snippet CLI** for the terminal. Store frequently used commands, con
 
 ## Features
 
-- **Fast save and recall**: Manage entries with `add`, `ls`, `show`, `edit`, and `rm`.
+- **Fast save and recall**: Manage entries with `add`, `list`, `show`, `edit`, `pick`, and `remove`.
 - **Flexible input**: Arguments, heredocs, pipes, or `$EDITOR`.
 - **Tags**: Classify, filter, and batch-edit with multiple tags.
 - **Shortcuts**: Assign a memorable string alias to any entry and use it in place of a numeric index.
 - **Shell-friendly**: `raw` prints body-only text for `eval`, aliases, and scripts.
 - **Variable substitution**: Expand `${KEY}` and `$1 $2 ...` placeholders at recall time with `--var` / `-V`.
-- **Display index**: Each entry has a stable `uid` (sha1 short hash) and a user-controlled `idx`. Reorder freely with `mv`/`sw`, and close gaps with `compact`.
+- **Display index**: Each entry has a stable `uid` (sha1 short hash) and a user-controlled `idx`. Reorder freely with `move`/`swap`, and close gaps with `compact`.
 - **XDG-friendly**: Default data under `~/.local/share/koda/`, config under `~/.config/koda/`.
 - **Configurable defaults**: Persist preferences like default command or list page size in `~/.config/koda/config.toml`.
 
@@ -48,12 +48,12 @@ Stop memorizing long `docker`, `kubectl`, or `ffmpeg` invocations.
 
 ```bash
 koda add "docker compose -f docker-compose.dev.yml up --build" -t docker,dev
-koda ls
+koda list
 # Suppose the new entry is at display index 12 — execute directly:
-koda ex 12
+koda exec 12
 ```
 
-Put **only the command you intend to run** in the body. The editor template keeps metadata in a separate `---` block. Because `ex` runs shell code, **store only trusted text**.
+Put **only the command you intend to run** in the body. The editor template keeps metadata in a separate `---` block. Because `exec` runs shell code, **store only trusted text**.
 
 ### 2. Config templates and Dockerfile fragments
 
@@ -74,7 +74,7 @@ Save authenticated `curl` one-liners or common `SELECT` statements; search with 
 
 ```bash
 koda add -t api,curl 'curl -sS -H "Authorization: Bearer $TOKEN" https://api.example.com/v1/status'
-koda ls -q "curl"
+koda list -q "curl"
 ```
 
 ### 4. Cheat sheets and plain notes (not only commands)
@@ -83,12 +83,12 @@ Git recipes, install commands, meeting notes — anything that fits in plain tex
 
 ```bash
 koda add "git reset --soft HEAD~1   # undo last commit, keep changes" -t git
-koda ls -t git
+koda list -t git
 ```
 
 ### 5. Execute stored commands and pipe into scripts
 
-`raw` writes plain stdout (no Rich), so `$(koda raw <IDX>)` feeds the body directly into another command as an argument. Use `koda ex` to run the body as a shell command. **Keep the body simple** when you automate: extra newlines or prose can break word splitting.
+`raw` writes plain stdout (no Rich), so `$(koda raw <IDX>)` feeds the body directly into another command as an argument. Use `koda exec` to run the body as a shell command. **Keep the body simple** when you automate: extra newlines or prose can break word splitting.
 
 ```bash
 # Store a path
@@ -102,10 +102,10 @@ koda add "user@prod.example.com" -t ssh
 ssh $(koda raw)
 
 # Execute the latest entry as a shell command
-koda ex
+koda exec
 
 # Execute entry at index 5 (works for single-line and multi-line)
-koda ex 5
+koda exec 5
 
 # Capture body into a variable
 CONTENT=$(koda raw)
@@ -114,10 +114,24 @@ echo "$CONTENT"
 
 ## Command reference
 
+### One-letter subcommand aliases
+
+Each top-level subcommand has a single-letter alias:
+
+```bash
+a add      c copy     d remove   e edit
+g config   h shift    k compact  l list
+m move     p pick     r raw      s show
+t tag      w swap     x exec
+```
+
+Single-letter aliases are reserved and cannot be used as entry shortcuts.
+
 ### Add
 
 ```bash
 koda add "One-line memo" -t tag1,tag2
+koda a "Quick memo via alias" -t quick
 koda add -t snippet <<EOF
 multi-line
 snippet
@@ -150,25 +164,26 @@ cat ~/.ssh/config | koda add -t ssh
 ### List and search
 
 ```bash
-koda ls                        # entries ordered by display index (IDX)
-koda ls -n 50                  # 50 entries per page
-koda ls -p 2                   # show page 2
-koda ls -n 25 -p 3             # page 3 at 25 entries per page
-koda ls --rows 1               # 1-line content preview (default)
-koda ls --rows 10              # 10-line content preview
-koda ls --rows 0               # show all lines
-koda ls --truncate 80          # truncate lines at 80 characters
-koda ls --truncate 0           # disable line truncation
-koda ls -s created_at --desc   # sort by created_at descending
-koda ls -s shortcut --asc      # sort alphabetically by shortcut
-koda ls -q "docker"            # substring search on body
-koda ls -t "linux"             # filter by tag substring
-koda ls -T "archive"           # exclude entries tagged "archive"
-koda ls --shortcuts            # show only entries that have a shortcut (-S)
+koda list                        # entries ordered by display index (IDX)
+koda l -q "docker"              # same as `koda list -q "docker"`
+koda list -n 50                  # 50 entries per page
+koda list -p 2                   # show page 2
+koda list -n 25 -p 3             # page 3 at 25 entries per page
+koda list --rows 1               # 1-line content preview (default)
+koda list --rows 10              # 10-line content preview
+koda list --rows 0               # show all lines
+koda list --truncate 80          # truncate lines at 80 characters
+koda list --truncate 0           # disable line truncation
+koda list -s created_at --desc   # sort by created_at descending
+koda list -s shortcut --asc      # sort alphabetically by shortcut
+koda list -q "docker"            # substring search on body
+koda list -t "linux"             # filter by tag substring
+koda list -T "archive"           # exclude entries tagged "archive"
+koda list --shortcuts            # show only entries that have a shortcut (-S)
 ```
 
 Each row shows `IDX` (display index), `UID` (7-char sha1), `SC` (shortcut), tags, content preview, and creation time.
-`ls` always prints summary stats below the table: total entries, total pages, and max IDX.
+`list` always prints summary stats below the table: total entries, total pages, and max IDX.
 Sort columns are: `id`, `idx`, `uid`, `tags`, `content`, `created_at`, `modified_at`, `shortcut`. Use `--desc` / `--asc` to choose direction.
 Use `--rows 0` to display full content lines in the list.
 Use `--truncate` to control max characters per content line (`0` disables truncation).
@@ -178,17 +193,56 @@ Use `--exclude-tag` / `-T` to hide entries that match a tag substring.
 
 ```bash
 koda show 1
+koda s 1                   # same as `koda show 1`
 koda show deploy         # look up by shortcut
 koda edit 1
+koda e deploy            # same as `koda edit deploy`
 koda edit deploy         # edit entry by shortcut (shortcut editable in footer)
-koda cp 1                # duplicate to a new entry (shortcut is not copied)
-koda rm 1                # delete with confirmation
-koda rm deploy           # delete by shortcut
-koda rm 1 3 5-8          # delete multiple entries or ranges
-koda rm -t archive       # delete all entries tagged "archive"
-koda rm -q "tmp"         # delete entries matching body substring
-koda rm --all -f         # delete everything (--all always requires -f)
+koda copy 1                # duplicate to a new entry (shortcut is not copied)
+koda c 1                   # same as `koda copy 1`
+koda remove 1              # delete with confirmation
+koda d 1                   # same as `koda remove 1`
+koda remove deploy         # delete by shortcut
+koda remove 1 3 5-8        # delete multiple entries or ranges
+koda remove -t archive     # delete all entries tagged "archive"
+koda remove -q "tmp"       # delete entries matching body substring
+koda remove --all -f       # delete everything (--all always requires -f)
 ```
+
+### Pick with `fzf` (`pick`)
+
+Interactively select an entry, then run an action. By default, `pick` uses `defaults.cmd` (when it is `raw` or `show`).
+
+```bash
+# Pick and run default action (depends on defaults.cmd)
+koda pick
+koda p
+
+# Pick and execute immediately
+koda pick -x
+koda p -x
+koda pick --exec
+
+# Pick and edit immediately
+koda pick -e
+
+# Pick and only print IDX for command substitution / pipes
+koda pick -p
+koda show "$(koda pick -p)"
+koda s "$(koda p -p)"
+koda exec "$(koda pick -p)"
+koda x "$(koda p -p)"
+
+# Filter candidate list before selection
+koda pick -q "docker" -t dev
+koda p -q "docker" -t dev
+koda pick -T archive -S
+```
+
+Action flags are exclusive: choose one of `-e/--edit`, `-x/--exec`, `-r/--raw`, `-s/--show`.
+`-p/--print-id` cannot be combined with action flags.
+`pick` requires [`fzf`](https://github.com/junegunn/fzf) and an interactive TTY.
+`pick` uses an adaptive preview layout: wide terminals use a right-side preview, narrower terminals use a bottom preview (both wrapped) so the candidate list remains readable.
 
 ### Shortcuts
 
@@ -200,16 +254,20 @@ koda add "kubectl rollout restart deploy/api" -t k8s --shortcut restart
 
 # Use the shortcut anywhere an index is accepted:
 koda raw restart       # print body
-koda ex restart        # execute
+koda r restart         # same as `koda raw restart`
+koda exec restart      # execute
+koda x restart         # same as `koda exec restart`
 koda show restart      # show with metadata
-koda rm restart        # delete
+koda s restart         # same as `koda show restart`
+koda remove restart    # delete
+koda d restart         # same as `koda remove restart`
 
 # Or use the default command directly (no subcommand needed):
 koda restart           # same as `koda raw restart` when defaults.cmd = raw
 
 # List all entries that have shortcuts:
-koda ls --shortcuts
-koda ls -S --sort-by shortcut
+koda list --shortcuts
+koda list -S --sort-by shortcut
 ```
 
 To change or remove a shortcut, use `edit` — the `shortcut:` field appears in the metadata footer.
@@ -218,6 +276,7 @@ To change or remove a shortcut, use `edit` — the `shortcut:` field appears in 
 
 ```bash
 koda raw          # latest entry body only
+koda r            # same as `koda raw`
 koda raw 5        # entry at display index 5, body only
 koda raw deploy   # entry with shortcut "deploy", body only
 koda 5            # numeric args route to the default command
@@ -240,27 +299,30 @@ echo '#literal'
 echo "value#suffix"   # no whitespace before #
 ```
 
-### Reorder entries (`mv`, `sw`, `shift`, `compact`)
+### Reorder entries (`move`, `swap`, `shift`, `compact`)
 
 Each entry has a display index (`IDX`) you can freely rearrange — handy for keeping frequently used snippets at low numbers (0–9).
 
 ```bash
-koda sw 3 0        # swap display positions of entries 3 and 0
-koda mv 7 1        # move entry 7 to empty position 1 (position must be unoccupied)
+koda swap 3 0      # swap display positions of entries 3 and 0
+koda w 3 0         # same as `koda swap 3 0`
+koda move 7 1      # move entry 7 to empty position 1 (position must be unoccupied)
+koda m 7 1         # same as `koda move 7 1`
 koda shift 1       # shift all entries at index 1 and above up by 1 (makes room at 1)
+koda h 1           # same as `koda shift 1`
 koda shift 1 -n 3  # shift up by 3 positions
 koda shift 5 -n -1 # shift entries from index 5 downward by 1
 koda compact       # reassign indices to 0..n-1 and fill gaps
+koda k             # same as `koda compact`
 ```
 
-`mv` requires the destination index to be unoccupied. Use `shift` first to make room, or `sw` to exchange two occupied positions.
-
-Long-form aliases: `move` → `mv`, `swap` → `sw`.
+`move` requires the destination index to be unoccupied. Use `shift` first to make room, or `swap` to exchange two occupied positions.
 
 ### Batch tag (`tag`)
 
 ```bash
 koda tag 1 3 5 -t work          # add tag to individual entries
+koda t 1 3 5 -t work            # same as `koda tag ...`
 koda tag 2-6 -t archive         # add tag to a range
 koda tag 1 3-5 7 -T old         # remove tag from mixed selection
 koda tag 1 -t new -T old        # add one tag and remove another in one command
@@ -291,16 +353,16 @@ gcloud storage cp ./report.csv gs://my-company-analytics-prod-us-central1/upload
 koda add "gcloud storage cp \$1 gs://my-company-analytics-prod-us-central1/uploads/" -t gcloud,storage
 
 # From now on:
-koda ex -V ./report.csv
-koda ex -V ./summary.csv
+koda exec -V ./report.csv
+koda exec -V ./summary.csv
 ```
 
 Same pattern works for AWS S3:
 
 ```bash
 koda add "aws s3 sync \$1 s3://acme-frontend-assets-prod-us-east-1/app/" -t aws,s3
-koda ex -V ./dist
-koda ex -V ./build
+koda exec -V ./dist
+koda exec -V ./build
 ```
 
 Pass two positional values with repeated `-V` flags or space-separated in one:
@@ -317,8 +379,8 @@ koda raw 8 -V "/src/path /user@host:/dest"   # same result
 # Deploy to different environments by changing one variable:
 koda add "aws s3 sync ./dist s3://acme-frontend-\${env}-us-east-1/app/" -t aws,s3,deploy
 
-koda ex -V env=prod
-koda ex -V env=staging
+koda exec -V env=prod
+koda exec -V env=staging
 ```
 
 **Mix named and positional** — order of `-V` flags determines positional index:
@@ -336,11 +398,11 @@ Values containing spaces must be quoted so the shell passes them as one token:
 -V "admin 5432"         # two positional values: admin → $1, 5432 → $2
 ```
 
-**Execute with substitution** (`ex` command):
+**Execute with substitution** (`exec` command):
 
 ```bash
-koda ex 7 -V env=prod
-koda ex 7 -V ./report.csv
+koda exec 7 -V env=prod
+koda exec 7 -V ./report.csv
 ```
 
 ## Configuration
@@ -363,7 +425,7 @@ desc = false      # sort direction
 path = "~/.local/share/koda/koda.db"
 
 [exec]
-shell = "sh"      # shell used by `ex`
+shell = "sh"      # shell used by `exec`
 ```
 
 ### `config` subcommand

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koda"
-version = "0.1.0"
+version = "1.0.0"
 description = "Koda: A fast CLI for memos and terminal snippets."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 import re
 import signal
+import shutil
 from datetime import datetime
 from importlib.metadata import version
 from pathlib import Path
@@ -24,13 +25,23 @@ DATETIME_FMT = "%Y-%m-%d %H:%M:%S"
 
 
 ALIASES = {
-    "remove": "rm",
-    "list":   "ls",
-    "copy":   "cp",
-    "exec":   "ex",
-    "move":   "mv",
-    "swap":   "sw",
+    "a": "add",
+    "c": "copy",
+    "d": "remove",
+    "e": "edit",
+    "g": "config",
+    "h": "shift",
+    "k": "compact",
+    "l": "list",
+    "m": "move",
+    "p": "pick",
+    "r": "raw",
+    "s": "show",
+    "t": "tag",
+    "w": "swap",
+    "x": "exec",
 }
+RESERVED_SHORTCUTS = set(ALIASES.keys())
 
 
 class KodaGroup(TyperGroup):
@@ -53,7 +64,10 @@ class KodaGroup(TyperGroup):
 app = typer.Typer(
     help=(
         "Koda — memos and terminal snippets in SQLite. "
-        "Run with no subcommand to print the latest entry body (same as `koda raw`)."
+        "Run with no subcommand to print the latest entry body (same as `koda raw`).\n\n"
+        "One-letter aliases:\n"
+        "a=add c=copy d=remove e=edit g=config h=shift k=compact\n"
+        "l=list m=move p=pick r=raw s=show t=tag w=swap x=exec"
     ),
     context_settings={"help_option_names": ["-h", "--help"]},
     cls=KodaGroup,
@@ -291,6 +305,25 @@ def get_memo_stats(query=None, tag=None, exclude_tag=None, shortcuts_only=False)
     return total_count, max_idx
 
 
+def get_memos_all(
+    query=None,
+    tag=None,
+    exclude_tag=None,
+    shortcuts_only=False,
+    sort_by="idx",
+    desc=False,
+):
+    order_column = sort_by if sort_by in VALID_SORT_COLUMNS else "idx"
+    order_direction = "DESC" if desc else "ASC"
+    where_sql, params = _build_memo_filters(query, tag, exclude_tag, shortcuts_only)
+    sql = (
+        "SELECT id, uid, idx, content, tags, shortcut, created_at FROM memos"
+        f"{where_sql} ORDER BY {order_column} {order_direction}, id ASC"
+    )
+    with sqlite3.connect(DB_PATH) as conn:
+        return conn.execute(sql, params).fetchall()
+
+
 def delete_memo(memo_id: int) -> None:
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute("DELETE FROM memos WHERE id = ?", (memo_id,))
@@ -364,6 +397,15 @@ def _parse_tag_args(tag_args: Optional[List[str]]) -> List[str]:
     for t in (tag_args or []):
         result.extend(item.strip() for item in t.split(",") if item.strip())
     return result
+
+
+def _validate_shortcut(shortcut: Optional[str]) -> Optional[str]:
+    if shortcut and len(shortcut) == 1 and shortcut in RESERVED_SHORTCUTS:
+        console.print(
+            f"[red]Shortcut {shortcut!r} is reserved as a 1-letter subcommand alias.[/red]"
+        )
+        raise typer.Exit(code=1)
+    return shortcut
 
 
 def _apply_vars(content: str, vars: Optional[List[str]]) -> str:
@@ -442,6 +484,130 @@ def emit_raw(ref: Optional[str], vars: Optional[List[str]] = None) -> None:
     content = _apply_vars(row[3] if row[3] is not None else "", vars)
     content = _strip_raw_inline_comments(content)
     sys.stdout.write(content)
+
+
+def _pick_candidates(
+    query: Optional[str],
+    tag: Optional[str],
+    exclude_tag: Optional[str],
+    shortcuts_only: bool,
+    sort_by: Optional[str],
+    desc: Optional[bool],
+):
+    cfg = _config["list"]
+    effective_sort = (sort_by or cfg["sort_by"]).lower()
+    if effective_sort not in VALID_SORT_COLUMNS:
+        valid = ", ".join(sorted(VALID_SORT_COLUMNS))
+        console.print(f"[red]Invalid --sort-by '{sort_by}'. Use one of: {valid}.[/red]")
+        raise typer.Exit(code=1)
+    effective_desc = cfg["desc"] if desc is None else desc
+    return get_memos_all(
+        query=query,
+        tag=tag,
+        exclude_tag=exclude_tag,
+        shortcuts_only=shortcuts_only,
+        sort_by=effective_sort,
+        desc=effective_desc,
+    )
+
+
+def _pick_with_fzf(candidates) -> Optional[str]:
+    if shutil.which("fzf") is None:
+        console.print("[red]fzf is not installed. Install fzf to use `koda pick`.[/red]")
+        raise typer.Exit(code=1)
+
+    if not sys.stdin.isatty():
+        console.print("[red]`koda pick` requires an interactive TTY.[/red]")
+        raise typer.Exit(code=1)
+
+    lines = []
+    for _, uid, idx, content, tags, shortcut, created_at in candidates:
+        first_line = (content or "").splitlines()[0] if content else ""
+        display = (
+            f"{idx}\t{uid}\t{shortcut or '-'}\t{tags or '-'}\t{created_at}\t{first_line}"
+        )
+        lines.append(display)
+
+    term_cols = shutil.get_terminal_size(fallback=(120, 40)).columns
+    # Keep list area readable on narrower terminals by switching to bottom preview.
+    preview_window = "right:55%:wrap" if term_cols >= 170 else "down:55%:wrap"
+
+    proc = subprocess.run(
+        [
+            "fzf",
+            "--delimiter", "\t",
+            "--with-nth", "1,3,4,6",
+            "--prompt", "koda> ",
+            "--preview",
+            "printf 'IDX: %s\\nUID: %s\\nSC: %s\\nTags: %s\\nCreated: %s\\n\\n%s\\n' {1} {2} {3} {4} {5} {6}",
+            "--preview-window", preview_window,
+        ],
+        input="\n".join(lines),
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        return None
+
+    selected = proc.stdout.strip()
+    if not selected:
+        return None
+    return selected.split("\t", 1)[0].strip()
+
+
+def _resolve_pick_action(
+    edit_mode: bool,
+    exec_mode: bool,
+    raw_mode: bool,
+    show_mode: bool,
+    print_id: bool,
+) -> str:
+    selected = [
+        name
+        for enabled, name in (
+            (edit_mode, "edit"),
+            (exec_mode, "exec"),
+            (raw_mode, "raw"),
+            (show_mode, "show"),
+        )
+        if enabled
+    ]
+    if len(selected) > 1:
+        console.print("[red]Use only one of --edit/-e, --exec/-x, --raw/-r, or --show/-s.[/red]")
+        raise typer.Exit(code=1)
+    if print_id and selected:
+        console.print("[red]--print-id/-p cannot be combined with action flags.[/red]")
+        raise typer.Exit(code=1)
+    if selected:
+        return selected[0]
+    default_cmd = _config["defaults"]["cmd"]
+    if default_cmd in ("raw", "show"):
+        return default_cmd
+    console.print(
+        "[red]defaults.cmd must be 'raw' or 'show' for `koda pick` without action flags.[/red]"
+    )
+    console.print("[dim]Hint: use --exec/-x, --edit/-e, --raw/-r, or --show/-s.[/dim]")
+    raise typer.Exit(code=1)
+
+
+def _run_pick_action(action: str, ref: str) -> None:
+    if action == "raw":
+        emit_raw(ref)
+        return
+    if action == "show":
+        init_db()
+        row = resolve_ref(ref)
+        _, uid, idx, content, tags, shortcut, created_at = row
+        _print_memo(uid, idx, shortcut, content, tags, created_at)
+        return
+    if action == "edit":
+        edit(ref)
+        return
+    if action == "exec":
+        exec_memo(ref, None)
+        return
+    console.print(f"[red]Unsupported pick action: {action}[/red]")
+    raise typer.Exit(code=1)
 
 
 @app.callback(invoke_without_command=True)
@@ -525,6 +691,7 @@ def _add_impl(
     tag: Optional[List[str]] = None,
     shortcut: Optional[str] = None,
 ) -> None:
+    shortcut = _validate_shortcut(shortcut)
     init_db()
     content = ""
 
@@ -580,11 +747,11 @@ def add(
         None, "--shortcut", "-s", help="Short alias for this entry (e.g. 'deploy')."
     ),
 ):
-    """Create an entry from arguments, stdin, or your editor."""
+    """Create an entry from arguments, stdin, or your editor. Alias: `koda a`."""
     _add_impl(text, tag, shortcut)
 
 
-@app.command(name="rm")
+@app.command(name="remove")
 def rm(
     indices: Optional[List[str]] = typer.Argument(
         None, help="Entry indices, ranges (e.g. 1 3 5-8), or a single shortcut. Default: latest."
@@ -602,7 +769,7 @@ def rm(
         False, "--force", "-f", help="Delete without prompting."
     ),
 ):
-    """Delete entries. Defaults to latest; supports ranges, -t, -q, and --all for batch."""
+    """Delete entries. Defaults to latest; supports ranges, -t, -q, and --all for batch. Alias: `koda d`."""
     if all_entries and not force:
         console.print("[red]--all requires -f/--force.[/red]")
         raise typer.Exit(code=1)
@@ -689,13 +856,13 @@ def rm(
         console.print(f"[red]Deleted [{idx}]: {preview}...[/red]")
 
 
-@app.command(name="cp")
+@app.command(name="copy")
 def copy(
     ref: Optional[str] = typer.Argument(
         None, help="Source entry index or shortcut (default: latest)."
     ),
 ):
-    """Duplicate an entry to a new row (same body and tags, no shortcut)."""
+    """Duplicate an entry to a new row (same body and tags, no shortcut). Alias: `koda c`."""
     init_db()
     row = resolve_ref(ref)
     memo_id, uid, idx, content, tags, shortcut, created_at = row
@@ -716,7 +883,7 @@ def edit(
         None, help="Entry index or shortcut to edit (default: latest)."
     ),
 ):
-    """Open an entry in $EDITOR (body plus tags/shortcut/metadata footer)."""
+    """Open an entry in $EDITOR (body plus tags/shortcut/metadata footer). Alias: `koda e`."""
     init_db()
     row = resolve_ref(ref)
     memo_id, uid, idx, content, tags, shortcut, created_at = row
@@ -753,6 +920,7 @@ def edit(
                     new_shortcut = val if val else None
                 elif line.startswith("created_at:"):
                     new_created_at = line.removeprefix("created_at:").strip()
+            new_shortcut = _validate_shortcut(new_shortcut)
 
             try:
                 update_memo_full(memo_id, new_content, new_tags, new_shortcut, new_created_at)
@@ -890,7 +1058,7 @@ def _list_memos_impl(
     )
 
 
-@app.command(name="ls")
+@app.command(name="list")
 def list_memos(
     query: Optional[str] = typer.Option(
         None, "--query", "-q", help="Substring match on memo body."
@@ -927,8 +1095,71 @@ def list_memos(
         help="Max characters per content line (0 = no truncation). [config: list.truncate]",
     ),
 ):
-    """Show entries as a table with paging and sortable columns."""
+    """Show entries as a table with paging and sortable columns. Alias: `koda l`."""
     _list_memos_impl(query, tag, exclude_tag, shortcuts_only, per_page, page, sort_by, desc, rows, truncate)
+
+
+@app.command()
+def pick(
+    query: Optional[str] = typer.Option(
+        None, "--query", "-q", help="Substring match on memo body."
+    ),
+    tag: Optional[str] = typer.Option(
+        None, "--tag", "-t", help="Substring match on tags."
+    ),
+    exclude_tag: Optional[str] = typer.Option(
+        None, "--exclude-tag", "-T", help="Exclude entries whose tags include this substring."
+    ),
+    shortcuts_only: bool = typer.Option(
+        False, "--shortcuts", "-S", help="Show only entries that have a shortcut."
+    ),
+    sort_by: Optional[str] = typer.Option(
+        None, "--sort-by", case_sensitive=False,
+        help="Sort column: id, idx, uid, tags, content, created_at, modified_at, shortcut. [config: list.sort_by]",
+    ),
+    desc: Optional[bool] = typer.Option(
+        None, "--desc/--asc", help="Sort order. [config: list.desc]",
+    ),
+    print_id: bool = typer.Option(
+        False, "--print-id", "-p", help="Print selected IDX and exit without running a command."
+    ),
+    edit_mode: bool = typer.Option(
+        False, "--edit", "-e", help="Open selected entry in editor."
+    ),
+    exec_mode: bool = typer.Option(
+        False, "--exec", "-x", help="Execute selected entry."
+    ),
+    raw_mode: bool = typer.Option(
+        False, "--raw", "-r", help="Print selected entry body."
+    ),
+    show_mode: bool = typer.Option(
+        False, "--show", "-s", help="Show selected entry with metadata."
+    ),
+):
+    """Pick an entry with fzf, then run an action (or print IDX). Alias: `koda p`."""
+    if print_id and (edit_mode or exec_mode or raw_mode or show_mode):
+        console.print("[red]--print-id/-p cannot be combined with action flags.[/red]")
+        raise typer.Exit(code=1)
+
+    action: Optional[str] = None if print_id else _resolve_pick_action(
+        edit_mode, exec_mode, raw_mode, show_mode, print_id
+    )
+
+    init_db()
+    candidates = _pick_candidates(query, tag, exclude_tag, shortcuts_only, sort_by, desc)
+    if not candidates:
+        console.print("[yellow]No entries found.[/yellow]")
+        raise typer.Exit(code=1)
+
+    selected_ref = _pick_with_fzf(candidates)
+    if selected_ref is None:
+        raise typer.Exit(code=0)
+
+    if print_id:
+        sys.stdout.write(selected_ref + "\n")
+        return
+
+    _run_pick_action(action, selected_ref)
 
 
 @app.command()
@@ -937,7 +1168,7 @@ def show(
         None, help="Entry index or shortcut (default: latest)."
     ),
 ):
-    """Print one entry with index, uid, tags, and timestamps (Rich formatted)."""
+    """Print one entry with index, uid, tags, and timestamps (Rich formatted). Alias: `koda s`."""
     init_db()
     row = resolve_ref(ref)
     memo_id, uid, idx, content, tags, shortcut, created_at = row
@@ -960,7 +1191,7 @@ def raw(
         ),
     ),
 ):
-    """Print memo body to stdout only (plain text, no Rich). Same as bare `koda <idx>`."""
+    """Print memo body to stdout only (plain text, no Rich). Same as bare `koda <idx>`. Alias: `koda r`."""
     if not entry_refs:
         emit_raw(None, vars)
     else:
@@ -968,7 +1199,7 @@ def raw(
             emit_raw(ref, vars)
 
 
-@app.command(name="ex")
+@app.command(name="exec")
 def exec_memo(
     ref: Optional[str] = typer.Argument(
         None, help="Entry index or shortcut to execute (default: latest)."
@@ -983,7 +1214,7 @@ def exec_memo(
         ),
     ),
 ):
-    """Execute the memo body as a shell command."""
+    """Execute the memo body as a shell command. Alias: `koda x`."""
     init_db()
     row = resolve_ref(ref)
     memo_id, uid, idx, content, tags, shortcut, created_at = row
@@ -998,7 +1229,7 @@ def tag(
     tags: Optional[List[str]] = typer.Option(None, "--tag", "-t", help="Tag(s) to add."),
     untag: Optional[List[str]] = typer.Option(None, "--untag", "-T", help="Tag(s) to remove."),
 ):
-    """Add or remove tags on one or more entries. Supports ranges (e.g. 2-5)."""
+    """Add or remove tags on one or more entries. Supports ranges (e.g. 2-5). Alias: `koda t`."""
     if not tags and not untag:
         console.print("[red]Specify at least one of -t/--tag (add) or -T/--untag (remove).[/red]")
         raise typer.Exit(code=1)
@@ -1031,12 +1262,12 @@ def tag(
     console.print(f"[green]{'; '.join(parts)}.[/green]")
 
 
-@app.command(name="mv")
+@app.command(name="move")
 def move(
     from_idx: int = typer.Argument(..., help="Source display index."),
     to_idx: int = typer.Argument(..., help="Destination display index (must be empty)."),
 ):
-    """Move entry at FROM to an unoccupied display position TO."""
+    """Move entry at FROM to an unoccupied display position TO. Alias: `koda m`."""
     init_db()
     if from_idx == to_idx:
         return
@@ -1047,7 +1278,7 @@ def move(
         if conn.execute("SELECT 1 FROM memos WHERE idx = ?", (to_idx,)).fetchone() is not None:
             console.print(f"[red]Index {to_idx} is already occupied.[/red]")
             console.print(
-                f"[dim]Hint: `koda sw {from_idx} {to_idx}` to swap, "
+                f"[dim]Hint: `koda swap {from_idx} {to_idx}` to swap, "
                 f"or `koda shift {to_idx}` to make room first.[/dim]"
             )
             raise typer.Exit(code=1)
@@ -1060,7 +1291,7 @@ def shift_cmd(
     start: int = typer.Argument(..., help="Shift entries at this index and above."),
     count: int = typer.Option(1, "--count", "-n", help="Positions to shift (negative = shift down)."),
 ):
-    """Shift all entries at START and above by COUNT positions."""
+    """Shift all entries at START and above by COUNT positions. Alias: `koda h`."""
     init_db()
     if count == 0:
         return
@@ -1092,12 +1323,12 @@ def shift_cmd(
     console.print(f"[green]Shifted entries from index {start} by {count:+d}.[/green]")
 
 
-@app.command(name="sw")
+@app.command(name="swap")
 def swap(
     idx1: int = typer.Argument(..., help="First display index."),
     idx2: int = typer.Argument(..., help="Second display index."),
 ):
-    """Swap the display positions of two entries."""
+    """Swap the display positions of two entries. Alias: `koda w`."""
     init_db()
     if idx1 == idx2:
         return
@@ -1119,7 +1350,7 @@ def swap(
 
 @app.command(name="compact")
 def compact_indices():
-    """Fill index gaps by reassigning idx to contiguous values from 0."""
+    """Fill index gaps by reassigning idx to contiguous values from 0. Alias: `koda k`."""
     init_db()
     with sqlite3.connect(DB_PATH) as conn:
         rows = conn.execute("SELECT id, idx FROM memos ORDER BY idx ASC, id ASC").fetchall()
@@ -1151,7 +1382,7 @@ def compact_indices():
 
 config_app = typer.Typer(
     name="config",
-    help="View and modify Koda configuration.",
+    help="View and modify Koda configuration. Alias: `koda g`.",
     invoke_without_command=True,
     no_args_is_help=False,
     context_settings={"help_option_names": ["-h", "--help"]},

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "koda"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary
- Add a new `pick` command (alias `p`) that uses `fzf` for interactive entry selection.
- Support action modes for picked entries: `--edit/-e`, `--exec/-x`, `--raw/-r`, `--show/-s`, and `--print-id/-p` for piping/composition.
- Use `defaults.cmd` as the default post-pick action when applicable (`raw` or `show`), and keep action flags explicit and mutually exclusive.
- Standardize command naming to canonical long forms (`remove`, `list`, `exec`, `move`, `swap`, `copy`) and add one-letter aliases for all top-level commands.
- Reserve one-letter aliases so they cannot be registered as entry shortcuts, and update global/per-command help and README examples.

## Test plan
- [x] `koda pick` follows `defaults.cmd` when set to `raw` or `show`.
- [x] `koda p -x`, `koda p -e`, `koda p -r`, `koda p -s` run the expected action.
- [x] `koda p -p` prints selected IDX only and works in command substitution.
- [x] `koda -h` shows one-letter aliases.
- [x] `koda <command> -h` includes each command's one-letter alias.
- [x] README examples reflect canonical command names and one-letter alias usage.

Made with [Cursor](https://cursor.com)