### PR TITLE
fix: convert query params to tuple for Turso libsql compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koda"
-version = "1.1.0"
+version = "1.1.1"
 description = "A fast CLI memo store and command launcher backed by SQLite or Turso."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -347,7 +347,7 @@ def _build_memo_filters(query=None, tag=None, exclude_tag=None, shortcuts_only=F
         params.append(f"%{exclude_tag}%")
     if shortcuts_only:
         sql += " AND shortcut IS NOT NULL AND shortcut != ''"
-    return sql, params
+    return sql, tuple(params)
 
 
 def get_memos(


### PR DESCRIPTION
## Summary

- `_build_memo_filters()` returned a `list` for SQL query parameters
- The Turso libsql Python driver requires parameters to be a `tuple`; passing a `list` raises `TypeError: argument 'parameters': 'list' object cannot be converted to 'PyTuple'`
- Standard `sqlite3` accepts both, so the local SQLite backend was unaffected

## Fix

Changed the return value of `_build_memo_filters()` from `params` to `tuple(params)`. This is the single source for all filter parameters, so it fixes every affected call site (`get_memos`, `get_memo_stats`, `get_memos_all`, etc.) at once.

```python
# before
return sql, params

# after
return sql, tuple(params)
```

## Test plan

- [ ] `koda list` no longer crashes with Turso backend
- [ ] `koda list -t <tag>`, `koda list -q <query>` work correctly with Turso backend
- [ ] All existing local SQLite behaviour unchanged (sqlite3 accepts tuple just as well as list)

Closes #10

🤖 Generated with [Claude Code](https://claude.ai/claude-code)