### PR TITLE
fix: validate configured list columns

### DIFF
--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -163,6 +163,13 @@ _CONFIG_VALIDATORS: dict[str, tuple[Callable, str]] = {
 }
 
 
+def _validate_list_columns(columns: List[str], source: str) -> None:
+    validator, msg = _CONFIG_VALIDATORS["list.columns"]
+    if not validator(columns):
+        console.print(f"[red]Invalid {source}: {msg}[/red]")
+        raise typer.Exit(code=1)
+
+
 def load_config() -> tuple[dict, dict]:
     """Return (merged_config, source_map). source_map[dotkey] = 'default'|'file'|'env'."""
     config = copy.deepcopy(CONFIG_DEFAULTS)
@@ -1074,6 +1081,7 @@ def _list_memos_impl(
     cfg = _config["list"]
     if columns is None:
         columns = cfg["columns"]
+        _validate_list_columns(columns, "list.columns")
     if per_page is None:
         per_page = cfg["per_page"]
     elif per_page < 1:
@@ -1227,10 +1235,7 @@ def list_memos(
     parsed_columns: Optional[List[str]] = None
     if columns is not None:
         parsed_columns = [c.strip() for c in columns.split(",") if c.strip()]
-        validator, msg = _CONFIG_VALIDATORS["list.columns"]
-        if not validator(parsed_columns):
-            console.print(f"[red]Invalid --columns: {msg}[/red]")
-            raise typer.Exit(code=1)
+        _validate_list_columns(parsed_columns, "--columns")
     _list_memos_impl(query, tag, exclude_tag, shortcuts_only, per_page, page, sort_by, desc, rows, truncate, parsed_columns)
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Validate `list.columns` from config before rendering the list table.
- Reuse the same validation path as `--columns` so invalid configured columns return a friendly error instead of a `KeyError` traceback.

## Test plan

- Pending post-push validation with isolated `KODA_DB_PATH` and `KODA_CONFIG_PATH`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3361dff8-941a-4d4d-8183-2b3ffbdf2c30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3361dff8-941a-4d4d-8183-2b3ffbdf2c30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

