### PR TITLE
fix: stop escaping positional var values with re.escape()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koda"
-version = "1.0.1"
+version = "1.0.2"
 description = "Koda: A fast CLI for memos and terminal snippets."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -423,7 +423,7 @@ def _apply_vars(content: str, vars: Optional[List[str]]) -> str:
                     key, value = item.split("=", 1)
                     content = content.replace(f"${{{key}}}", value)
                 else:
-                    content = re.sub(rf'\${pos_index}(?!\d)', re.escape(item), content)
+                    content = re.sub(rf'\${pos_index}(?!\d)', item.replace('\\', '\\\\'), content)
                     pos_index += 1
     return content
 


### PR DESCRIPTION
## Summary

- `_apply_vars()` の位置変数置換で `re.escape()` を使っていたため、`?` などの特殊文字が `\?` にエスケープされてしまっていた
- `re.escape()` は正規表現パターン用の関数であり、`re.sub()` の置換文字列には不適切
- `\` のみをエスケープする `item.replace('\\', '\\\\')` に修正

## Test plan

- [x] `koda raw <entry> -V "文字列?"` で `?` がエスケープされないことを確認
- [x] `koda exec <entry> -V "文字列?"` で正常実行されることを確認
- [x] `\` を含む値でも壊れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to CLI variable substitution plus a patch version bump; only potential risk is subtle behavior change for backslashes in `$1`-style replacements.
> 
> **Overview**
> Fixes `_apply_vars()` positional (`$1`, `$2`, …) substitution to stop using `re.escape()` (which incorrectly escaped characters like `?`) and instead only escapes backslashes for `re.sub()` replacement strings.
> 
> Bumps package version from `1.0.1` to `1.0.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d57df4e93ce60a6f5599b6e6bca60f0bc5bd5e03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->