### PR TITLE
fix: use tuple concatenation instead of append in get_memos

### DIFF
--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -368,8 +368,7 @@ def get_memos(
         "SELECT id, uid, idx, content, tags, shortcut, created_at FROM memos"
         f"{where_sql} ORDER BY {order_column} {order_direction}, id ASC LIMIT ? OFFSET ?"
     )
-    params.append(limit)
-    params.append(offset)
+    params = params + (limit, offset)
     with _db_connection() as conn:
         return conn.execute(sql, params).fetchall()
 


### PR DESCRIPTION
## Summary

- `_build_memo_filters` returns `tuple(params)` for Turso/libsql compatibility (introduced in #11)
- `get_memos` was calling `.append()` on that tuple, causing `AttributeError: 'tuple' object has no attribute 'append'` on every `list` invocation
- Fix: replace `params.append(limit)` / `params.append(offset)` with `params = params + (limit, offset)`

## Test plan

- [x] `uv run koda list` returns results without error
- [x] `kl` (installed via `uv tool install`) works correctly with Turso backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)