### PR TITLE
fix: change positional variable delimiter from spaces to CSV format (comma + quotes)

### DIFF
--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -4,6 +4,7 @@ import sqlite3
 import sys
 import hashlib
 import copy
+import csv
 from click.utils import make_str
 from typer.core import TyperGroup
 import os
@@ -408,23 +409,26 @@ def _validate_shortcut(shortcut: Optional[str]) -> Optional[str]:
     return shortcut
 
 
+def _parse_var_items(var_spec: str) -> List[str]:
+    """Parse a var spec into items using CSV rules: comma-delimited, "..." for quoting."""
+    reader = csv.reader([var_spec], quotechar='"', delimiter=',', skipinitialspace=True)
+    return list(reader)[0]
+
+
 def _apply_vars(content: str, vars: Optional[List[str]]) -> str:
     if not vars:
         return content
     pos_index = 1
     for var_spec in vars:
-        m = re.match(r'^(\w+)=(.*)', var_spec.strip(), re.DOTALL)
+        stripped = var_spec.strip()
+        m = re.match(r'^(\w+)=(.*)', stripped, re.DOTALL)
         if m:
             key, value = m.group(1), m.group(2)
             content = content.replace(f"${{{key}}}", value)
         else:
-            for item in var_spec.split():
-                if "=" in item:
-                    key, value = item.split("=", 1)
-                    content = content.replace(f"${{{key}}}", value)
-                else:
-                    content = re.sub(rf'\${pos_index}(?!\d)', item.replace('\\', '\\\\'), content)
-                    pos_index += 1
+            for item in _parse_var_items(stripped):
+                content = re.sub(rf'\${pos_index}(?!\d)', item.replace('\\', '\\\\'), content)
+                pos_index += 1
     return content
 
 
@@ -1206,8 +1210,8 @@ def raw(
         help=(
             "Variable substitution. Named: KEY=VALUE → replaces ${KEY}. "
             "Positional: VALUE → replaces $1,$2,... in order. "
-            "Space-separate multiple values in one flag or repeat -V. "
-            'Examples: -V "localhost 5432" -V name="new york"'
+            'Comma-separate multiple values; use "..." to include spaces or commas. '
+            'Examples: -V \'localhost,5432\' -V \'name=prod\' -V \'"hello world","foo,bar"\''
         ),
     ),
 ):
@@ -1239,8 +1243,8 @@ def exec_memo(
         help=(
             "Variable substitution. Named: KEY=VALUE → replaces ${KEY}. "
             "Positional: VALUE → replaces $1,$2,... in order. "
-            "Space-separate multiple values in one flag or repeat -V. "
-            'Examples: -V "localhost 5432" -V name="new york"'
+            'Comma-separate multiple values; use "..." to include spaces or commas. '
+            'Examples: -V \'localhost,5432\' -V \'name=prod\' -V \'"hello world","foo,bar"\''
         ),
     ),
 ):


### PR DESCRIPTION
## Problem

When passing a string with spaces as a positional variable (`$1`, `$2`, ...) via `-V`, the value was split on spaces and treated as separate variables.

```bash
# Old behavior (bug)
koda exec 5 -V "hello world"
# → $1=hello, $2=world  ← split into two variables
```

## Changes

The delimiter for positional variables has been changed from **spaces** to **comma-delimited with `"..."` quoting (CSV format)**.

### New syntax

| Use case | Example | Result |
|----------|---------|--------|
| Value with spaces (single variable) | `-V "hello world"` | `$1=hello world` |
| Multiple positional args | `-V 'localhost,5432'` | `$1=localhost`, `$2=5432` |
| Multiple values each containing spaces | `-V '"hello world","foo bar"'` | `$1=hello world`, `$2=foo bar` |
| Value with comma | `-V '"foo,bar"'` | `$1=foo,bar` |
| Named variable | `-V 'name=New York'` | `${name}=New York` (unchanged) |
| Named variable with comma | `-V 'list=a, b, c'` | `${list}=a, b, c` (unchanged) |

## ⚠️ Breaking Change

**The behavior of `-V "hello world"` has changed.**

| | Old behavior | New behavior |
|--|-------------|--------------|
| `-V "hello world"` | `$1=hello`, `$2=world` (2 variables) | `$1=hello world` (**1 variable**) |

To pass multiple positional variables, use **commas** instead of spaces.

```bash
# Old: space-delimited (removed)
koda exec 5 -V "localhost 5432"

# New: comma-delimited
koda exec 5 -V 'localhost,5432'

# New: value with spaces — this is the core fix
koda exec 5 -V "hello world"
# → $1=hello world

# New: multiple values each containing spaces
koda exec 5 -V '"hello world","foo bar"'
# → $1=hello world, $2=foo bar
```

## Implementation

- Added `_parse_var_items()` using Python's `csv` module for comma-delimited, quote-aware parsing
- Only positional variables use the new CSV format; named variables (`KEY=VALUE`) are still matched first at the top level, preserving support for values containing spaces or commas
- Updated help text for both `raw` and `exec` commands to reflect the new syntax

https://claude.ai/code/session_01JiJhkAiovg5qGKrKP1ZGq6