### PR TITLE
docs: revise README to reflect launcher role and add alias patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Each section below shows four equivalent forms:
 |---|---|
 | long | `koda exec web-srv -V localhost` |
 | built-in alias | `koda x web-srv -V localhost` |
-| kd prefix (`alias kd='koda'`) | `kd x web-srv -V localhost` |
-| two-letter alias (e.g. `alias kx='koda exec'`) | `kx web-srv -V localhost` |
+| kd prefix<br>(`alias kd='koda'`) | `kd x web-srv -V localhost` |
+| two-letter alias<br>(e.g. `alias kx='koda exec'`) | `kx web-srv -V localhost` |
 
 See [Recommended aliases](#recommended-aliases) for setup instructions.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,36 @@ docker inspect web \
 curl http://$(kd r):3000/healthz
 ```
 
+## Quick reference
+
+### Subcommands
+
+| Command | Alias | Description |
+|---|---|---|
+| `add` | `a` | Save a new entry |
+| `raw` | `r` | Print entry body to stdout |
+| `list` | `l` | List and filter entries |
+| `exec` | `x` | Run a saved entry as a shell command |
+| `edit` | `e` | Open entry in `$EDITOR` |
+| `pick` | `p` | Interactive selector (requires fzf) |
+| `show` | `s` | Display entry with full metadata |
+| `remove` | `d` | Delete entries |
+| `copy` | `c` | Duplicate an entry |
+| `tag` | `t` | Batch-add or remove tags |
+| `move` | `m` | Move entry to a display index |
+| `swap` | `w` | Swap display positions of two entries |
+| `shift` | `h` | Shift entries up or down by N |
+| `compact` | `k` | Reassign indices to 0..n-1 |
+| `config` | `g` | Read/write configuration |
+
+### Options
+
+| Option | Description |
+|---|---|
+| `-s` / `--shortcut` | Assign a memorable alias to an entry |
+| `-t` / `--tag` | Assign tags (on `add`) or filter by tag |
+| `-V` / `--var` | Variable substitution at recall time |
+
 ## Installation
 
 ```bash
@@ -229,72 +259,6 @@ kl -q docker -t dev          # two-letter alias
 
 Each row shows `IDX`, `UID`, `SC` (shortcut), tags, content preview, and creation time.
 Sort columns: `id`, `idx`, `uid`, `tags`, `content`, `created_at`, `modified_at`, `shortcut`.
-
----
-
-### Shortcuts
-
-Shortcuts and variable substitution are not subcommands — they are options (`-s`, `-V`) that work across multiple commands.
-
-Assign a memorable string alias to any entry and use it instead of a numeric index.
-
-```bash
-# Save with a shortcut (-s is short for --shortcut)
-koda a "kubectl rollout restart deploy/api" -t k8s -s restart
-
-# Use the shortcut anywhere an index is accepted
-koda r restart
-koda x restart
-koda s restart
-koda d restart
-
-# Default command — no subcommand needed (when defaults.cmd = raw)
-koda restart          # → koda raw restart
-
-# List all entries that have shortcuts
-koda l -S
-koda l -S --sort-by shortcut
-```
-
-To change or remove a shortcut, open the entry with `edit` — the `shortcut:` field appears in the metadata footer.
-
----
-
-### Variable substitution (`-V` / `--var`)
-
-Embed placeholders in a saved entry; fill them in at recall time with `-V`.
-
-| Style | Placeholder | How to pass |
-|---|---|---|
-| Named | `${host}` | `-V KEY=VALUE` |
-| Positional | `$1`, `$2`, ... | `-V value` or `-V val1,val2` (comma-separated, left-to-right) |
-
-```bash
-# Save a template with a positional placeholder
-koda a "gcloud storage cp \$1 gs://my-company-analytics-prod/uploads/" -t gcloud -s upload
-
-# Run with different values — no need to retype the bucket path
-koda x upload -V ./report.csv
-koda x upload -V ./summary.csv
-kx upload -V ./report.csv          # two-letter alias
-
-# Named substitution — swap one variable by name
-koda a "aws s3 sync ./dist s3://acme-frontend-\${env}-us-east-1/app/" -t aws -s deploy
-koda x deploy -V env=prod
-koda x deploy -V env=staging
-kx deploy -V env=prod              # two-letter alias
-
-# Multiple positional values
-koda a "rsync -avz \$1 \$2" -t rsync
-koda r 8 -V /src/path -V user@host:/dest
-koda r 8 -V '/src/path,user@host:/dest'    # same result, comma-separated
-
-# Mix named and positional
-koda r 9 -V 'admin,5432' -V host=db.example.com -V name="new york"
-# → connect admin@db.example.com:5432 as new york
-```
-
-Positional values are comma-separated within a single `-V` flag. Use `"..."` inside the flag to include spaces or commas in a value: `-V '"hello world","foo,bar"'`.
 
 ---
 
@@ -523,6 +487,92 @@ koda config set defaults.cmd list   # long form
 kd g set defaults.cmd list          # kd prefix
 kg set defaults.cmd list            # two-letter alias
 ```
+
+---
+
+## Options
+
+The following are flags that work across multiple commands, not standalone subcommands.
+
+---
+
+### Shortcuts (`-s` / `--shortcut`)
+
+Assign a memorable string alias to any entry and use it instead of a numeric index.
+
+```bash
+# Save with a shortcut (-s is short for --shortcut)
+koda a "kubectl rollout restart deploy/api" -t k8s -s restart
+
+# Use the shortcut anywhere an index is accepted
+koda r restart
+koda x restart
+koda s restart
+koda d restart
+
+# Default command — no subcommand needed (when defaults.cmd = raw)
+koda restart          # → koda raw restart
+
+# List all entries that have shortcuts
+koda l -S
+koda l -S --sort-by shortcut
+```
+
+To change or remove a shortcut, open the entry with `edit` — the `shortcut:` field appears in the metadata footer.
+
+---
+
+### Tags (`-t` / `--tag`)
+
+Assign one or more tags to an entry at save time; use them to filter across commands.
+
+```bash
+koda a "docker compose up" -t docker,dev     # assign multiple tags at add time
+koda l -t docker                             # filter list by tag substring
+koda l -T archive                            # exclude entries tagged "archive"
+koda d -t tmp                                # delete all entries tagged "tmp"
+koda p -x -t dev                             # pick + exec, pre-filtered by tag
+```
+
+Use `tag` (subcommand) to add or remove tags on existing entries in bulk — see [Tag](#tag).
+
+---
+
+### Variable substitution (`-V` / `--var`)
+
+Embed placeholders in a saved entry; fill them in at recall time with `-V`.
+
+| Style | Placeholder | How to pass |
+|---|---|---|
+| Named | `${host}` | `-V KEY=VALUE` |
+| Positional | `$1`, `$2`, ... | `-V value` or `-V val1,val2` (comma-separated, left-to-right) |
+
+```bash
+# Save a template with a positional placeholder
+koda a "gcloud storage cp \$1 gs://my-company-analytics-prod/uploads/" -t gcloud -s upload
+
+# Run with different values — no need to retype the bucket path
+koda x upload -V ./report.csv
+koda x upload -V ./summary.csv
+kx upload -V ./report.csv          # two-letter alias
+
+# Named substitution — swap one variable by name
+koda a "aws s3 sync ./dist s3://acme-frontend-\${env}-us-east-1/app/" -t aws -s deploy
+koda x deploy -V env=prod
+koda x deploy -V env=staging
+kx deploy -V env=prod              # two-letter alias
+
+# Multiple positional values
+koda a "rsync -avz \$1 \$2" -t rsync
+koda r 8 -V /src/path -V user@host:/dest
+koda r 8 -V '/src/path,user@host:/dest'    # same result, comma-separated
+
+# Mix named and positional
+koda r 9 -V 'admin,5432' -V host=db.example.com -V name="new york"
+# → connect admin@db.example.com:5432 as new york
+```
+
+Positional values are comma-separated within a single `-V` flag. Use `"..."` inside the flag to include spaces or commas in a value: `-V '"hello world","foo,bar"'`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -98,68 +98,6 @@ ka "memo" -t tag -s sc                # two-letter alias
 
 ---
 
-### Execute (`exec`) — run a saved command
-
-Run a saved entry as a shell command, with optional variable substitution.
-
-```bash
-# Without koda — retype or search history every time
-ssh -i ~/.ssh/key.pem ec2-user@192.168.1.100
-
-# Save once
-koda a "ssh -i ~/.ssh/key.pem ec2-user@\$1" -t ssh -s web-srv
-```
-
-```bash
-koda x web-srv              # run by shortcut
-koda x web-srv -V prod      # with variable substitution
-koda x 12                   # run by index
-```
-
-Full form and aliases:
-
-```bash
-koda exec web-srv -V localhost   # long form
-kd x web-srv -V localhost        # kd prefix
-kx web-srv -V localhost          # two-letter alias
-```
-
-> **Security**: only store trusted commands. `exec` runs the body through the configured shell (`sh` by default).
-
----
-
-### Pick — interactive launcher (fzf)
-
-Interactively select an entry with `fzf`, then run an action. Requires [`fzf`](https://github.com/junegunn/fzf) and an interactive TTY.
-
-```bash
-koda p -x                      # pick from all entries, execute immediately
-koda p -x -q docker -t dev     # pre-filter by query and tag, then pick
-```
-
-Full form and aliases:
-
-```bash
-koda pick --exec -q docker -t dev   # long form
-kd p -x -q docker -t dev            # kd prefix
-kp -x -q docker -t dev              # two-letter alias
-```
-
-**Compound patterns — use pick as a selector:**
-
-```bash
-koda x "$(koda p -p)"          # pick IDX, pass to exec
-kd x "$(kd p -p)"              # kd prefix
-kx "$(kp -p)"                  # two-letter alias
-
-eval $(kp -p | xargs kr)       # pick IDX, eval the body
-```
-
-Other action flags: `-e` edit, `-r` raw, `-s` show.
-`-p` (print IDX only) cannot be combined with action flags.
-
----
-
 ### Raw — body-only output
 
 Print the entry body to stdout (no Rich formatting). Use for pipes, `eval`, and command substitution.
@@ -230,7 +168,34 @@ koda s 5    # → echo hello  # this is a comment
 
 ---
 
+### List
+
+```bash
+koda l                          # all entries ordered by display index
+koda l -q "docker"              # substring search on body
+koda l -t linux                 # filter by tag substring
+koda l -T archive               # exclude entries tagged "archive"
+koda l -S                       # only entries that have a shortcut
+koda l -n 50 -p 2              # 50 entries per page, page 2
+koda l -s created_at --desc     # sort by creation date descending
+```
+
+Full form and aliases:
+
+```bash
+koda list -q docker -t dev   # long form
+kd l -q docker -t dev        # kd prefix
+kl -q docker -t dev          # two-letter alias
+```
+
+Each row shows `IDX`, `UID`, `SC` (shortcut), tags, content preview, and creation time.
+Sort columns: `id`, `idx`, `uid`, `tags`, `content`, `created_at`, `modified_at`, `shortcut`.
+
+---
+
 ### Shortcuts
+
+Shortcuts and variable substitution are not subcommands — they are options (`-s`, `-V`) that work across multiple commands.
 
 Assign a memorable string alias to any entry and use it instead of a numeric index.
 
@@ -294,28 +259,84 @@ Values with spaces must be quoted so the shell passes them as a single token.
 
 ---
 
-### List
+### Execute (`exec`) — run a saved command
+
+Run a saved entry as a shell command, with optional variable substitution.
 
 ```bash
-koda l                          # all entries ordered by display index
-koda l -q "docker"              # substring search on body
-koda l -t linux                 # filter by tag substring
-koda l -T archive               # exclude entries tagged "archive"
-koda l -S                       # only entries that have a shortcut
-koda l -n 50 -p 2              # 50 entries per page, page 2
-koda l -s created_at --desc     # sort by creation date descending
+# Without koda — retype or search history every time
+ssh -i ~/.ssh/key.pem ec2-user@192.168.1.100
+
+# Save once
+koda a "ssh -i ~/.ssh/key.pem ec2-user@\$1" -t ssh -s web-srv
+```
+
+```bash
+koda x web-srv              # run by shortcut
+koda x web-srv -V prod      # with variable substitution
+koda x 12                   # run by index
 ```
 
 Full form and aliases:
 
 ```bash
-koda list -q docker -t dev   # long form
-kd l -q docker -t dev        # kd prefix
-kl -q docker -t dev          # two-letter alias
+koda exec web-srv -V localhost   # long form
+kd x web-srv -V localhost        # kd prefix
+kx web-srv -V localhost          # two-letter alias
 ```
 
-Each row shows `IDX`, `UID`, `SC` (shortcut), tags, content preview, and creation time.
-Sort columns: `id`, `idx`, `uid`, `tags`, `content`, `created_at`, `modified_at`, `shortcut`.
+> **Security**: only store trusted commands. `exec` runs the body through the configured shell (`sh` by default).
+
+---
+
+### Edit
+
+Open an entry in `$EDITOR`. The footer contains editable metadata (tags, shortcut).
+
+```bash
+koda e web-srv        # by shortcut
+koda e 5              # by index
+```
+
+Full form and aliases:
+
+```bash
+koda edit web-srv   # long form
+kd e web-srv        # kd prefix
+ke web-srv          # two-letter alias
+```
+
+---
+
+### Pick — interactive launcher (fzf)
+
+Interactively select an entry with `fzf`, then run an action. Requires [`fzf`](https://github.com/junegunn/fzf) and an interactive TTY.
+
+```bash
+koda p -x                      # pick from all entries, execute immediately
+koda p -x -q docker -t dev     # pre-filter by query and tag, then pick
+```
+
+Full form and aliases:
+
+```bash
+koda pick --exec -q docker -t dev   # long form
+kd p -x -q docker -t dev            # kd prefix
+kp -x -q docker -t dev              # two-letter alias
+```
+
+**Compound patterns — use pick as a selector:**
+
+```bash
+koda x "$(koda p -p)"          # pick IDX, pass to exec
+kd x "$(kd p -p)"              # kd prefix
+kx "$(kp -p)"                  # two-letter alias
+
+eval $(kp -p | xargs kr)       # pick IDX, eval the body
+```
+
+Other action flags: `-e` edit, `-r` raw, `-s` show.
+`-p` (print IDX only) cannot be combined with action flags.
 
 ---
 
@@ -335,25 +356,6 @@ Full form and aliases:
 koda show web-srv   # long form
 kd s web-srv        # kd prefix
 ks web-srv          # two-letter alias
-```
-
----
-
-### Edit
-
-Open an entry in `$EDITOR`. The footer contains editable metadata (tags, shortcut).
-
-```bash
-koda e web-srv        # by shortcut
-koda e 5              # by index
-```
-
-Full form and aliases:
-
-```bash
-koda edit web-srv   # long form
-kd e web-srv        # kd prefix
-ke web-srv          # two-letter alias
 ```
 
 ---
@@ -400,6 +402,27 @@ kc web-srv          # two-letter alias
 
 ---
 
+### Tag
+
+```bash
+koda t 1 3 5 -t work          # add tag to individual entries
+koda t 2-6 -t archive         # add tag to a range
+koda t 1 3-5 7 -T old         # remove tag from mixed selection
+koda t 1 -t new -T old        # add one tag and remove another in one command
+```
+
+Full form and aliases:
+
+```bash
+koda tag 1 3-5 -t archive   # long form
+kd t 1 3-5 -t archive       # kd prefix
+kt 1 3-5 -t archive         # two-letter alias
+```
+
+Re-tagging with an already-present tag is idempotent (no-op).
+
+---
+
 ### Reorder entries (`move`, `swap`, `shift`, `compact`)
 
 Each entry has a display index (`IDX`) you can freely rearrange — useful for keeping frequently used snippets at low numbers.
@@ -423,27 +446,6 @@ koda compact     kd k        kk
 ```
 
 `move` requires the destination index to be unoccupied. Use `shift` to make room first, or `swap` to exchange two occupied positions.
-
----
-
-### Batch tag (`tag`)
-
-```bash
-koda t 1 3 5 -t work          # add tag to individual entries
-koda t 2-6 -t archive         # add tag to a range
-koda t 1 3-5 7 -T old         # remove tag from mixed selection
-koda t 1 -t new -T old        # add one tag and remove another in one command
-```
-
-Full form and aliases:
-
-```bash
-koda tag 1 3-5 -t archive   # long form
-kd t 1 3-5 -t archive       # kd prefix
-kt 1 3-5 -t archive         # two-letter alias
-```
-
-Re-tagging with an already-present tag is idempotent (no-op).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,45 @@ A **terminal launcher and snippet store**. Save commands, config templates, and 
 - **XDG-friendly**: Data under `~/.local/share/koda/`, config under `~/.config/koda/`.
 - **Configurable defaults**: Persist preferences in `~/.config/koda/config.toml`.
 
+## In action
+
+**① Save a command once, run it with different inputs:**
+
+```bash
+koda a "ssh -i ~/.ssh/key.pem ec2-user@$1" -t ssh -s web-srv
+
+koda x web-srv -V prod.example.com
+koda x web-srv -V staging.example.com
+```
+
+**② Query a local LLM with a one-liner:**
+
+```bash
+# ka = koda add, kx = koda exec  (two-letter aliases)
+ka -t llm -s ask <<'EOF'
+curl -sS http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "$1"}], "stream": false}' \
+  | jq -r '.choices[0].message.content'
+EOF
+
+# kx = koda exec — fill in $1 at call time
+kx ask -V "How high is Mt. Fuji?"
+kx ask -V "Summarize the last git commit"
+```
+
+**③ Pipe docker output in, retrieve immediately:**
+
+```bash
+# kd a = koda add, kd r = koda raw  (kd prefix: alias kd='koda')
+docker inspect web \
+  | jq -r '.[0].NetworkSettings.IPAddress' \
+  | kd a -t docker
+
+# no ref needed — kd r retrieves the most recent entry
+curl http://$(kd r):3000/healthz
+```
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ curl http://$(kd r):3000/healthz
 | `compact` | `k` | Reassign indices to 0..n-1 |
 | `config` | `g` | Read/write configuration |
 
+Single-letter aliases are reserved and cannot be used as entry shortcuts.
+
 ### Options
 
 | Option | Description |
@@ -102,32 +104,6 @@ uv tool install . --force
 ```
 
 ## Command reference
-
-### Built-in single-letter aliases
-
-Each subcommand has a built-in single-letter alias:
-
-```
-a add      c copy     d remove   e edit
-g config   h shift    k compact  l list
-m move     p pick     r raw      s show
-t tag      w swap     x exec
-```
-
-Single-letter aliases are reserved and cannot be used as entry shortcuts.
-
-Each section below shows these equivalent forms:
-
-| Form | Example |
-|---|---|
-| long | `koda exec web-srv -V localhost` |
-| built-in alias | `koda x web-srv -V localhost` |
-| kd prefix<br>(`alias kd='koda'`) | `kd x web-srv -V localhost` |
-| two-letter alias<br>(e.g. `alias kx='koda exec'`) | `kx web-srv -V localhost` |
-
-See [Recommended aliases](#recommended-aliases) for setup instructions.
-
----
 
 ### Add
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Embed placeholders in a saved entry; fill them in at recall time with `-V`.
 | Style | Placeholder | How to pass |
 |---|---|---|
 | Named | `${host}` | `-V KEY=VALUE` |
-| Positional | `$1`, `$2`, ... | `-V value` (left-to-right) |
+| Positional | `$1`, `$2`, ... | `-V value` or `-V val1,val2` (comma-separated, left-to-right) |
 
 ```bash
 # Save a template with a positional placeholder
@@ -248,14 +248,14 @@ kx deploy -V env=prod              # two-letter alias
 # Multiple positional values
 koda a "rsync -avz \$1 \$2" -t rsync
 koda r 8 -V /src/path -V user@host:/dest
-koda r 8 -V "/src/path user@host:/dest"    # same result
+koda r 8 -V '/src/path,user@host:/dest'    # same result, comma-separated
 
 # Mix named and positional
-koda r 9 -V "admin 5432" -V host=db.example.com -V name="new york"
+koda r 9 -V 'admin,5432' -V host=db.example.com -V name="new york"
 # → connect admin@db.example.com:5432 as new york
 ```
 
-Values with spaces must be quoted so the shell passes them as a single token.
+Positional values are comma-separated within a single `-V` flag. Use `"..."` inside the flag to include spaces or commas in a value: `-V '"hello world","foo,bar"'`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Koda
 
-A **memo and snippet CLI** for the terminal. Store frequently used commands, config fragments, and notes in SQLite, then pull them back instantly with `list`, `show`, and search. Built with Python, Typer, and Rich.
+A **terminal launcher and snippet store**. Save commands, config templates, and notes to SQLite; retrieve and execute them instantly — by index, shortcut, or fuzzy search. Built with Python, Typer, and Rich.
 
 ## Features
 
-- **Fast save and recall**: Manage entries with `add`, `list`, `show`, `edit`, `pick`, and `remove`.
+- **Launcher**: Run any saved command with `exec` or `pick`, with variable substitution at call time.
+- **Fast save and recall**: `add`, `list`, `show`, `edit`, `pick`, `remove` — all with one-letter aliases.
 - **Flexible input**: Arguments, heredocs, pipes, or `$EDITOR`.
-- **Tags**: Classify, filter, and batch-edit with multiple tags.
 - **Shortcuts**: Assign a memorable string alias to any entry and use it in place of a numeric index.
-- **Shell-friendly**: `raw` prints body-only text for `eval`, aliases, and scripts.
-- **Variable substitution**: Expand `${KEY}` and `$1 $2 ...` placeholders at recall time with `--var` / `-V`.
-- **Display index**: Each entry has a stable `uid` (sha1 short hash) and a user-controlled `idx`. Reorder freely with `move`/`swap`, and close gaps with `compact`.
-- **XDG-friendly**: Default data under `~/.local/share/koda/`, config under `~/.config/koda/`.
-- **Configurable defaults**: Persist preferences like default command or list page size in `~/.config/koda/config.toml`.
+- **Variable substitution**: Expand `${KEY}` and `$1 $2 ...` placeholders at recall time with `-V`.
+- **Shell-friendly output**: `raw` prints body-only text for pipes, `eval`, and scripts.
+- **Tags**: Classify, filter, and batch-edit entries with multiple tags.
+- **Display index**: Stable `uid` (SHA1 short hash) plus user-controlled `idx`. Reorder with `move`/`swap`; close gaps with `compact`.
+- **XDG-friendly**: Data under `~/.local/share/koda/`, config under `~/.config/koda/`.
+- **Configurable defaults**: Persist preferences in `~/.config/koda/config.toml`.
 
 ## Installation
 
@@ -24,101 +25,19 @@ uv tool install .
 
 ## Update
 
-To update to the latest version:
-
 ```bash
 cd koda
 git pull
 uv tool install . --force
 ```
 
-## Recommended alias
-
-Add this to `.zshrc` or `.bashrc` to type less:
-
-```bash
-alias kd='koda'
-```
-
-## Example use cases
-
-### 1. Save shell one-liners as runnable snippets
-
-Stop memorizing long `docker`, `kubectl`, or `ffmpeg` invocations.
-
-```bash
-koda add "docker compose -f docker-compose.dev.yml up --build" -t docker,dev
-koda list
-# Suppose the new entry is at display index 12 — execute directly:
-koda exec 12
-```
-
-Put **only the command you intend to run** in the body. The editor template keeps metadata in a separate `---` block. Because `exec` runs shell code, **store only trusted text**.
-
-### 2. Config templates and Dockerfile fragments
-
-Tag infra snippets and paste the full body with `show` when needed.
-
-```bash
-koda add -t docker,template <<'EOF'
-FROM python:3.12-slim
-RUN pip install uv
-WORKDIR /app
-EOF
-koda show   # show the entry just added (latest)
-```
-
-### 3. Reuse API `curl` commands or SQL
-
-Save authenticated `curl` one-liners or common `SELECT` statements; search with `ls -q`.
-
-```bash
-koda add -t api,curl 'curl -sS -H "Authorization: Bearer $TOKEN" https://api.example.com/v1/status'
-koda list -q "curl"
-```
-
-### 4. Cheat sheets and plain notes (not only commands)
-
-Git recipes, install commands, meeting notes — anything that fits in plain text.
-
-```bash
-koda add "git reset --soft HEAD~1   # undo last commit, keep changes" -t git
-koda list -t git
-```
-
-### 5. Execute stored commands and pipe into scripts
-
-`raw` writes plain stdout (no Rich), so `$(koda raw <IDX>)` feeds the body directly into another command as an argument. Use `koda exec` to run the body as a shell command. **Keep the body simple** when you automate: extra newlines or prose can break word splitting.
-
-```bash
-# Store a path
-koda add "/var/log/nginx/access.log" -t log
-
-# Use the stored path as a command argument
-tail -f $(koda raw)
-
-# Store and reuse a hostname
-koda add "user@prod.example.com" -t ssh
-ssh $(koda raw)
-
-# Execute the latest entry as a shell command
-koda exec
-
-# Execute entry at index 5 (works for single-line and multi-line)
-koda exec 5
-
-# Capture body into a variable
-CONTENT=$(koda raw)
-echo "$CONTENT"
-```
-
 ## Command reference
 
-### One-letter subcommand aliases
+### Built-in single-letter aliases
 
-Each top-level subcommand has a single-letter alias:
+Each subcommand has a built-in single-letter alias:
 
-```bash
+```
 a add      c copy     d remove   e edit
 g config   h shift    k compact  l list
 m move     p pick     r raw      s show
@@ -127,296 +46,500 @@ t tag      w swap     x exec
 
 Single-letter aliases are reserved and cannot be used as entry shortcuts.
 
+Each section below shows four equivalent forms:
+
+| Form | Example |
+|---|---|
+| long | `koda exec web-srv -V localhost` |
+| built-in alias | `koda x web-srv -V localhost` |
+| Pattern A (`alias kd='koda'`) | `kd x web-srv -V localhost` |
+| Pattern B (two-letter aliases) | `kx web-srv -V localhost` |
+
+See [Recommended aliases](#recommended-aliases) for setup instructions.
+
+---
+
 ### Add
 
+Save a new entry from arguments, heredoc, stdin, or `$EDITOR`.
+
 ```bash
-koda add "One-line memo" -t tag1,tag2
-koda a "Quick memo via alias" -t quick
-koda add -t snippet <<EOF
-multi-line
-snippet
+# Without koda — paste into a file or memorize
+echo "docker compose -f docker-compose.dev.yml up --build" >> snippets.txt
+
+# koda long form
+koda add "docker compose -f docker-compose.dev.yml up --build" -t docker --shortcut dc
+koda add -t infra <<'EOF'
+FROM python:3.12-slim
+RUN pip install uv
+WORKDIR /app
 EOF
-koda add   # opens $EDITOR
+koda add           # opens $EDITOR
 
-# Assign a shortcut alias at save time:
-koda add "docker compose up --build" -t docker --shortcut dc
+# built-in alias
+koda a "Quick note" -t quick -s dc
+
+# Pattern A
+kd a "Quick note" -t quick -s dc
+
+# Pattern B
+ka "Quick note" -t quick -s dc
 ```
 
-Any command's output can be piped directly into `koda add`:
+Pipe any command output directly into `koda add`:
 
 ```bash
-# Save a command you just ran from history
-history | grep "ffmpeg" | tail -1 | koda add -t ffmpeg
-
-# Save the output of a command as a note
-kubectl get pods -o wide | koda add -t k8s
-
-# Save a generated value (e.g. a token or key) for later use
-openssl rand -hex 32 | koda add -t secret
-
-# Save a file path found by a search
-find /etc -name "*.conf" | fzf | koda add -t path
-
-# Save multi-line output (e.g. a config snippet)
-cat ~/.ssh/config | koda add -t ssh
+history | grep ffmpeg | tail -1 | koda add -t ffmpeg
+kubectl get pods -o wide    | koda add -t k8s
+openssl rand -hex 32        | koda add -t secret
 ```
 
-### List and search
+---
+
+### List
 
 ```bash
-koda list                        # entries ordered by display index (IDX)
-koda l -q "docker"              # same as `koda list -q "docker"`
-koda list -n 50                  # 50 entries per page
-koda list -p 2                   # show page 2
-koda list -n 25 -p 3             # page 3 at 25 entries per page
-koda list --rows 1               # 1-line content preview (default)
-koda list --rows 10              # 10-line content preview
-koda list --rows 0               # show all lines
-koda list --truncate 80          # truncate lines at 80 characters
-koda list --truncate 0           # disable line truncation
-koda list -s created_at --desc   # sort by created_at descending
-koda list -s shortcut --asc      # sort alphabetically by shortcut
-koda list -q "docker"            # substring search on body
-koda list -t "linux"             # filter by tag substring
-koda list -T "archive"           # exclude entries tagged "archive"
-koda list --shortcuts            # show only entries that have a shortcut (-S)
+# koda long form
+koda list                          # all entries ordered by display index
+koda list -q "docker"              # substring search on body
+koda list -t linux                 # filter by tag substring
+koda list -T archive               # exclude entries tagged "archive"
+koda list -n 50 -p 2              # 50 entries per page, page 2
+koda list -s created_at --desc     # sort by creation date descending
+koda list --shortcuts              # only entries that have a shortcut
+
+# built-in alias
+koda l -q docker -t dev
+
+# Pattern A
+kd l -q docker -t dev
+
+# Pattern B
+kl -q docker -t dev
 ```
 
-Each row shows `IDX` (display index), `UID` (7-char sha1), `SC` (shortcut), tags, content preview, and creation time.
-`list` always prints summary stats below the table: total entries, total pages, and max IDX.
-Sort columns are: `id`, `idx`, `uid`, `tags`, `content`, `created_at`, `modified_at`, `shortcut`. Use `--desc` / `--asc` to choose direction.
-Use `--rows 0` to display full content lines in the list.
-Use `--truncate` to control max characters per content line (`0` disables truncation).
-Use `--exclude-tag` / `-T` to hide entries that match a tag substring.
+Each row shows `IDX`, `UID`, `SC` (shortcut), tags, content preview, and creation time.
+Sort columns: `id`, `idx`, `uid`, `tags`, `content`, `created_at`, `modified_at`, `shortcut`.
 
-### Show, edit, remove
+---
+
+### Show
+
+Display a single entry with full metadata.
 
 ```bash
-koda show 1
-koda s 1                   # same as `koda show 1`
-koda show deploy         # look up by shortcut
-echo 1 | koda show       # read one ref from stdin
-koda edit 1
-koda e deploy            # same as `koda edit deploy`
-koda edit deploy         # edit entry by shortcut (shortcut editable in footer)
-koda copy 1                # duplicate to a new entry (shortcut is not copied)
-koda c 1                   # same as `koda copy 1`
-koda remove 1              # delete with confirmation
-koda d 1                   # same as `koda remove 1`
-koda remove deploy         # delete by shortcut
-koda remove 1 3 5-8        # delete multiple entries or ranges
-koda remove -t archive     # delete all entries tagged "archive"
-koda remove -q "tmp"       # delete entries matching body substring
-koda remove --all -f       # delete everything (--all always requires -f)
+# koda long form
+koda show 5
+koda show web-srv      # by shortcut
+echo 5 | koda show     # ref from stdin
+
+# built-in alias
+koda s web-srv
+
+# Pattern A
+kd s web-srv
+
+# Pattern B
+ks web-srv
 ```
 
-### Pick with `fzf` (`pick`)
+---
 
-Interactively select an entry, then run an action. By default, `pick` uses `defaults.cmd` (when it is `raw` or `show`).
+### Edit
+
+Open an entry in `$EDITOR`. The footer contains editable metadata (tags, shortcut).
 
 ```bash
-# Pick and run default action (depends on defaults.cmd)
-koda pick
-koda p
+# koda long form
+koda edit 5
+koda edit web-srv      # by shortcut
 
-# Pick and execute immediately
-koda pick -x
+# built-in alias
+koda e web-srv
+
+# Pattern A
+kd e web-srv
+
+# Pattern B
+ke web-srv
+```
+
+---
+
+### Remove
+
+Delete one or more entries.
+
+```bash
+# koda long form
+koda remove 5
+koda remove web-srv          # by shortcut
+koda remove 1 3 5-8          # multiple entries and ranges
+koda remove -t archive        # delete all tagged "archive"
+koda remove -q "tmp"          # delete entries matching body substring
+koda remove --all -f          # delete everything (--all always requires -f)
+
+# built-in alias
+koda d web-srv
+
+# Pattern A
+kd d web-srv
+
+# Pattern B
+kd web-srv                   # kd = koda remove in Pattern B
+```
+
+---
+
+### Copy
+
+Duplicate an entry. The body and tags are copied; the shortcut is not.
+
+```bash
+# koda long form
+koda copy 5
+koda copy web-srv
+
+# built-in alias
+koda c web-srv
+
+# Pattern A
+kd c web-srv
+
+# Pattern B
+kc web-srv
+```
+
+---
+
+### Execute (`exec`) — run a saved command
+
+Run a saved entry as a shell command, with optional variable substitution.
+
+```bash
+# Without koda — retype or search history every time
+ssh -i ~/.ssh/key.pem ec2-user@192.168.1.100
+
+# Store once, run by index or shortcut
+koda add "ssh -i ~/.ssh/key.pem ec2-user@\$1" -t ssh --shortcut web-srv
+
+# koda long form
+koda exec 12                      # by index
+koda exec web-srv                 # by shortcut
+koda exec 12 -V host=localhost    # named substitution
+koda exec web-srv -V localhost    # positional substitution
+
+# built-in alias
+koda x web-srv -V localhost
+
+# Pattern A
+kd x web-srv -V localhost
+
+# Pattern B
+kx web-srv -V localhost
+```
+
+> **Security**: only store trusted commands. `exec` runs the body through the configured shell (`sh` by default).
+
+---
+
+### Raw
+
+Print the entry body to stdout only (no Rich formatting). Use for pipes, `eval`, and command substitution.
+
+```bash
+# koda long form
+koda raw 5
+koda raw web-srv        # by shortcut
+koda raw                # latest entry
+echo 5 | koda raw       # ref from stdin
+$(koda raw 5)           # command substitution
+
+# built-in alias
+koda r web-srv
+
+# Pattern A
+kd r web-srv
+
+# Pattern B
+kr web-srv
+```
+
+`raw` strips shell-style inline comments (`#` at line start or after whitespace). Use `show` to see the original stored text.
+
+```bash
+koda add 'echo hello  # this is a comment'
+koda raw 5    # → echo hello
+koda show 5   # → echo hello  # this is a comment
+```
+
+---
+
+### Pick — interactive launcher (fzf)
+
+Interactively select an entry with `fzf`, then run an action. Requires [`fzf`](https://github.com/junegunn/fzf) and an interactive TTY.
+
+**Main use case — pick and execute immediately:**
+
+```bash
+# koda long form
+koda pick --exec                     # pick from all entries, execute immediately
+koda pick --exec -q docker -t dev    # pre-filter by query and tag, then pick
+
+# built-in alias
 koda p -x
-koda pick --exec
 
-# Pick and edit immediately
-koda pick -e
+# Pattern A
+kd p -x
+kd p -x -q docker -t dev
 
-# Pick and only print IDX for command substitution / pipes
-koda pick -p
-koda show "$(koda pick -p)"
-koda s "$(koda p -p)"
-koda exec "$(koda pick -p)"
-koda x "$(koda p -p)"
-
-# Filter candidate list before selection
-koda pick -q "docker" -t dev
-koda p -q "docker" -t dev
-koda pick -T archive -S
+# Pattern B
+kp -x
+kp -x -q docker -t dev
 ```
 
-Action flags are exclusive: choose one of `-e/--edit`, `-x/--exec`, `-r/--raw`, `-s/--show`.
-`-p/--print-id` cannot be combined with action flags.
-`pick` requires [`fzf`](https://github.com/junegunn/fzf) and an interactive TTY.
-`pick` uses an adaptive preview layout: wide terminals use a right-side preview, narrower terminals use a bottom preview (both wrapped) so the candidate list remains readable.
+**Compound patterns — use pick as a selector:**
+
+```bash
+# Eval the body of the selected entry (requires defaults.cmd = raw)
+eval $(koda pick -p | xargs koda raw)
+eval $(kd p -p | xargs kd r)    # Pattern A
+eval $(kp -p | xargs kr)        # Pattern B
+
+# Pass the selected IDX to exec
+koda exec "$(koda pick -p)"
+kd x "$(kd p -p)"               # Pattern A
+kx "$(kp -p)"                   # Pattern B
+```
+
+Other action flags: `-e` edit, `-r` raw, `-s` show.
+`-p` (print IDX only) cannot be combined with action flags.
+
+---
 
 ### Shortcuts
 
-Assign a memorable alias to any entry and use it instead of a numeric index:
+Assign a memorable string alias to any entry and use it instead of a numeric index.
 
 ```bash
-# Save with a shortcut:
+# Save with a shortcut
 koda add "kubectl rollout restart deploy/api" -t k8s --shortcut restart
 
-# Use the shortcut anywhere an index is accepted:
-koda raw restart       # print body
-koda r restart         # same as `koda raw restart`
-koda exec restart      # execute
-koda x restart         # same as `koda exec restart`
-koda show restart      # show with metadata
-koda s restart         # same as `koda show restart`
-koda remove restart    # delete
-koda d restart         # same as `koda remove restart`
+# Use the shortcut anywhere an index is accepted
+koda raw restart
+koda exec restart
+koda show restart
+koda remove restart
 
-# Or use the default command directly (no subcommand needed):
-koda restart           # same as `koda raw restart` when defaults.cmd = raw
+# Default command — no subcommand needed (when defaults.cmd = raw)
+koda restart          # → koda raw restart
 
-# List all entries that have shortcuts:
+# List all entries that have shortcuts
 koda list --shortcuts
 koda list -S --sort-by shortcut
 ```
 
-To change or remove a shortcut, use `edit` — the `shortcut:` field appears in the metadata footer.
+To change or remove a shortcut, open the entry with `edit` — the `shortcut:` field appears in the metadata footer.
 
-### Body-only stdout (scripts and shells)
+---
 
-```bash
-koda raw          # latest entry body only
-koda r            # same as `koda raw`
-koda raw 5        # entry at display index 5, body only
-koda raw deploy   # entry with shortcut "deploy", body only
-echo 5 | koda raw # read ref(s) from stdin
-koda 5            # numeric args route to the default command
-koda deploy       # shortcut args also route to the default command
-```
+### Variable substitution (`-V` / `--var`)
 
-`show`/`ex` accept one stdin ref when no argument is given. `raw` accepts one or more whitespace-separated refs from stdin when no argument is given.
-
-`raw` treats inline comments like shell scripts: an unquoted `#` at the start of a line or after whitespace hides everything to the right on that line. `show` always displays the original stored text.
-
-```bash
-koda add 'echo hello # comment'
-koda raw 10      # -> echo hello
-koda show 10     # -> echo hello # comment
-```
-
-To keep `#` as a literal character in `raw`, escape or quote it:
-
-```bash
-echo \#literal
-echo '#literal'
-echo "value#suffix"   # no whitespace before #
-```
-
-### Reorder entries (`move`, `swap`, `shift`, `compact`)
-
-Each entry has a display index (`IDX`) you can freely rearrange — handy for keeping frequently used snippets at low numbers (0–9).
-
-```bash
-koda swap 3 0      # swap display positions of entries 3 and 0
-koda w 3 0         # same as `koda swap 3 0`
-koda move 7 1      # move entry 7 to empty position 1 (position must be unoccupied)
-koda m 7 1         # same as `koda move 7 1`
-koda shift 1       # shift all entries at index 1 and above up by 1 (makes room at 1)
-koda h 1           # same as `koda shift 1`
-koda shift 1 -n 3  # shift up by 3 positions
-koda shift 5 -n -1 # shift entries from index 5 downward by 1
-koda compact       # reassign indices to 0..n-1 and fill gaps
-koda k             # same as `koda compact`
-```
-
-`move` requires the destination index to be unoccupied. Use `shift` first to make room, or `swap` to exchange two occupied positions.
-
-### Batch tag (`tag`)
-
-```bash
-koda tag 1 3 5 -t work          # add tag to individual entries
-koda t 1 3 5 -t work            # same as `koda tag ...`
-koda tag 2-6 -t archive         # add tag to a range
-koda tag 1 3-5 7 -T old         # remove tag from mixed selection
-koda tag 1 -t new -T old        # add one tag and remove another in one command
-```
-
-Re-tagging with an already-present tag is a no-op (idempotent).
-
-### Variable substitution (`--var` / `-V`)
-
-Embed placeholders in a memo at save time, then fill them in at recall time.
-
-Two placeholder styles:
+Embed placeholders in a saved entry; fill them in at recall time with `-V`.
 
 | Style | Placeholder | How to pass |
 |---|---|---|
-| Named | `${host}` | `KEY=VALUE` |
-| Positional | `$1`, `$2`, ... | bare values, left-to-right |
-
-**Positional substitution** — use bare values; they map to `$1`, `$2`, ... in order:
-
-Cloud bucket names are long and hard to retype. Store the command once, pass only the part that changes:
+| Named | `${host}` | `-V KEY=VALUE` |
+| Positional | `$1`, `$2`, ... | `-V value` (left-to-right) |
 
 ```bash
-# Without Koda — retype the full bucket path every time:
-gcloud storage cp ./report.csv gs://my-company-analytics-prod-us-central1/uploads/
+# Save a template with a positional placeholder
+koda add "gcloud storage cp \$1 gs://my-company-analytics-prod/uploads/" -t gcloud -s upload
 
-# Store once with a positional placeholder for the local file:
-koda add "gcloud storage cp \$1 gs://my-company-analytics-prod-us-central1/uploads/" -t gcloud,storage
+# Run it with different values — no need to retype the bucket path
+koda exec upload -V ./report.csv
+koda exec upload -V ./summary.csv
+kx upload -V ./report.csv          # Pattern B
 
-# From now on:
-koda exec -V ./report.csv
-koda exec -V ./summary.csv
-```
+# Named substitution — swap one variable by name
+koda add "aws s3 sync ./dist s3://acme-frontend-\${env}-us-east-1/app/" -t aws -s deploy
+koda exec deploy -V env=prod
+koda exec deploy -V env=staging
+kx deploy -V env=prod              # Pattern B
 
-Same pattern works for AWS S3:
-
-```bash
-koda add "aws s3 sync \$1 s3://acme-frontend-assets-prod-us-east-1/app/" -t aws,s3
-koda exec -V ./dist
-koda exec -V ./build
-```
-
-Pass two positional values with repeated `-V` flags or space-separated in one:
-
-```bash
+# Positional with multiple values
 koda add "rsync -avz \$1 \$2" -t rsync
-koda raw 8 -V /src/path -V /user@host:/dest
-koda raw 8 -V "/src/path /user@host:/dest"   # same result
-```
+koda raw 8 -V /src/path -V user@host:/dest
+koda raw 8 -V "/src/path user@host:/dest"    # same result
 
-**Named substitution** — use `KEY=VALUE` when you want to swap a specific part by name:
-
-```bash
-# Deploy to different environments by changing one variable:
-koda add "aws s3 sync ./dist s3://acme-frontend-\${env}-us-east-1/app/" -t aws,s3,deploy
-
-koda exec -V env=prod
-koda exec -V env=staging
-```
-
-**Mix named and positional** — order of `-V` flags determines positional index:
-
-```bash
-# Template: connect $1@${host}:$2 as ${name}
+# Mix named and positional
 koda raw 9 -V "admin 5432" -V host=db.example.com -V name="new york"
 # → connect admin@db.example.com:5432 as new york
 ```
 
-Values containing spaces must be quoted so the shell passes them as one token:
+Values with spaces must be quoted so the shell passes them as a single token.
+
+---
+
+### Reorder entries (`move`, `swap`, `shift`, `compact`)
+
+Each entry has a display index (`IDX`) you can freely rearrange — useful for keeping frequently used snippets at low numbers.
 
 ```bash
--V name="new york"      # value is: new york
--V "admin 5432"         # two positional values: admin → $1, 5432 → $2
+# koda long form
+koda swap 3 0           # exchange display positions of entries 3 and 0
+koda move 7 1           # move entry 7 to empty position 1
+koda shift 1            # shift entries at index 1+ up by 1 (makes room at 1)
+koda shift 1 -n 3       # shift up by 3 positions
+koda shift 5 -n -1      # shift entries from index 5 downward by 1
+koda compact            # reassign all indices to 0..n-1, fill gaps
+
+# built-in alias
+koda w 3 0
+koda m 7 1
+koda h 1
+koda k
+
+# Pattern A
+kd w 3 0
+kd m 7 1
+kd h 1
+kd k
+
+# Pattern B
+kw 3 0
+km 7 1
+kh 1
+kk
 ```
 
-**Execute with substitution** (`exec` command):
+`move` requires the destination index to be unoccupied. Use `shift` to make room first, or `swap` to exchange two occupied positions.
+
+---
+
+### Batch tag (`tag`)
 
 ```bash
-koda exec 7 -V env=prod
-koda exec 7 -V ./report.csv
+# koda long form
+koda tag 1 3 5 -t work          # add tag to individual entries
+koda tag 2-6 -t archive         # add tag to a range
+koda tag 1 3-5 7 -T old         # remove tag from mixed selection
+koda tag 1 -t new -T old        # add one tag and remove another in one command
+
+# built-in alias
+koda t 1 3-5 -t archive
+
+# Pattern A
+kd t 1 3-5 -t archive
+
+# Pattern B
+kt 1 3-5 -t archive
 ```
+
+Re-tagging with an already-present tag is idempotent (no-op).
+
+---
+
+### Configuration (`config`)
+
+```bash
+# koda long form
+koda config                           # show all settings with source
+koda config get defaults.cmd          # print a single value
+koda config set defaults.cmd list     # write to config file
+koda config unset list.per_page       # remove key (reverts to built-in default)
+koda config reset                     # delete config file (prompts for confirmation)
+koda config reset -f                  # delete without prompt
+koda config edit                      # open config in $EDITOR
+koda config path                      # print config file path
+
+# built-in alias
+koda g set defaults.cmd list
+
+# Pattern A
+kd g set defaults.cmd list
+
+# Pattern B
+kg set defaults.cmd list
+```
+
+---
+
+## Recommended aliases
+
+Two patterns are available. Choose one based on how much you want to shorten your workflow.
+
+---
+
+### Pattern A — minimal (`kd='koda'` only)
+
+Register only `kd` as an alias for `koda`, then use koda's built-in single-letter aliases for subcommands. No risk of conflicting with other tools.
+
+```bash
+# Add to ~/.zshrc or ~/.bashrc
+alias kd='koda'
+```
+
+Examples with Pattern A:
+
+```bash
+kd a "memo" -t tag -s sc    # add
+kd l -q docker              # list
+kd s web-srv                # show
+kd e web-srv                # edit
+kd r web-srv                # raw
+kd x web-srv -V localhost   # exec
+kd p -x -q docker           # pick + exec
+kd d web-srv                # remove
+kd t 1 3-5 -t archive       # tag
+kd g set defaults.cmd list  # config set
+```
+
+---
+
+### Pattern B — full two-letter aliases
+
+Register a two-letter alias for every subcommand. Shorter to type, but check for conflicts before adding.
+
+> **Note**: Pattern B assigns `kd` to `koda remove`. If you previously used `alias kd='koda'` (Pattern A), remove that line first.
+
+```bash
+# Add to ~/.zshrc or ~/.bashrc
+alias ka='koda add'
+alias kl='koda list'
+alias ks='koda show'
+alias ke='koda edit'
+alias kr='koda raw'
+alias kx='koda exec'
+alias kp='koda pick'
+alias kd='koda remove'   # ← replaces kd='koda' if you had Pattern A
+alias kc='koda copy'
+alias km='koda move'
+alias kw='koda swap'
+alias kh='koda shift'
+alias kk='koda compact'
+alias kt='koda tag'
+alias kg='koda config'
+```
+
+**Potential conflicts — check before adding:**
+
+| Alias | Possible conflict |
+|---|---|
+| `ks` | Kakoune session manager on some setups |
+| `kt` | Kotlin toolchain (`ktlint`, etc.) in some environments |
+
+Run `alias` in your shell to see what is already defined before adding these.
+
+---
 
 ## Configuration
 
-Koda reads `~/.config/koda/config.toml` (XDG: `$XDG_CONFIG_HOME/koda/config.toml`).
-All settings are optional — unset values fall back to the built-in defaults.
+Koda reads `~/.config/koda/config.toml` (XDG: `$XDG_CONFIG_HOME/koda/config.toml`). All settings are optional — unset values fall back to built-in defaults.
 
 ```toml
 [defaults]
-cmd = "raw"       # "raw", "list", "show", or "add" — what bare `kd` does
+cmd = "raw"       # "raw", "list", "show", or "add" — what bare `koda` does
 
 [list]
 per_page = 20     # entries per page
@@ -429,32 +552,19 @@ desc = false      # sort direction
 path = "~/.local/share/koda/koda.db"
 
 [exec]
-shell = "sh"      # shell used by `exec`
-```
-
-### `config` subcommand
-
-```bash
-koda config                       # show all settings with source (default/file/env)
-koda config get defaults.cmd      # print a single value
-koda config set defaults.cmd list # write to config file
-koda config unset list.per_page   # remove key (reverts to default)
-koda config reset                 # delete config file (prompts for confirmation)
-koda config reset -f              # delete without prompt
-koda config edit                  # open config file in $EDITOR
-koda config path                  # print config file path
+shell = "sh"      # shell used by exec
 ```
 
 Priority order: **CLI flags > environment variables > config file > built-in defaults**
 
 ## Environment variables
 
-| Variable           | Purpose |
-|--------------------|---------|
-| `KODA_DB_PATH`     | Override database file path |
+| Variable | Purpose |
+|---|---|
+| `KODA_DB_PATH` | Override database file path |
 | `KODA_DEFAULT_CMD` | Override `defaults.cmd` for this session |
 | `KODA_CONFIG_PATH` | Override config file path |
-| `EDITOR`           | Editor for `add`, `edit`, and `config edit` (default: `vim`) |
+| `EDITOR` | Editor for `add`, `edit`, and `config edit` (default: `vim`) |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Each section below shows four equivalent forms:
 |---|---|
 | long | `koda exec web-srv -V localhost` |
 | built-in alias | `koda x web-srv -V localhost` |
-| Pattern A (`alias kd='koda'`) | `kd x web-srv -V localhost` |
-| Pattern B (two-letter aliases) | `kx web-srv -V localhost` |
+| kd prefix (`alias kd='koda'`) | `kd x web-srv -V localhost` |
+| two-letter alias (e.g. `alias kx='koda exec'`) | `kx web-srv -V localhost` |
 
 See [Recommended aliases](#recommended-aliases) for setup instructions.
 
@@ -80,10 +80,10 @@ koda add           # opens $EDITOR
 # built-in alias
 koda a "Quick note" -t quick -s dc
 
-# Pattern A
+# kd prefix
 kd a "Quick note" -t quick -s dc
 
-# Pattern B
+# two-letter alias
 ka "Quick note" -t quick -s dc
 ```
 
@@ -112,10 +112,10 @@ koda list --shortcuts              # only entries that have a shortcut
 # built-in alias
 koda l -q docker -t dev
 
-# Pattern A
+# kd prefix
 kd l -q docker -t dev
 
-# Pattern B
+# two-letter alias
 kl -q docker -t dev
 ```
 
@@ -137,10 +137,10 @@ echo 5 | koda show     # ref from stdin
 # built-in alias
 koda s web-srv
 
-# Pattern A
+# kd prefix
 kd s web-srv
 
-# Pattern B
+# two-letter alias
 ks web-srv
 ```
 
@@ -158,10 +158,10 @@ koda edit web-srv      # by shortcut
 # built-in alias
 koda e web-srv
 
-# Pattern A
+# kd prefix
 kd e web-srv
 
-# Pattern B
+# two-letter alias
 ke web-srv
 ```
 
@@ -183,11 +183,11 @@ koda remove --all -f          # delete everything (--all always requires -f)
 # built-in alias
 koda d web-srv
 
-# Pattern A
+# kd prefix
 kd d web-srv
 
-# Pattern B
-kd web-srv                   # kd = koda remove in Pattern B
+# two-letter alias
+kd web-srv                   # kd = koda remove in two-letter alias
 ```
 
 ---
@@ -204,10 +204,10 @@ koda copy web-srv
 # built-in alias
 koda c web-srv
 
-# Pattern A
+# kd prefix
 kd c web-srv
 
-# Pattern B
+# two-letter alias
 kc web-srv
 ```
 
@@ -233,10 +233,10 @@ koda exec web-srv -V localhost    # positional substitution
 # built-in alias
 koda x web-srv -V localhost
 
-# Pattern A
+# kd prefix
 kd x web-srv -V localhost
 
-# Pattern B
+# two-letter alias
 kx web-srv -V localhost
 ```
 
@@ -258,10 +258,10 @@ echo 5 | koda raw       # ref from stdin
 # built-in alias
 koda r web-srv
 
-# Pattern A
+# kd prefix
 kd r web-srv
 
-# Pattern B
+# two-letter alias
 kr web-srv
 ```
 
@@ -283,11 +283,11 @@ ssh -i ~/.ssh/key.pem ec2-user@$(koda raw bastion)
 tail -f $(koda raw nginx-log)
 curl -H "Authorization: Bearer $(koda raw api-token)" https://api.example.com/v1/status
 
-# Pattern A
+# kd prefix
 ssh -i ~/.ssh/key.pem ec2-user@$(kd r bastion)
 tail -f $(kd r nginx-log)
 
-# Pattern B — shortest form
+# two-letter alias — shortest form
 ssh -i ~/.ssh/key.pem ec2-user@$(kr bastion)
 tail -f $(kr nginx-log)
 curl -H "Authorization: Bearer $(kr api-token)" https://api.example.com/v1/status
@@ -317,11 +317,11 @@ koda pick --exec -q docker -t dev    # pre-filter by query and tag, then pick
 # built-in alias
 koda p -x
 
-# Pattern A
+# kd prefix
 kd p -x
 kd p -x -q docker -t dev
 
-# Pattern B
+# two-letter alias
 kp -x
 kp -x -q docker -t dev
 ```
@@ -331,13 +331,13 @@ kp -x -q docker -t dev
 ```bash
 # Eval the body of the selected entry (requires defaults.cmd = raw)
 eval $(koda pick -p | xargs koda raw)
-eval $(kd p -p | xargs kd r)    # Pattern A
-eval $(kp -p | xargs kr)        # Pattern B
+eval $(kd p -p | xargs kd r)    # kd prefix
+eval $(kp -p | xargs kr)        # two-letter alias
 
 # Pass the selected IDX to exec
 koda exec "$(koda pick -p)"
-kd x "$(kd p -p)"               # Pattern A
-kx "$(kp -p)"                   # Pattern B
+kd x "$(kd p -p)"               # kd prefix
+kx "$(kp -p)"                   # two-letter alias
 ```
 
 Other action flags: `-e` edit, `-r` raw, `-s` show.
@@ -387,13 +387,13 @@ koda add "gcloud storage cp \$1 gs://my-company-analytics-prod/uploads/" -t gclo
 # Run it with different values — no need to retype the bucket path
 koda exec upload -V ./report.csv
 koda exec upload -V ./summary.csv
-kx upload -V ./report.csv          # Pattern B
+kx upload -V ./report.csv          # two-letter alias
 
 # Named substitution — swap one variable by name
 koda add "aws s3 sync ./dist s3://acme-frontend-\${env}-us-east-1/app/" -t aws -s deploy
 koda exec deploy -V env=prod
 koda exec deploy -V env=staging
-kx deploy -V env=prod              # Pattern B
+kx deploy -V env=prod              # two-letter alias
 
 # Positional with multiple values
 koda add "rsync -avz \$1 \$2" -t rsync
@@ -428,13 +428,13 @@ koda m 7 1
 koda h 1
 koda k
 
-# Pattern A
+# kd prefix
 kd w 3 0
 kd m 7 1
 kd h 1
 kd k
 
-# Pattern B
+# two-letter alias
 kw 3 0
 km 7 1
 kh 1
@@ -457,10 +457,10 @@ koda tag 1 -t new -T old        # add one tag and remove another in one command
 # built-in alias
 koda t 1 3-5 -t archive
 
-# Pattern A
+# kd prefix
 kd t 1 3-5 -t archive
 
-# Pattern B
+# two-letter alias
 kt 1 3-5 -t archive
 ```
 
@@ -484,10 +484,10 @@ koda config path                      # print config file path
 # built-in alias
 koda g set defaults.cmd list
 
-# Pattern A
+# kd prefix
 kd g set defaults.cmd list
 
-# Pattern B
+# two-letter alias
 kg set defaults.cmd list
 ```
 
@@ -499,7 +499,7 @@ Two patterns are available. Choose one based on how much you want to shorten you
 
 ---
 
-### Pattern A — minimal (`kd='koda'` only)
+### kd prefix — minimal (`kd='koda'` only)
 
 Register only `kd` as an alias for `koda`, then use koda's built-in single-letter aliases for subcommands. No risk of conflicting with other tools.
 
@@ -508,7 +508,7 @@ Register only `kd` as an alias for `koda`, then use koda's built-in single-lette
 alias kd='koda'
 ```
 
-Examples with Pattern A:
+Examples with kd prefix:
 
 ```bash
 kd a "memo" -t tag -s sc    # add
@@ -525,11 +525,11 @@ kd g set defaults.cmd list  # config set
 
 ---
 
-### Pattern B — full two-letter aliases
+### two-letter alias — full two-letter aliases
 
 Register a two-letter alias for every subcommand. Shorter to type, but check for conflicts before adding.
 
-> **Note**: Pattern B assigns `kd` to `koda remove`. If you previously used `alias kd='koda'` (Pattern A), remove that line first.
+> **Note**: two-letter alias assigns `kd` to `koda remove`. If you previously used `alias kd='koda'` (kd prefix), remove that line first.
 
 ```bash
 # Add to ~/.zshrc or ~/.bashrc
@@ -540,7 +540,7 @@ alias ke='koda edit'
 alias kr='koda raw'
 alias kx='koda exec'
 alias kp='koda pick'
-alias kd='koda remove'   # ← replaces kd='koda' if you had Pattern A
+alias kd='koda remove'   # ← replaces kd='koda' if you had kd prefix
 alias kc='koda copy'
 alias km='koda move'
 alias kw='koda swap'

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ A **terminal launcher and snippet store**. Save commands, config templates, and 
 ## Features
 
 - **Launcher**: Run any saved command with `exec` or `pick`, with variable substitution at call time.
+- **Command substitution**: Embed stored values directly in any command — `ssh $(kr bastion)`, `tail -f $(kr log-path)`.
 - **Fast save and recall**: `add`, `list`, `show`, `edit`, `pick`, `remove` — all with one-letter aliases.
 - **Flexible input**: Arguments, heredocs, pipes, or `$EDITOR`.
 - **Shortcuts**: Assign a memorable string alias to any entry and use it in place of a numeric index.
 - **Variable substitution**: Expand `${KEY}` and `$1 $2 ...` placeholders at recall time with `-V`.
-- **Command substitution**: Embed stored values directly in any command — `ssh $(kr bastion)`, `tail -f $(kr log-path)`.
 - **Shell-friendly output**: `raw` prints body-only text for pipes, `eval`, and scripts.
 - **Tags**: Classify, filter, and batch-edit entries with multiple tags.
 - **Display index**: Stable `uid` (SHA1 short hash) plus user-controlled `idx`. Reorder with `move`/`swap`; close gaps with `compact`.
@@ -47,7 +47,7 @@ t tag      w swap     x exec
 
 Single-letter aliases are reserved and cannot be used as entry shortcuts.
 
-Each section below shows four equivalent forms:
+Each section below shows these equivalent forms:
 
 | Form | Example |
 |---|---|
@@ -65,150 +65,35 @@ See [Recommended aliases](#recommended-aliases) for setup instructions.
 Save a new entry from arguments, heredoc, stdin, or `$EDITOR`.
 
 ```bash
-# Without koda — paste into a file or memorize
-echo "docker compose -f docker-compose.dev.yml up --build" >> snippets.txt
+koda a "docker compose up --build" -t docker -s dc
+koda a "quick note" -t work
+koda a              # opens $EDITOR
+```
 
-# koda long form
-koda add "docker compose -f docker-compose.dev.yml up --build" -t docker --shortcut dc
-koda add -t infra <<'EOF'
+Heredoc for multi-line content:
+
+```bash
+koda a -t infra <<'EOF'
 FROM python:3.12-slim
 RUN pip install uv
 WORKDIR /app
 EOF
-koda add           # opens $EDITOR
-
-# built-in alias
-koda a "Quick note" -t quick -s dc
-
-# kd prefix
-kd a "Quick note" -t quick -s dc
-
-# two-letter alias
-ka "Quick note" -t quick -s dc
 ```
 
-Pipe any command output directly into `koda add`:
+Pipe any command output directly into `koda a`:
 
 ```bash
-history | grep ffmpeg | tail -1 | koda add -t ffmpeg
-kubectl get pods -o wide    | koda add -t k8s
-openssl rand -hex 32        | koda add -t secret
+history | grep ffmpeg | tail -1 | koda a -t ffmpeg
+kubectl get pods -o wide    | koda a -t k8s
+openssl rand -hex 32        | koda a -t secret
 ```
 
----
-
-### List
+Full form and aliases:
 
 ```bash
-# koda long form
-koda list                          # all entries ordered by display index
-koda list -q "docker"              # substring search on body
-koda list -t linux                 # filter by tag substring
-koda list -T archive               # exclude entries tagged "archive"
-koda list -n 50 -p 2              # 50 entries per page, page 2
-koda list -s created_at --desc     # sort by creation date descending
-koda list --shortcuts              # only entries that have a shortcut
-
-# built-in alias
-koda l -q docker -t dev
-
-# kd prefix
-kd l -q docker -t dev
-
-# two-letter alias
-kl -q docker -t dev
-```
-
-Each row shows `IDX`, `UID`, `SC` (shortcut), tags, content preview, and creation time.
-Sort columns: `id`, `idx`, `uid`, `tags`, `content`, `created_at`, `modified_at`, `shortcut`.
-
----
-
-### Show
-
-Display a single entry with full metadata.
-
-```bash
-# koda long form
-koda show 5
-koda show web-srv      # by shortcut
-echo 5 | koda show     # ref from stdin
-
-# built-in alias
-koda s web-srv
-
-# kd prefix
-kd s web-srv
-
-# two-letter alias
-ks web-srv
-```
-
----
-
-### Edit
-
-Open an entry in `$EDITOR`. The footer contains editable metadata (tags, shortcut).
-
-```bash
-# koda long form
-koda edit 5
-koda edit web-srv      # by shortcut
-
-# built-in alias
-koda e web-srv
-
-# kd prefix
-kd e web-srv
-
-# two-letter alias
-ke web-srv
-```
-
----
-
-### Remove
-
-Delete one or more entries.
-
-```bash
-# koda long form
-koda remove 5
-koda remove web-srv          # by shortcut
-koda remove 1 3 5-8          # multiple entries and ranges
-koda remove -t archive        # delete all tagged "archive"
-koda remove -q "tmp"          # delete entries matching body substring
-koda remove --all -f          # delete everything (--all always requires -f)
-
-# built-in alias
-koda d web-srv
-
-# kd prefix
-kd d web-srv
-
-# two-letter alias
-kd web-srv                   # kd = koda remove in two-letter alias
-```
-
----
-
-### Copy
-
-Duplicate an entry. The body and tags are copied; the shortcut is not.
-
-```bash
-# koda long form
-koda copy 5
-koda copy web-srv
-
-# built-in alias
-koda c web-srv
-
-# kd prefix
-kd c web-srv
-
-# two-letter alias
-kc web-srv
+koda add "memo" -t tag --shortcut sc   # long form
+kd a "memo" -t tag -s sc              # kd prefix
+ka "memo" -t tag -s sc                # two-letter alias
 ```
 
 ---
@@ -221,85 +106,25 @@ Run a saved entry as a shell command, with optional variable substitution.
 # Without koda — retype or search history every time
 ssh -i ~/.ssh/key.pem ec2-user@192.168.1.100
 
-# Store once, run by index or shortcut
-koda add "ssh -i ~/.ssh/key.pem ec2-user@\$1" -t ssh --shortcut web-srv
+# Save once
+koda a "ssh -i ~/.ssh/key.pem ec2-user@\$1" -t ssh -s web-srv
+```
 
-# koda long form
-koda exec 12                      # by index
-koda exec web-srv                 # by shortcut
-koda exec 12 -V host=localhost    # named substitution
-koda exec web-srv -V localhost    # positional substitution
+```bash
+koda x web-srv              # run by shortcut
+koda x web-srv -V prod      # with variable substitution
+koda x 12                   # run by index
+```
 
-# built-in alias
-koda x web-srv -V localhost
+Full form and aliases:
 
-# kd prefix
-kd x web-srv -V localhost
-
-# two-letter alias
-kx web-srv -V localhost
+```bash
+koda exec web-srv -V localhost   # long form
+kd x web-srv -V localhost        # kd prefix
+kx web-srv -V localhost          # two-letter alias
 ```
 
 > **Security**: only store trusted commands. `exec` runs the body through the configured shell (`sh` by default).
-
----
-
-### Raw
-
-Print the entry body to stdout only (no Rich formatting). Use for pipes, `eval`, and command substitution.
-
-```bash
-# koda long form
-koda raw 5
-koda raw web-srv        # by shortcut
-koda raw                # latest entry
-echo 5 | koda raw       # ref from stdin
-
-# built-in alias
-koda r web-srv
-
-# kd prefix
-kd r web-srv
-
-# two-letter alias
-kr web-srv
-```
-
-**Command substitution** — embed a stored value directly inside any command you type:
-
-```bash
-# Without koda — retype long strings inline every time
-ssh -i ~/.ssh/key.pem ec2-user@bastion.prod.example.com
-tail -f /var/log/nginx/access.log
-curl -H "Authorization: Bearer eyJhbGciOiJSUzI1Ni..." https://api.example.com/v1/status
-
-# Store once, reference by shortcut
-koda add "bastion.prod.example.com"       -t ssh    --shortcut bastion
-koda add "/var/log/nginx/access.log"      -t log    --shortcut nginx-log
-koda add "eyJhbGciOiJSUzI1Ni..."          -t secret --shortcut api-token
-
-# Embed in any command with $()
-ssh -i ~/.ssh/key.pem ec2-user@$(koda raw bastion)
-tail -f $(koda raw nginx-log)
-curl -H "Authorization: Bearer $(koda raw api-token)" https://api.example.com/v1/status
-
-# kd prefix
-ssh -i ~/.ssh/key.pem ec2-user@$(kd r bastion)
-tail -f $(kd r nginx-log)
-
-# two-letter alias — shortest form
-ssh -i ~/.ssh/key.pem ec2-user@$(kr bastion)
-tail -f $(kr nginx-log)
-curl -H "Authorization: Bearer $(kr api-token)" https://api.example.com/v1/status
-```
-
-`raw` strips shell-style inline comments (`#` at line start or after whitespace). Use `show` to see the original stored text.
-
-```bash
-koda add 'echo hello  # this is a comment'
-koda raw 5    # → echo hello
-koda show 5   # → echo hello  # this is a comment
-```
 
 ---
 
@@ -307,41 +132,101 @@ koda show 5   # → echo hello  # this is a comment
 
 Interactively select an entry with `fzf`, then run an action. Requires [`fzf`](https://github.com/junegunn/fzf) and an interactive TTY.
 
-**Main use case — pick and execute immediately:**
+```bash
+koda p -x                      # pick from all entries, execute immediately
+koda p -x -q docker -t dev     # pre-filter by query and tag, then pick
+```
+
+Full form and aliases:
 
 ```bash
-# koda long form
-koda pick --exec                     # pick from all entries, execute immediately
-koda pick --exec -q docker -t dev    # pre-filter by query and tag, then pick
-
-# built-in alias
-koda p -x
-
-# kd prefix
-kd p -x
-kd p -x -q docker -t dev
-
-# two-letter alias
-kp -x
-kp -x -q docker -t dev
+koda pick --exec -q docker -t dev   # long form
+kd p -x -q docker -t dev            # kd prefix
+kp -x -q docker -t dev              # two-letter alias
 ```
 
 **Compound patterns — use pick as a selector:**
 
 ```bash
-# Eval the body of the selected entry (requires defaults.cmd = raw)
-eval $(koda pick -p | xargs koda raw)
-eval $(kd p -p | xargs kd r)    # kd prefix
-eval $(kp -p | xargs kr)        # two-letter alias
+koda x "$(koda p -p)"          # pick IDX, pass to exec
+kd x "$(kd p -p)"              # kd prefix
+kx "$(kp -p)"                  # two-letter alias
 
-# Pass the selected IDX to exec
-koda exec "$(koda pick -p)"
-kd x "$(kd p -p)"               # kd prefix
-kx "$(kp -p)"                   # two-letter alias
+eval $(kp -p | xargs kr)       # pick IDX, eval the body
 ```
 
 Other action flags: `-e` edit, `-r` raw, `-s` show.
 `-p` (print IDX only) cannot be combined with action flags.
+
+---
+
+### Raw — body-only output
+
+Print the entry body to stdout (no Rich formatting). Use for pipes, `eval`, and command substitution.
+
+```bash
+koda r web-srv        # by shortcut
+koda r 5              # by index
+koda r                # latest entry
+echo 5 | koda r       # ref from stdin
+```
+
+Full form and aliases:
+
+```bash
+koda raw web-srv   # long form
+kd r web-srv       # kd prefix
+kr web-srv         # two-letter alias
+```
+
+**Command substitution — embed a stored value inside any command:**
+
+```bash
+# Without koda — retype long strings inline every time
+ssh -i ~/.ssh/key.pem ec2-user@bastion.prod.example.com
+tail -f /var/log/nginx/access.log
+
+# Save once
+koda a "bastion.prod.example.com"  -t ssh -s bastion
+koda a "/var/log/nginx/access.log" -t log -s nginx-log
+
+# Embed with $() — using two-letter alias
+ssh -i ~/.ssh/key.pem ec2-user@$(kr bastion)
+tail -f $(kr nginx-log)
+
+# kd prefix
+ssh -i ~/.ssh/key.pem ec2-user@$(kd r bastion)
+tail -f $(kd r nginx-log)
+```
+
+**Workflow example — save a token via pipe, reuse in requests:**
+
+```bash
+# Step 1: obtain a token and save it
+curl -s -X POST https://auth.example.com/token \
+  -d '{"client_id":"myapp","client_secret":"s3cr3t"}' \
+  | jq -r '.access_token' \
+  | koda a -t api,token -s api-token
+
+# Step 2: embed in every subsequent request — no copy-paste
+curl -H "Authorization: Bearer $(kr api-token)" \
+  https://api.example.com/v1/users
+
+# kd prefix
+curl -H "Authorization: Bearer $(kd r api-token)" \
+  https://api.example.com/v1/users
+
+# Refresh when expired
+koda e api-token   # opens $EDITOR to paste the new value
+```
+
+`raw` strips shell-style inline comments (`#` at line start or after whitespace). Use `show` to see the original stored text.
+
+```bash
+koda a 'echo hello  # this is a comment'
+koda r 5    # → echo hello
+koda s 5    # → echo hello  # this is a comment
+```
 
 ---
 
@@ -350,21 +235,21 @@ Other action flags: `-e` edit, `-r` raw, `-s` show.
 Assign a memorable string alias to any entry and use it instead of a numeric index.
 
 ```bash
-# Save with a shortcut
-koda add "kubectl rollout restart deploy/api" -t k8s --shortcut restart
+# Save with a shortcut (-s is short for --shortcut)
+koda a "kubectl rollout restart deploy/api" -t k8s -s restart
 
 # Use the shortcut anywhere an index is accepted
-koda raw restart
-koda exec restart
-koda show restart
-koda remove restart
+koda r restart
+koda x restart
+koda s restart
+koda d restart
 
 # Default command — no subcommand needed (when defaults.cmd = raw)
 koda restart          # → koda raw restart
 
 # List all entries that have shortcuts
-koda list --shortcuts
-koda list -S --sort-by shortcut
+koda l -S
+koda l -S --sort-by shortcut
 ```
 
 To change or remove a shortcut, open the entry with `edit` — the `shortcut:` field appears in the metadata footer.
@@ -382,30 +267,136 @@ Embed placeholders in a saved entry; fill them in at recall time with `-V`.
 
 ```bash
 # Save a template with a positional placeholder
-koda add "gcloud storage cp \$1 gs://my-company-analytics-prod/uploads/" -t gcloud -s upload
+koda a "gcloud storage cp \$1 gs://my-company-analytics-prod/uploads/" -t gcloud -s upload
 
-# Run it with different values — no need to retype the bucket path
-koda exec upload -V ./report.csv
-koda exec upload -V ./summary.csv
+# Run with different values — no need to retype the bucket path
+koda x upload -V ./report.csv
+koda x upload -V ./summary.csv
 kx upload -V ./report.csv          # two-letter alias
 
 # Named substitution — swap one variable by name
-koda add "aws s3 sync ./dist s3://acme-frontend-\${env}-us-east-1/app/" -t aws -s deploy
-koda exec deploy -V env=prod
-koda exec deploy -V env=staging
+koda a "aws s3 sync ./dist s3://acme-frontend-\${env}-us-east-1/app/" -t aws -s deploy
+koda x deploy -V env=prod
+koda x deploy -V env=staging
 kx deploy -V env=prod              # two-letter alias
 
-# Positional with multiple values
-koda add "rsync -avz \$1 \$2" -t rsync
-koda raw 8 -V /src/path -V user@host:/dest
-koda raw 8 -V "/src/path user@host:/dest"    # same result
+# Multiple positional values
+koda a "rsync -avz \$1 \$2" -t rsync
+koda r 8 -V /src/path -V user@host:/dest
+koda r 8 -V "/src/path user@host:/dest"    # same result
 
 # Mix named and positional
-koda raw 9 -V "admin 5432" -V host=db.example.com -V name="new york"
+koda r 9 -V "admin 5432" -V host=db.example.com -V name="new york"
 # → connect admin@db.example.com:5432 as new york
 ```
 
 Values with spaces must be quoted so the shell passes them as a single token.
+
+---
+
+### List
+
+```bash
+koda l                          # all entries ordered by display index
+koda l -q "docker"              # substring search on body
+koda l -t linux                 # filter by tag substring
+koda l -T archive               # exclude entries tagged "archive"
+koda l -S                       # only entries that have a shortcut
+koda l -n 50 -p 2              # 50 entries per page, page 2
+koda l -s created_at --desc     # sort by creation date descending
+```
+
+Full form and aliases:
+
+```bash
+koda list -q docker -t dev   # long form
+kd l -q docker -t dev        # kd prefix
+kl -q docker -t dev          # two-letter alias
+```
+
+Each row shows `IDX`, `UID`, `SC` (shortcut), tags, content preview, and creation time.
+Sort columns: `id`, `idx`, `uid`, `tags`, `content`, `created_at`, `modified_at`, `shortcut`.
+
+---
+
+### Show
+
+Display a single entry with full metadata.
+
+```bash
+koda s web-srv        # by shortcut
+koda s 5              # by index
+echo 5 | koda s       # ref from stdin
+```
+
+Full form and aliases:
+
+```bash
+koda show web-srv   # long form
+kd s web-srv        # kd prefix
+ks web-srv          # two-letter alias
+```
+
+---
+
+### Edit
+
+Open an entry in `$EDITOR`. The footer contains editable metadata (tags, shortcut).
+
+```bash
+koda e web-srv        # by shortcut
+koda e 5              # by index
+```
+
+Full form and aliases:
+
+```bash
+koda edit web-srv   # long form
+kd e web-srv        # kd prefix
+ke web-srv          # two-letter alias
+```
+
+---
+
+### Remove
+
+Delete one or more entries.
+
+```bash
+koda d web-srv              # by shortcut
+koda d 5                    # by index
+koda d 1 3 5-8              # multiple entries and ranges
+koda d -t archive           # delete all tagged "archive"
+koda d -q "tmp"             # delete entries matching body substring
+koda d --all -f             # delete everything (--all always requires -f)
+```
+
+Full form and aliases:
+
+```bash
+koda remove web-srv   # long form
+kd d web-srv          # kd prefix
+kd web-srv            # two-letter alias (kd = koda remove)
+```
+
+---
+
+### Copy
+
+Duplicate an entry. The body and tags are copied; the shortcut is not.
+
+```bash
+koda c web-srv        # by shortcut
+koda c 5              # by index
+```
+
+Full form and aliases:
+
+```bash
+koda copy web-srv   # long form
+kd c web-srv        # kd prefix
+kc web-srv          # two-letter alias
+```
 
 ---
 
@@ -414,31 +405,21 @@ Values with spaces must be quoted so the shell passes them as a single token.
 Each entry has a display index (`IDX`) you can freely rearrange — useful for keeping frequently used snippets at low numbers.
 
 ```bash
-# koda long form
-koda swap 3 0           # exchange display positions of entries 3 and 0
-koda move 7 1           # move entry 7 to empty position 1
-koda shift 1            # shift entries at index 1+ up by 1 (makes room at 1)
-koda shift 1 -n 3       # shift up by 3 positions
-koda shift 5 -n -1      # shift entries from index 5 downward by 1
-koda compact            # reassign all indices to 0..n-1, fill gaps
+koda w 3 0        # swap display positions of entries 3 and 0
+koda m 7 1        # move entry 7 to empty position 1
+koda h 1          # shift entries at index 1+ up by 1 (makes room at 1)
+koda h 1 -n 3     # shift up by 3 positions
+koda h 5 -n -1    # shift entries from index 5 downward by 1
+koda k            # reassign all indices to 0..n-1, fill gaps
+```
 
-# built-in alias
-koda w 3 0
-koda m 7 1
-koda h 1
-koda k
+Full form and aliases:
 
-# kd prefix
-kd w 3 0
-kd m 7 1
-kd h 1
-kd k
-
-# two-letter alias
-kw 3 0
-km 7 1
-kh 1
-kk
+```bash
+koda swap 3 0    kd w 3 0    kw 3 0
+koda move 7 1    kd m 7 1    km 7 1
+koda shift 1     kd h 1      kh 1
+koda compact     kd k        kk
 ```
 
 `move` requires the destination index to be unoccupied. Use `shift` to make room first, or `swap` to exchange two occupied positions.
@@ -448,20 +429,18 @@ kk
 ### Batch tag (`tag`)
 
 ```bash
-# koda long form
-koda tag 1 3 5 -t work          # add tag to individual entries
-koda tag 2-6 -t archive         # add tag to a range
-koda tag 1 3-5 7 -T old         # remove tag from mixed selection
-koda tag 1 -t new -T old        # add one tag and remove another in one command
+koda t 1 3 5 -t work          # add tag to individual entries
+koda t 2-6 -t archive         # add tag to a range
+koda t 1 3-5 7 -T old         # remove tag from mixed selection
+koda t 1 -t new -T old        # add one tag and remove another in one command
+```
 
-# built-in alias
-koda t 1 3-5 -t archive
+Full form and aliases:
 
-# kd prefix
-kd t 1 3-5 -t archive
-
-# two-letter alias
-kt 1 3-5 -t archive
+```bash
+koda tag 1 3-5 -t archive   # long form
+kd t 1 3-5 -t archive       # kd prefix
+kt 1 3-5 -t archive         # two-letter alias
 ```
 
 Re-tagging with an already-present tag is idempotent (no-op).
@@ -471,24 +450,21 @@ Re-tagging with an already-present tag is idempotent (no-op).
 ### Configuration (`config`)
 
 ```bash
-# koda long form
-koda config                           # show all settings with source
-koda config get defaults.cmd          # print a single value
-koda config set defaults.cmd list     # write to config file
-koda config unset list.per_page       # remove key (reverts to built-in default)
-koda config reset                     # delete config file (prompts for confirmation)
-koda config reset -f                  # delete without prompt
-koda config edit                      # open config in $EDITOR
-koda config path                      # print config file path
+koda g                           # show all settings with source
+koda g get defaults.cmd          # print a single value
+koda g set defaults.cmd list     # write to config file
+koda g unset list.per_page       # remove key (reverts to built-in default)
+koda g reset -f                  # delete config file without prompt
+koda g edit                      # open config in $EDITOR
+koda g path                      # print config file path
+```
 
-# built-in alias
-koda g set defaults.cmd list
+Full form and aliases:
 
-# kd prefix
-kd g set defaults.cmd list
-
-# two-letter alias
-kg set defaults.cmd list
+```bash
+koda config set defaults.cmd list   # long form
+kd g set defaults.cmd list          # kd prefix
+kg set defaults.cmd list            # two-letter alias
 ```
 
 ---
@@ -499,16 +475,16 @@ Two patterns are available. Choose one based on how much you want to shorten you
 
 ---
 
-### kd prefix — minimal (`kd='koda'` only)
+### kd prefix — minimal (`alias kd='koda'` only)
 
-Register only `kd` as an alias for `koda`, then use koda's built-in single-letter aliases for subcommands. No risk of conflicting with other tools.
+Register only `kd` as an alias for `koda`, then use koda's built-in single-letter aliases for subcommands (`kd a`, `kd x`, `kd p -x`, etc.). No risk of conflicting with other tools.
 
 ```bash
 # Add to ~/.zshrc or ~/.bashrc
 alias kd='koda'
 ```
 
-Examples with kd prefix:
+Usage with kd prefix:
 
 ```bash
 kd a "memo" -t tag -s sc    # add
@@ -525,11 +501,11 @@ kd g set defaults.cmd list  # config set
 
 ---
 
-### two-letter alias — full two-letter aliases
+### Two-letter alias — full set
 
 Register a two-letter alias for every subcommand. Shorter to type, but check for conflicts before adding.
 
-> **Note**: two-letter alias assigns `kd` to `koda remove`. If you previously used `alias kd='koda'` (kd prefix), remove that line first.
+> **Note**: This pattern assigns `kd` to `koda remove`. If you already have `alias kd='koda'` (kd prefix), remove that line first.
 
 ```bash
 # Add to ~/.zshrc or ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A **terminal launcher and snippet store**. Save commands, config templates, and 
 - **Flexible input**: Arguments, heredocs, pipes, or `$EDITOR`.
 - **Shortcuts**: Assign a memorable string alias to any entry and use it in place of a numeric index.
 - **Variable substitution**: Expand `${KEY}` and `$1 $2 ...` placeholders at recall time with `-V`.
+- **Command substitution**: Embed stored values directly in any command — `ssh $(kr bastion)`, `tail -f $(kr log-path)`.
 - **Shell-friendly output**: `raw` prints body-only text for pipes, `eval`, and scripts.
 - **Tags**: Classify, filter, and batch-edit entries with multiple tags.
 - **Display index**: Stable `uid` (SHA1 short hash) plus user-controlled `idx`. Reorder with `move`/`swap`; close gaps with `compact`.
@@ -253,7 +254,6 @@ koda raw 5
 koda raw web-srv        # by shortcut
 koda raw                # latest entry
 echo 5 | koda raw       # ref from stdin
-$(koda raw 5)           # command substitution
 
 # built-in alias
 koda r web-srv
@@ -263,6 +263,34 @@ kd r web-srv
 
 # Pattern B
 kr web-srv
+```
+
+**Command substitution** — embed a stored value directly inside any command you type:
+
+```bash
+# Without koda — retype long strings inline every time
+ssh -i ~/.ssh/key.pem ec2-user@bastion.prod.example.com
+tail -f /var/log/nginx/access.log
+curl -H "Authorization: Bearer eyJhbGciOiJSUzI1Ni..." https://api.example.com/v1/status
+
+# Store once, reference by shortcut
+koda add "bastion.prod.example.com"       -t ssh    --shortcut bastion
+koda add "/var/log/nginx/access.log"      -t log    --shortcut nginx-log
+koda add "eyJhbGciOiJSUzI1Ni..."          -t secret --shortcut api-token
+
+# Embed in any command with $()
+ssh -i ~/.ssh/key.pem ec2-user@$(koda raw bastion)
+tail -f $(koda raw nginx-log)
+curl -H "Authorization: Bearer $(koda raw api-token)" https://api.example.com/v1/status
+
+# Pattern A
+ssh -i ~/.ssh/key.pem ec2-user@$(kd r bastion)
+tail -f $(kd r nginx-log)
+
+# Pattern B — shortest form
+ssh -i ~/.ssh/key.pem ec2-user@$(kr bastion)
+tail -f $(kr nginx-log)
+curl -H "Authorization: Bearer $(kr api-token)" https://api.example.com/v1/status
 ```
 
 `raw` strips shell-style inline comments (`#` at line start or after whitespace). Use `show` to see the original stored text.

--- a/README.md
+++ b/README.md
@@ -285,6 +285,22 @@ kd x web-srv -V localhost        # kd prefix
 kx web-srv -V localhost          # two-letter alias
 ```
 
+**Workflow example — query a local LLM with a one-liner:**
+
+```bash
+# Save once via heredoc
+koda a -t llm -s ask <<'EOF'
+curl -sS http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "$1"}], "stream": false}' \
+  | jq -r '.choices[0].message.content'
+EOF
+
+# Ask anything — no copy-paste, no editing
+koda x ask -V "How high is Mt. Fuji?"
+kx ask -V "Summarize the last git commit"   # two-letter alias
+```
+
 > **Security**: only store trusted commands. `exec` runs the body through the configured shell (`sh` by default).
 
 ---


### PR DESCRIPTION
## Summary

- Reframe koda as a **terminal launcher and snippet store** (not just a memo/snippet tool)
- Remove the verbose "Example use cases" section
- Rewrite all command examples with a consistent 4-way contrast: long form / built-in alias / Pattern A / Pattern B
- Add a dedicated `pick` section highlighting `kp -x` as the primary interactive launcher, plus compound patterns (`kx $(kp -p)`, `eval $(kp -p | xargs kr)`)
- Add **Recommended aliases** section with two separate copy-paste snippets:
  - **Pattern A** — `alias kd='koda'` only; uses koda's built-in single-letter aliases (`kd x`, `kd p -x`, etc.); no conflict risk
  - **Pattern B** — full two-letter aliases for every subcommand (`kx`, `kp`, `kl`, etc.); includes conflict warnings for `ks` and `kt`

## Test plan

- [ ] Read through each command section and verify all four forms are consistent
- [ ] Confirm Pattern A snippet works: `alias kd='koda'` then `kd x web-srv -V localhost`
- [ ] Confirm Pattern B snippet works: all aliases registered, `kx web-srv -V localhost` etc.
- [ ] Confirm conflict warnings for `ks` and `kt` are visible

https://claude.ai/code/session_01CmFYTnKCeavkGnk7d3ZZED