### PR TITLE
feat: add Turso remote database backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A **memo and snippet CLI** for the terminal. Store frequently used commands, con
 - **Display index**: Each entry has a stable `uid` (sha1 short hash) and a user-controlled `idx`. Reorder freely with `move`/`swap`, and close gaps with `compact`.
 - **XDG-friendly**: Default data under `~/.local/share/koda/`, config under `~/.config/koda/`.
 - **Configurable defaults**: Persist preferences like default command or list page size in `~/.config/koda/config.toml`.
+- **Turso support**: Switch from local SQLite to a [Turso](https://turso.tech) remote database to share entries across machines.
 
 ## Installation
 
@@ -427,6 +428,11 @@ desc = false      # sort direction
 
 [db]
 path = "~/.local/share/koda/koda.db"
+backend = "local"   # "local" or "turso"
+
+[turso]
+url = "libsql://your-db.turso.io"   # Turso database URL
+token = "your-auth-token"           # Auth token (prefer KODA_TURSO_TOKEN env var)
 
 [exec]
 shell = "sh"      # shell used by `exec`
@@ -454,7 +460,56 @@ Priority order: **CLI flags > environment variables > config file > built-in def
 | `KODA_DB_PATH`     | Override database file path |
 | `KODA_DEFAULT_CMD` | Override `defaults.cmd` for this session |
 | `KODA_CONFIG_PATH` | Override config file path |
+| `KODA_TURSO_URL`   | Turso database URL (overrides `turso.url` in config) |
+| `KODA_TURSO_TOKEN` | Turso auth token (overrides `turso.token` in config) |
 | `EDITOR`           | Editor for `add`, `edit`, and `config edit` (default: `vim`) |
+
+## Turso (remote database)
+
+Koda supports [Turso](https://turso.tech) as a remote backend, letting you share entries across machines.
+
+### Setup
+
+1. Install the optional dependency:
+
+```bash
+pip install libsql-experimental
+# or with uv:
+uv tool install "koda[turso]"
+```
+
+2. Create a Turso database and get your URL and token from the [Turso dashboard](https://app.turso.tech) or CLI:
+
+```bash
+turso db create koda
+turso db show koda --url
+turso db tokens create koda
+```
+
+3. Configure Koda (use env vars to keep the token out of the config file):
+
+```bash
+export KODA_TURSO_URL="libsql://your-db.turso.io"
+export KODA_TURSO_TOKEN="your-auth-token"
+koda config set db.backend turso
+```
+
+Or write both to the config file:
+
+```bash
+koda config set db.backend turso
+koda config set turso.url "libsql://your-db.turso.io"
+koda config set turso.token "your-auth-token"
+```
+
+### Switching between backends
+
+```bash
+koda config set db.backend turso   # use Turso
+koda config set db.backend local   # use local SQLite (default)
+```
+
+The local SQLite database (`db.path`) and the Turso database are independent — switching backends does not migrate data.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "koda"
-version = "1.0.2"
-description = "Koda: A fast CLI for memos and terminal snippets."
+version = "1.1.0"
+description = "A fast CLI memo store and command launcher backed by SQLite or Turso."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
@@ -23,6 +23,9 @@ dependencies = [
     "typer>=0.12.3",
     "rich>=13.7.1",
 ]
+
+[project.optional-dependencies]
+turso = ["libsql-experimental>=0.0.1"]
 
 [project.urls]
 Homepage = "https://github.com/ngt22/koda"

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -12,12 +12,25 @@ import tempfile
 import re
 import signal
 import shutil
+from contextlib import contextmanager
 from datetime import datetime
 from importlib.metadata import version
 from pathlib import Path
 from typing import Optional, List, Callable
 from rich.console import Console
 from rich.table import Table
+
+try:
+    import libsql_experimental as _libsql
+    _LIBSQL_AVAILABLE = True
+    try:
+        _IntegrityErrors = (sqlite3.IntegrityError, _libsql.IntegrityError)
+    except AttributeError:
+        _IntegrityErrors = (sqlite3.IntegrityError,)
+except ImportError:
+    _libsql = None
+    _LIBSQL_AVAILABLE = False
+    _IntegrityErrors = (sqlite3.IntegrityError,)
 
 __app_name__ = "koda"
 __version__ = version("koda")
@@ -90,7 +103,8 @@ VALID_SORT_COLUMNS = {"id", "idx", "uid", "tags", "content", "created_at", "modi
 CONFIG_DEFAULTS: dict = {
     "defaults": {"cmd": "raw"},
     "list":     {"per_page": 20, "rows": 1, "truncate": 80, "sort_by": "idx", "desc": False},
-    "db":       {"path": str(DEFAULT_DB_PATH)},
+    "db":       {"path": str(DEFAULT_DB_PATH), "backend": "local"},
+    "turso":    {"url": "", "token": ""},
     "exec":     {"shell": "sh"},
 }
 
@@ -106,6 +120,9 @@ _CONFIG_TYPES: dict[str, type] = {
     "list.sort_by":  str,
     "list.desc":     bool,
     "db.path":       str,
+    "db.backend":    str,
+    "turso.url":     str,
+    "turso.token":   str,
     "exec.shell":    str,
 }
 
@@ -118,6 +135,7 @@ _CONFIG_VALIDATORS: dict[str, tuple[Callable, str]] = {
         lambda v: v in VALID_SORT_COLUMNS,
         f"must be one of: {', '.join(sorted(VALID_SORT_COLUMNS))}",
     ),
+    "db.backend":    (lambda v: v in ("local", "turso"), "must be 'local' or 'turso'"),
 }
 
 
@@ -152,6 +170,16 @@ def load_config() -> tuple[dict, dict]:
     if env_db:
         config["db"]["path"] = env_db
         sources["db.path"] = "env"
+
+    env_turso_url = os.getenv("KODA_TURSO_URL")
+    if env_turso_url:
+        config["turso"]["url"] = env_turso_url
+        sources["turso.url"] = "env"
+
+    env_turso_token = os.getenv("KODA_TURSO_TOKEN")
+    if env_turso_token:
+        config["turso"]["token"] = env_turso_token
+        sources["turso.token"] = "env"
 
     return config, sources
 
@@ -207,6 +235,51 @@ _config, _config_sources = load_config()
 DB_PATH = Path(_config["db"]["path"])
 
 
+@contextmanager
+def _db_connection():
+    """Context manager that yields a DB connection for the configured backend."""
+    backend = _config["db"]["backend"]
+    if backend == "turso":
+        if not _LIBSQL_AVAILABLE:
+            console.print(
+                "[red]libsql-experimental is not installed. "
+                "Run: pip install libsql-experimental[/red]"
+            )
+            raise typer.Exit(code=1)
+        url = _config["turso"]["url"]
+        token = _config["turso"]["token"]
+        if not url:
+            console.print(
+                "[red]Turso URL is not configured. "
+                "Set turso.url in config or KODA_TURSO_URL env var.[/red]"
+            )
+            raise typer.Exit(code=1)
+        conn = _libsql.connect(url, auth_token=token or None)
+        try:
+            yield conn
+        except typer.Exit:
+            raise
+        except Exception:
+            raise
+        else:
+            conn.commit()
+        finally:
+            conn.close()
+    else:
+        conn = sqlite3.connect(DB_PATH)
+        try:
+            yield conn
+        except typer.Exit:
+            raise
+        except Exception:
+            conn.rollback()
+            raise
+        else:
+            conn.commit()
+        finally:
+            conn.close()
+
+
 def version_callback(value: bool):
     if value:
         console.print(f"{__app_name__} version: [bold cyan]{__version__}[/bold cyan]")
@@ -224,8 +297,9 @@ def _generate_uid(content: str, created_at: str) -> str:
 
 def init_db():
     try:
-        DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with sqlite3.connect(DB_PATH) as conn:
+        if _config["db"]["backend"] == "local":
+            DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with _db_connection() as conn:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS memos (
                     id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -246,6 +320,8 @@ def init_db():
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_memos_shortcut "
                 "ON memos(shortcut) WHERE shortcut IS NOT NULL"
             )
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f"[red]Database Error:[/red] {e}")
         raise typer.Exit(code=1)
@@ -293,14 +369,14 @@ def get_memos(
     )
     params.append(limit)
     params.append(offset)
-    with sqlite3.connect(DB_PATH) as conn:
+    with _db_connection() as conn:
         return conn.execute(sql, params).fetchall()
 
 
 def get_memo_stats(query=None, tag=None, exclude_tag=None, shortcuts_only=False):
     where_sql, params = _build_memo_filters(query, tag, exclude_tag, shortcuts_only)
     sql = f"SELECT COUNT(*), MAX(idx) FROM memos{where_sql}"
-    with sqlite3.connect(DB_PATH) as conn:
+    with _db_connection() as conn:
         total_count, max_idx = conn.execute(sql, params).fetchone()
     return total_count, max_idx
 
@@ -320,17 +396,17 @@ def get_memos_all(
         "SELECT id, uid, idx, content, tags, shortcut, created_at FROM memos"
         f"{where_sql} ORDER BY {order_column} {order_direction}, id ASC"
     )
-    with sqlite3.connect(DB_PATH) as conn:
+    with _db_connection() as conn:
         return conn.execute(sql, params).fetchall()
 
 
 def delete_memo(memo_id: int) -> None:
-    with sqlite3.connect(DB_PATH) as conn:
+    with _db_connection() as conn:
         conn.execute("DELETE FROM memos WHERE id = ?", (memo_id,))
 
 
 def get_latest_entry():
-    with sqlite3.connect(DB_PATH) as conn:
+    with _db_connection() as conn:
         return conn.execute(
             "SELECT id, uid, idx, content, tags, shortcut, created_at FROM memos ORDER BY created_at DESC, id DESC LIMIT 1"
         ).fetchone()
@@ -348,7 +424,7 @@ def resolve_ref(ref: Optional[str]):
             raise typer.Exit(code=1)
         return row
     if ref.isdigit():
-        with sqlite3.connect(DB_PATH) as conn:
+        with _db_connection() as conn:
             row = conn.execute(
                 "SELECT id, uid, idx, content, tags, shortcut, created_at FROM memos WHERE idx = ?",
                 (int(ref),)
@@ -357,7 +433,7 @@ def resolve_ref(ref: Optional[str]):
             console.print(f"[yellow]No entry at index {ref}.[/yellow]")
             raise typer.Exit(code=1)
         return row
-    with sqlite3.connect(DB_PATH) as conn:
+    with _db_connection() as conn:
         row = conn.execute(
             "SELECT id, uid, idx, content, tags, shortcut, created_at FROM memos WHERE shortcut = ?",
             (ref,)
@@ -494,7 +570,7 @@ def _read_stdin_refs() -> List[str]:
     if not data:
         return []
     return [part for part in data.split() if part]
-  
+
 def _pick_candidates(
     query: Optional[str],
     tag: Optional[str],
@@ -648,7 +724,7 @@ def main(
 
 def update_memo_full(memo_id: int, content: str, tags: str, shortcut: Optional[str], created_at: str):
     now = datetime.now().strftime(DATETIME_FMT)
-    with sqlite3.connect(DB_PATH) as conn:
+    with _db_connection() as conn:
         conn.execute(
             "UPDATE memos SET content = ?, tags = ?, shortcut = ?, created_at = ?, modified_at = ? WHERE id = ?",
             (content.strip(), tags, shortcut or None, created_at, now, memo_id)
@@ -729,13 +805,13 @@ def _add_impl(
     now = datetime.now().strftime(DATETIME_FMT)
     uid = _generate_uid(content, now)
     try:
-        with sqlite3.connect(DB_PATH) as conn:
+        with _db_connection() as conn:
             new_idx = _next_idx(conn)
             conn.execute(
                 "INSERT INTO memos (uid, idx, shortcut, content, tags, created_at, modified_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (uid, new_idx, shortcut or None, content, formatted_tags, now, now)
             )
-    except sqlite3.IntegrityError:
+    except _IntegrityErrors:
         console.print(f"[red]Shortcut {shortcut!r} is already in use.[/red]")
         raise typer.Exit(code=1)
 
@@ -788,7 +864,7 @@ def rm(
     if is_batch:
         if indices:
             idx_list = _parse_indices(indices)
-            with sqlite3.connect(DB_PATH) as conn:
+            with _db_connection() as conn:
                 target_rows = []
                 for idx in idx_list:
                     row = conn.execute(
@@ -800,7 +876,7 @@ def rm(
                         target_rows.append(row)
         else:
             where_sql, params = _build_memo_filters(query=query, tag=tag)
-            with sqlite3.connect(DB_PATH) as conn:
+            with _db_connection() as conn:
                 target_rows = conn.execute(
                     f"SELECT id, uid, idx, content, tags, shortcut, created_at FROM memos{where_sql} ORDER BY idx ASC",
                     params,
@@ -833,7 +909,7 @@ def rm(
                 raise typer.Exit(code=0)
 
         ids = [row[0] for row in target_rows]
-        with sqlite3.connect(DB_PATH) as conn:
+        with _db_connection() as conn:
             conn.executemany("DELETE FROM memos WHERE id = ?", [(id_,) for id_ in ids])
         console.print(f"[red]Deleted {n} entr{'y' if n == 1 else 'ies'}.[/red]")
 
@@ -876,7 +952,7 @@ def copy(
     memo_id, uid, idx, content, tags, shortcut, created_at = row
     now = datetime.now().strftime(DATETIME_FMT)
     new_uid = _generate_uid(content, now)
-    with sqlite3.connect(DB_PATH) as conn:
+    with _db_connection() as conn:
         new_idx = _next_idx(conn)
         conn.execute(
             "INSERT INTO memos (uid, idx, shortcut, content, tags, created_at, modified_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
@@ -932,7 +1008,7 @@ def edit(
 
             try:
                 update_memo_full(memo_id, new_content, new_tags, new_shortcut, new_created_at)
-            except sqlite3.IntegrityError:
+            except _IntegrityErrors:
                 console.print(f"[red]Shortcut {new_shortcut!r} is already in use.[/red]")
                 raise typer.Exit(code=1)
             console.print(f"[green]Entry [{idx}] updated.[/green]")
@@ -1178,7 +1254,7 @@ def show(
 ):
 
     """Print one entry with index, uid, tags, and timestamps (Rich formatted). Alias: `koda s`.
-    
+
     When no argument is given, this command also accepts one ref from stdin.
     """
     if ref is None:
@@ -1282,7 +1358,7 @@ def tag(
     remove_list = _parse_tag_args(untag)
 
     updated = 0
-    with sqlite3.connect(DB_PATH) as conn:
+    with _db_connection() as conn:
         for idx in idx_list:
             row = conn.execute("SELECT id, tags FROM memos WHERE idx = ?", (idx,)).fetchone()
             if row is None:
@@ -1313,7 +1389,7 @@ def move(
     init_db()
     if from_idx == to_idx:
         return
-    with sqlite3.connect(DB_PATH) as conn:
+    with _db_connection() as conn:
         if conn.execute("SELECT 1 FROM memos WHERE idx = ?", (from_idx,)).fetchone() is None:
             console.print(f"[red]No entry at index {from_idx}.[/red]")
             raise typer.Exit(code=1)
@@ -1337,7 +1413,7 @@ def shift_cmd(
     init_db()
     if count == 0:
         return
-    with sqlite3.connect(DB_PATH) as conn:
+    with _db_connection() as conn:
         if count < 0:
             if start + count < 0:
                 console.print(
@@ -1374,7 +1450,7 @@ def swap(
     init_db()
     if idx1 == idx2:
         return
-    with sqlite3.connect(DB_PATH) as conn:
+    with _db_connection() as conn:
         a = conn.execute("SELECT id FROM memos WHERE idx = ?", (idx1,)).fetchone()
         b = conn.execute("SELECT id FROM memos WHERE idx = ?", (idx2,)).fetchone()
         if a is None:
@@ -1394,7 +1470,7 @@ def swap(
 def compact_indices():
     """Fill index gaps by reassigning idx to contiguous values from 0. Alias: `koda k`."""
     init_db()
-    with sqlite3.connect(DB_PATH) as conn:
+    with _db_connection() as conn:
         rows = conn.execute("SELECT id, idx FROM memos ORDER BY idx ASC, id ASC").fetchall()
         if not rows:
             console.print("[yellow]No entries in database.[/yellow]")
@@ -1449,7 +1525,8 @@ def config_show(ctx: typer.Context) -> None:
             val = _config[sec][subkey]
             src = _config_sources.get(dotkey, "default")
             label = src_labels.get(src, "[dim]default[/dim]")
-            console.print(f"  {dotkey:<{key_width}} = {str(val):<24} {label}")
+            display_val = "****" if dotkey == "turso.token" and val else str(val)
+            console.print(f"  {dotkey:<{key_width}} = {display_val:<24} {label}")
 
 
 @config_app.command("get")
@@ -1557,7 +1634,11 @@ def config_edit_cmd() -> None:
             '# sort_by = "idx"\n'
             "# desc = false\n\n"
             "# [db]\n"
-            f'# path = "{DEFAULT_DB_PATH}"\n\n'
+            f'# path = "{DEFAULT_DB_PATH}"\n'
+            '# backend = "local"   # "local" or "turso"\n\n'
+            "# [turso]\n"
+            '# url = "libsql://your-db.turso.io"   # or set KODA_TURSO_URL\n'
+            '# token = "your-auth-token"            # or set KODA_TURSO_TOKEN\n\n'
             "# [exec]\n"
             '# shell = "sh"\n'
         )

--- a/uv.lock
+++ b/uv.lock
@@ -34,17 +34,46 @@ wheels = [
 
 [[package]]
 name = "koda"
-version = "1.0.1"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+turso = [
+    { name = "libsql-experimental" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "libsql-experimental", marker = "extra == 'turso'", specifier = ">=0.0.1" },
     { name = "rich", specifier = ">=13.7.1" },
     { name = "typer", specifier = ">=0.12.3" },
+]
+provides-extras = ["turso"]
+
+[[package]]
+name = "libsql-experimental"
+version = "0.0.55"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/14/d3eb81673e2096f38eb48f08e38b447f6f2fdc37a50bdb1810d4a225a7aa/libsql_experimental-0.0.55.tar.gz", hash = "sha256:34df13ad6da446e4ccede9b3803af40684da399c8f304848b54ea37e7111b249", size = 31954, upload-time = "2025-06-09T07:26:48.682Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/87/a7900e72d05fb26b76052fdee69b078b27c1438d4f0fc65dccbd43bd307b/libsql_experimental-0.0.55-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:5da3736d8fa4e26f6e90cd79d6ce9fd58af05411b60fd37a8563d207171f0320", size = 4874809, upload-time = "2025-06-09T07:26:20.957Z" },
+    { url = "https://files.pythonhosted.org/packages/60/46/70f5aad3008d89ce7a755844495de3c987fa1cabac059a97481734e32ca7/libsql_experimental-0.0.55-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1facaa5a9a3a955408990e86269d4cfad5d0432ddfb65b5cd68ba57af57b1eac", size = 4652922, upload-time = "2025-06-09T07:26:23.271Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e1/2d9c4ecbcc663c1e94f79b9de01e86c5a051c4b945fdc956b961b3437381/libsql_experimental-0.0.55-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d8f5282548ead7af8f419b788ac0b190840fa6ec7c622c8c5458aa5fc2f96aff", size = 5269829, upload-time = "2025-06-09T07:26:25.093Z" },
+    { url = "https://files.pythonhosted.org/packages/86/5d/27315a4287356d9d859e7702dda54146a560581f973f3efb6c65515ca7ad/libsql_experimental-0.0.55-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:213a0fb80117e5946f16cfc5e4d99fc961829bdb6ded3121ba94516a327d7b79", size = 4874679, upload-time = "2025-06-09T07:26:26.989Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ed/72132173b149933d539f00cd308d036d9de526db2dcb844912b9e7869101/libsql_experimental-0.0.55-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c858f49a3270127f4f9e7b5835dde3e89c5df8eed375c9f17afd13d9d5723ed5", size = 4653222, upload-time = "2025-06-09T07:26:29.34Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e6/186db46aedf96edab9392c9a72e4e5e965616620e9c82efe0832c5a081bd/libsql_experimental-0.0.55-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dacab03d6579c228e502833c30597af6a6d6b399d50debb482fc87e3b199e513", size = 5270078, upload-time = "2025-06-09T07:26:30.778Z" },
+    { url = "https://files.pythonhosted.org/packages/25/28/72e3bea3d9f28fbabcf11648d791f1f20fe42c288f58afdfbd978bd5500e/libsql_experimental-0.0.55-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:cffb9cd0c4bb39b37a5060ad492516c921ecbcc17ca7baa62c791d6753aa155b", size = 4881247, upload-time = "2025-06-09T07:26:32.335Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ed/479f0908ccfdf1ccace798aac65480cb9514737fb37757daae0036ae6c7d/libsql_experimental-0.0.55-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:50312e354e739676885a9ea4000365538f3cec914d6b508a2206c3d33bea93a3", size = 4656349, upload-time = "2025-06-09T07:26:34.217Z" },
+    { url = "https://files.pythonhosted.org/packages/69/32/d84a47c7ab5332247be52065aaa6b22e4baae969b33af8daa99fb1a317bf/libsql_experimental-0.0.55-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60d018dbad48f98ddee49d211618ab6309d4fa2a51beb8d9076de184d1cae9da", size = 5273739, upload-time = "2025-06-09T07:26:35.913Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9f/3589b9590ba948922bd200a02d754fa29e739da81a2953367e9283667a16/libsql_experimental-0.0.55-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f3bfd7af2ca9d1ff8f8c7f7fce5f1a650bfe53c23b45658253480fe287283bae", size = 4881245, upload-time = "2025-06-09T07:26:37.382Z" },
+    { url = "https://files.pythonhosted.org/packages/37/cf/4aead944cb90f82ab1b61edc78dbe893420e8c4ceee19e1fdae775b1273d/libsql_experimental-0.0.55-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b3476a78edb8f59aa6c571d6def1840fff8d263eb4bbc4b26b2afd7400cb9ba2", size = 4656348, upload-time = "2025-06-09T07:26:39.04Z" },
+    { url = "https://files.pythonhosted.org/packages/70/73/134dc2db0c3805f62953c85778bf93ac2f4a5ad81d49e592be990b012711/libsql_experimental-0.0.55-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5dd325f87425546e0a7f0d460d4b6e1852bc4d4194a7b5ad127614ef8b3b10", size = 5273740, upload-time = "2025-06-09T07:26:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/11/51616b7725e3954f49384831b38d87b002d1ac62ed31c386432062641349/libsql_experimental-0.0.55-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eb906b180b34e77c95f948ffeee84d3cf7376fb538e97819172022ee551f09b", size = 5268431, upload-time = "2025-06-09T07:26:45.56Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/72/d958df309c1cf3baa816eb323dd49dbb0cb91b1cf0e29beea13aa1ade637/libsql_experimental-0.0.55-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f12fdddea8987572e44eda7eef8f2ed7377c42ea43386bccaae43d001116bbc1", size = 5268646, upload-time = "2025-06-09T07:26:47.407Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `db.backend = "local" | "turso"` to switch between local SQLite and Turso
- Add `turso.url` / `turso.token` config keys and `KODA_TURSO_URL` / `KODA_TURSO_TOKEN` env vars
- Add `libsql-experimental` as an optional dependency (`koda[turso]`)
- Abstract all DB connections behind a `_db_connection()` context manager — local backend behavior is unchanged
- Mask token with `****` in `koda config` output

## Test plan

- [ ] Verify existing commands (`list`, `add`, `exec`, etc.) work correctly with the local backend
- [ ] Verify a helpful error is shown when switching to turso without `libsql-experimental` installed
- [ ] After `pip install libsql-experimental`, connect to a Turso DB and confirm `koda add` / `koda list` work
- [ ] Verify `KODA_TURSO_URL` / `KODA_TURSO_TOKEN` env vars override config file values
- [ ] Verify the token is displayed as `****` in `koda config` output

🤖 Generated with [Claude Code](https://claude.ai/claude-code)