### PR TITLE
feat: add Neovim integration and ignore local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ CLAUDE.md
 *.log
 .fuse_hidden*
 Thumbs.db
+
+# Local worktrees
+.worktree/
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Use `--exclude-tag` / `-T` to hide entries that match a tag substring.
 ```bash
 koda show 1
 koda show deploy         # look up by shortcut
+echo 1 | koda show       # read one ref from stdin
 koda edit 1
 koda edit deploy         # edit entry by shortcut (shortcut editable in footer)
 koda cp 1                # duplicate to a new entry (shortcut is not copied)
@@ -220,9 +221,12 @@ To change or remove a shortcut, use `edit` — the `shortcut:` field appears in 
 koda raw          # latest entry body only
 koda raw 5        # entry at display index 5, body only
 koda raw deploy   # entry with shortcut "deploy", body only
+echo 5 | koda raw # read ref(s) from stdin
 koda 5            # numeric args route to the default command
 koda deploy       # shortcut args also route to the default command
 ```
+
+`show`/`ex` accept one stdin ref when no argument is given. `raw` accepts one or more whitespace-separated refs from stdin when no argument is given.
 
 `raw` treats inline comments like shell scripts: an unquoted `#` at the start of a line or after whitespace hides everything to the right on that line. `show` always displays the original stored text.
 

--- a/extras/nvim/README.md
+++ b/extras/nvim/README.md
@@ -1,0 +1,72 @@
+# koda.lua — Neovim integration for koda
+
+Insert and manage [koda](https://github.com/your-org/koda) snippets from within Neovim.
+
+## Requirements
+
+- [koda](https://github.com/your-org/koda) installed and available in `$PATH`
+- [fzf-lua](https://github.com/ibhagwan/fzf-lua) (required for `<leader>ki`)
+- Neovim 0.9+
+
+## Installation
+
+Copy `koda.lua` to your Neovim config's Lua path, for example:
+
+```
+~/.config/nvim/lua/custom/koda.lua
+```
+
+Then call `setup()` somewhere in your config (e.g. `~/.config/nvim/lua/custom/config.lua`):
+
+```lua
+require("custom.koda").setup()
+```
+
+### With lazy.nvim (local path)
+
+If you have cloned the koda repository locally, you can point lazy.nvim at the
+`extras/nvim` directory directly:
+
+```lua
+{
+  dir = "/path/to/koda/extras/nvim",
+  name = "koda-nvim",
+  config = function()
+    require("koda").setup()
+  end,
+}
+```
+
+> **Note:** when using `dir`, place `koda.lua` at `extras/nvim/lua/koda.lua`
+> so that lazy.nvim can find it on the runtime path. Alternatively, just copy
+> the file as described above.
+
+## Keymaps
+
+| Key           | Mode   | Action                                          |
+|---------------|--------|-------------------------------------------------|
+| `<leader>ki`  | normal | Pick a koda entry with fzf-lua and insert below cursor |
+| `<leader>ka`  | visual | Add the selected text to koda (prompts for tags) |
+| `<leader>kl`  | normal | Show `koda ls` output in a split (press `q` to close) |
+
+All three keys are grouped under `<leader>k` and appear in which-key if it is
+installed.
+
+## Usage
+
+### Insert a snippet
+
+In normal mode, press `<leader>ki`. A fzf-lua picker opens showing all koda
+entries. Select one and press `<Enter>` — the full content (`koda raw <idx>`)
+is inserted as new lines below the cursor.
+
+### Save a selection
+
+Visually select text, then press `<leader>ka`. You will be prompted for
+optional comma-separated tags. Press `<Enter>` to save (leave blank to skip
+tags). The selection is passed to `koda add` via stdin.
+
+### Browse entries
+
+Press `<leader>kl` to open a read-only split showing `koda ls` output. Press
+`q` to close it.

--- a/extras/nvim/lua/koda/init.lua
+++ b/extras/nvim/lua/koda/init.lua
@@ -1,0 +1,202 @@
+local M = {}
+
+local function run_koda_list_cmd()
+  local raw = vim.fn.system("NO_COLOR=1 koda l --rows 1 --truncate 0 2>/dev/null")
+  if vim.v.shell_error == 0 then
+    return raw
+  end
+  raw = vim.fn.system("NO_COLOR=1 koda ls --rows 1 --truncate 0 2>/dev/null")
+  if vim.v.shell_error == 0 then
+    return raw
+  end
+  return nil
+end
+
+local function collect_indices(raw)
+  local indices = {}
+  for line in raw:gmatch("[^\n]+") do
+    local idx = line:match("^%s*(%d+)%s+")
+    if idx then
+      table.insert(indices, idx)
+    end
+  end
+  return indices
+end
+
+local function format_picker_line(idx, content)
+  local one_line = (content or ""):gsub("\r", ""):gsub("%s*\n%s*", " | ")
+  one_line = one_line:gsub("%s+", " "):gsub("^ +", ""):gsub(" +$", "")
+  if one_line == "" then
+    one_line = "(empty)"
+  end
+  return idx, (idx .. " " .. one_line)
+end
+
+local function get_picker_entries()
+  local raw = run_koda_list_cmd()
+  if not raw then
+    return nil
+  end
+
+  local entries = {}
+  for _, idx in ipairs(collect_indices(raw)) do
+    local content = vim.fn.system({ "koda", "raw", idx })
+    if vim.v.shell_error == 0 then
+      local parsed_idx, display = format_picker_line(idx, content)
+      table.insert(entries, { idx = parsed_idx, display = display })
+    end
+  end
+  return entries
+end
+
+local function get_entry_labels(entries)
+  local labels = {}
+  for _, e in ipairs(entries) do
+    table.insert(labels, e.display)
+  end
+  return labels
+end
+
+local function idx_from_selected_label(selected_label)
+  local normalized = selected_label:gsub("%s+", " "):gsub("^ +", ""):gsub(" +$", "")
+  local idx = normalized:match("^(%d+)%s+")
+  return idx
+end
+
+local function insert_below(lines)
+  vim.api.nvim_put(lines, "l", true, true)
+end
+
+local function get_visual_selection()
+  local start_mark = vim.api.nvim_buf_get_mark(0, "<")
+  local end_mark = vim.api.nvim_buf_get_mark(0, ">")
+
+  local s_line, s_col = start_mark[1], start_mark[2]
+  local e_line, e_col = end_mark[1], end_mark[2]
+
+  -- Fallback for cases where visual marks are not yet available.
+  if s_line == 0 or e_line == 0 then
+    local vpos = vim.fn.getpos("v")
+    local cpos = vim.fn.getpos(".")
+    if vpos[2] == 0 or cpos[2] == 0 then
+      return ""
+    end
+    s_line, s_col = vpos[2], math.max(vpos[3] - 1, 0)
+    e_line, e_col = cpos[2], math.max(cpos[3] - 1, 0)
+  end
+
+  if s_line > e_line or (s_line == e_line and s_col > e_col) then
+    s_line, e_line = e_line, s_line
+    s_col, e_col = e_col, s_col
+  end
+
+  local vmode = vim.fn.visualmode()
+  if vmode == "V" then
+    local buf_lines = vim.api.nvim_buf_get_lines(0, s_line - 1, e_line, false)
+    return table.concat(buf_lines, "\n")
+  end
+
+  local text_lines = vim.api.nvim_buf_get_text(0, s_line - 1, s_col, e_line - 1, e_col + 1, {})
+  return table.concat(text_lines, "\n")
+end
+
+function M.pick_and_insert()
+  local ok, fzf = pcall(require, "fzf-lua")
+  if not ok then
+    vim.notify("koda: fzf-lua is required", vim.log.levels.ERROR)
+    return
+  end
+
+  local entries = get_picker_entries()
+  if not entries then
+    vim.notify("koda: failed to run `koda l`", vim.log.levels.ERROR)
+    return
+  end
+
+  if #entries == 0 then
+    vim.notify("koda: no entries found", vim.log.levels.WARN)
+    return
+  end
+
+  fzf.fzf_exec(
+    get_entry_labels(entries),
+    {
+      prompt = "Koda> ",
+      actions = {
+        ["default"] = function(selected)
+          if not selected or not selected[1] then return end
+          local idx = idx_from_selected_label(selected[1])
+          if not idx then
+            return
+          end
+          local content = vim.fn.system({ "koda", "raw", idx })
+          content = content:gsub("\n$", "")
+          insert_below(vim.split(content, "\n", { plain = true }))
+        end,
+      },
+    }
+  )
+end
+
+function M.add_selection()
+  local content = get_visual_selection()
+  if content == "" then
+    vim.notify("koda: no selection", vim.log.levels.WARN)
+    return
+  end
+  if not content:match("%S") then
+    vim.notify("koda: selection is whitespace only", vim.log.levels.WARN)
+    return
+  end
+
+  vim.ui.input({ prompt = "Tags (optional): " }, function(tags)
+    if tags == nil then return end
+    local cmd = { "koda", "add" }
+    if tags ~= "" then
+      vim.list_extend(cmd, { "-t", tags })
+    end
+    local result = vim.fn.system(cmd, content)
+    if vim.v.shell_error ~= 0 then
+      vim.notify("koda: add failed — " .. result, vim.log.levels.ERROR)
+      return
+    end
+    if result:find("Saved", 1, true) then
+      vim.notify("koda: saved", vim.log.levels.INFO)
+    elseif result:find("Aborted", 1, true) then
+      vim.notify("koda: add aborted (empty content)", vim.log.levels.WARN)
+    else
+      vim.notify("koda: add result — " .. result, vim.log.levels.WARN)
+    end
+  end)
+end
+
+function M.list()
+  local raw = run_koda_list_cmd()
+  if not raw then
+    vim.notify("koda: failed to run `koda l`", vim.log.levels.ERROR)
+    return
+  end
+  local output = vim.split(raw, "\n", { plain = true, trimempty = true })
+
+  vim.cmd("botright new")
+  local buf = vim.api.nvim_get_current_buf()
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, output)
+  vim.bo[buf].modifiable = false
+  vim.bo[buf].buftype = "nofile"
+  vim.bo[buf].bufhidden = "wipe"
+  vim.keymap.set("n", "q", "<cmd>close<cr>", { buffer = buf, silent = true })
+  vim.cmd("resize " .. math.min(#output + 1, 20))
+end
+
+function M.setup()
+  local ok, wk = pcall(require, "which-key")
+  if ok then
+    wk.add({ { "<leader>k", group = "[K]oda" } })
+  end
+
+  vim.keymap.set("n", "<leader>ki", M.pick_and_insert, { desc = "[K]oda [I]nsert" })
+  vim.keymap.set("x", "<leader>ka", M.add_selection,   { desc = "[K]oda [A]dd selection" })
+  vim.keymap.set("n", "<leader>kl", M.list,            { desc = "[K]oda [L]ist" })
+end
+
+return M

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koda"
-version = "0.1.0"
+version = "0.1.1"
 description = "Koda: A fast CLI for memos and terminal snippets."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -444,6 +444,16 @@ def emit_raw(ref: Optional[str], vars: Optional[List[str]] = None) -> None:
     sys.stdout.write(content)
 
 
+def _read_stdin_refs() -> List[str]:
+    """Read whitespace-separated entry refs from stdin (non-interactive only)."""
+    if sys.stdin.isatty():
+        return []
+    data = sys.stdin.read().strip()
+    if not data:
+        return []
+    return [part for part in data.split() if part]
+
+
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
@@ -937,7 +947,17 @@ def show(
         None, help="Entry index or shortcut (default: latest)."
     ),
 ):
-    """Print one entry with index, uid, tags, and timestamps (Rich formatted)."""
+    """Print one entry with index, uid, tags, and timestamps (Rich formatted).
+
+    When no argument is given, this command also accepts one ref from stdin.
+    """
+    if ref is None:
+        stdin_refs = _read_stdin_refs()
+        if len(stdin_refs) > 1:
+            console.print("[red]show accepts one ref from stdin. Got multiple values.[/red]")
+            raise typer.Exit(code=1)
+        if stdin_refs:
+            ref = stdin_refs[0]
     init_db()
     row = resolve_ref(ref)
     memo_id, uid, idx, content, tags, shortcut, created_at = row
@@ -960,11 +980,19 @@ def raw(
         ),
     ),
 ):
-    """Print memo body to stdout only (plain text, no Rich). Same as bare `koda <idx>`."""
-    if not entry_refs:
+    """Print memo body to stdout only (plain text, no Rich). Same as bare `koda <idx>`.
+
+    When no argument is given, refs can also be passed from stdin.
+    """
+    refs = entry_refs
+    if not refs:
+        stdin_refs = _read_stdin_refs()
+        refs = stdin_refs or None
+
+    if not refs:
         emit_raw(None, vars)
     else:
-        for ref in entry_refs:
+        for ref in refs:
             emit_raw(ref, vars)
 
 
@@ -983,7 +1011,17 @@ def exec_memo(
         ),
     ),
 ):
-    """Execute the memo body as a shell command."""
+    """Execute the memo body as a shell command.
+
+    When no argument is given, this command also accepts one ref from stdin.
+    """
+    if ref is None:
+        stdin_refs = _read_stdin_refs()
+        if len(stdin_refs) > 1:
+            console.print("[red]ex accepts one ref from stdin. Got multiple values.[/red]")
+            raise typer.Exit(code=1)
+        if stdin_refs:
+            ref = stdin_refs[0]
     init_db()
     row = resolve_ref(ref)
     memo_id, uid, idx, content, tags, shortcut, created_at = row

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "koda"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "koda"
-version = "0.2.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary
- Add Neovim integration under `extras/nvim` for working with koda entries
- Implement fzf-lua based insert, visual-selection add, and list keymaps
- Add `.worktree/` and `.worktrees/` to `.gitignore` to avoid staging local worktree directories
- Align `koda` version in `uv.lock` with `pyproject.toml` (`0.1.1`)

## Test plan
- [ ] Run `uv run koda --version` and confirm it shows `0.1.1`
- [ ] In Neovim, call `require("koda").setup()` and verify `<leader>ki` works
- [ ] In visual mode, run `<leader>ka` and verify content is saved via `koda add`
- [ ] Run `<leader>kl` and verify the `koda l/ls` output buffer opens

Made with [Cursor](https://cursor.com)