### PR TITLE
security(exec,fs): exec.shell allowlist + 0600/0700 file perms (#43, #44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,10 +541,12 @@ payload_file = "koda-sync.jsonl"    # JSONL file inside sync_path
 sync_format = "jsonl"               # wire format (jsonl only)
 
 [exec]
-shell = "sh"      # shell used by exec
+shell = "sh"      # shell used by exec — restricted to: sh, bash, zsh, fish
 ```
 
 Priority order: **CLI flags > environment variables > config file > built-in defaults**
+
+> **Security**: `exec.shell` is restricted to an allowlist (`sh`, `bash`, `zsh`, `fish`) that must resolve to an installed executable. This prevents a tampered config from redirecting `koda x` to an arbitrary binary. The config file (`config.toml`) and database are created with `0600` permissions and their parent directories with `0700`, so a plaintext Turso token is not world-readable.
 
 ## Environment variables
 

--- a/src/koda/config.py
+++ b/src/koda/config.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 import tomllib
 from dataclasses import asdict, dataclass, field, fields, replace
 from enum import Enum
@@ -40,6 +41,20 @@ COLUMN_DEFS: dict = {
 
 
 GIT_SYNC_FORMAT_JSONL = "jsonl"
+
+EXEC_SHELL_ALLOWLIST = ("sh", "bash", "zsh", "fish")
+
+
+def valid_exec_shell(v: Any) -> bool:
+    """True if ``v`` names an allowlisted shell that resolves to an existing
+    absolute executable. Guards `koda x` against arbitrary-binary redirection
+    via a tampered config (e.g. exec.shell = '/tmp/evil')."""
+    if not isinstance(v, str) or not v.strip():
+        return False
+    if Path(v).name not in EXEC_SHELL_ALLOWLIST:
+        return False
+    resolved = shutil.which(v)
+    return bool(resolved) and Path(resolved).is_absolute()
 
 
 class DefaultCmd(str, Enum):
@@ -139,7 +154,12 @@ _FIELD_SPECS: Dict[str, FieldSpec] = {
         lambda v: str(v).strip().lower() == GIT_SYNC_FORMAT_JSONL,
         f"must be {GIT_SYNC_FORMAT_JSONL!r} (case-insensitive)",
     ),
-    "exec.shell":    FieldSpec(str),
+    "exec.shell":    FieldSpec(
+        str,
+        valid_exec_shell,
+        f"must be an installed shell ({', '.join(EXEC_SHELL_ALLOWLIST)}) "
+        "resolvable to an absolute path",
+    ),
 }
 
 ALL_KEYS: List[str] = list(_FIELD_SPECS.keys())
@@ -207,6 +227,7 @@ class ConfigManager:
     def write_raw(self, data: dict) -> None:
         """Serialize data to TOML and write to config_path."""
         self.config_path.parent.mkdir(parents=True, exist_ok=True)
+        os.chmod(self.config_path.parent, 0o700)
         lines: List[str] = []
         for section, values in data.items():
             lines.append(f"[{section}]")
@@ -222,6 +243,7 @@ class ConfigManager:
                     lines.append(f"{k} = {v}")
             lines.append("")
         self.config_path.write_text("\n".join(lines), encoding="utf-8")
+        os.chmod(self.config_path, 0o600)
 
     @staticmethod
     def coerce(key: str, raw: str) -> Any:

--- a/src/koda/db.py
+++ b/src/koda/db.py
@@ -1,5 +1,6 @@
 """Database layer for koda: connection, schema, CRUD over the memos table."""
 
+import os
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
@@ -86,6 +87,7 @@ class MemoDatabase:
         """Create the memos table and required indexes if missing."""
         if self.backend == "local" and self.path is not None:
             self.path.parent.mkdir(parents=True, exist_ok=True)
+            os.chmod(self.path.parent, 0o700)
         with self.connection() as conn:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS memos (
@@ -106,6 +108,8 @@ class MemoDatabase:
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_memos_shortcut "
                 "ON memos(shortcut) WHERE shortcut IS NOT NULL"
             )
+        if self.backend == "local" and self.path is not None:
+            os.chmod(self.path, 0o600)
 
     @staticmethod
     def next_idx(conn) -> int:

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -836,6 +836,13 @@ def exec_memo(
     row = resolve_ref(ref)
     content = _apply_vars(row.content.strip() if row.content else "", vars)
     shell = config.exec_shell
+    try:
+        ConfigManager.validate("exec.shell", shell)
+    except ValidationError:
+        exit_error(
+            f"Refusing to exec: exec.shell {shell!r} is not allowed "
+            f"({ConfigManager.error_message('exec.shell')})."
+        )
     os.execvp(shell, [shell, "-c", content])
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for ConfigManager.coerce and ConfigManager.validate."""
 
+import shutil
+
 import pytest
 
 from koda.config import ConfigManager, ValidationError
@@ -116,9 +118,40 @@ class TestValidate:
         with pytest.raises(ValidationError):
             ConfigManager.validate("git.sync_format", "yaml")
 
-    @pytest.mark.parametrize("key", ["db.path", "turso.url", "turso.token", "git.sync_path", "exec.shell"])
+    @pytest.mark.parametrize("key", ["db.path", "turso.url", "turso.token", "git.sync_path"])
     def test_no_validator_passthrough(self, key):
         assert ConfigManager.validate(key, "anything") == "anything"
 
     def test_unknown_key_passthrough(self):
         assert ConfigManager.validate("unknown.key", "x") == "x"
+
+
+class TestExecShell:
+    @pytest.mark.parametrize("shell", ["sh", "bash"])
+    def test_allowlisted_resolvable_shell_valid(self, shell):
+        if shutil.which(shell) is None:
+            pytest.skip(f"{shell} not installed")
+        assert ConfigManager.validate("exec.shell", shell) == shell
+
+    def test_absolute_path_to_allowlisted_shell_valid(self):
+        resolved = shutil.which("sh")
+        if resolved is None:
+            pytest.skip("sh not installed")
+        assert ConfigManager.validate("exec.shell", resolved) == resolved
+
+    def test_arbitrary_binary_rejected(self):
+        with pytest.raises(ValidationError):
+            ConfigManager.validate("exec.shell", "/tmp/evil")
+
+    def test_non_allowlisted_name_rejected(self):
+        with pytest.raises(ValidationError):
+            ConfigManager.validate("exec.shell", "python")
+
+    def test_nonexistent_allowlisted_shell_rejected(self, monkeypatch):
+        monkeypatch.setattr("koda.config.shutil.which", lambda _: None)
+        with pytest.raises(ValidationError):
+            ConfigManager.validate("exec.shell", "bash")
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValidationError):
+            ConfigManager.validate("exec.shell", "")

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,24 @@
+"""Tests that config and DB files/dirs are created with restrictive modes."""
+
+import stat
+
+from koda.config import ConfigManager
+from koda.db import MemoDatabase
+
+
+def _mode(path):
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def test_config_file_and_dir_modes(tmp_path):
+    cfg_path = tmp_path / "cfgdir" / "config.toml"
+    ConfigManager(config_path=cfg_path).write_raw({"exec": {"shell": "sh"}})
+    assert _mode(cfg_path) == 0o600
+    assert _mode(cfg_path.parent) == 0o700
+
+
+def test_db_file_and_dir_modes(tmp_path):
+    db_path = tmp_path / "dbdir" / "koda.db"
+    MemoDatabase(backend="local", path=db_path).init_db()
+    assert _mode(db_path) == 0o600
+    assert _mode(db_path.parent) == 0o700


### PR DESCRIPTION
> Recreated from #88 (original base branch was deleted when #87 merged). Rebased onto main.

## Summary
- **#43** — `exec.shell` is restricted to an allowlist (`sh`, `bash`, `zsh`, `fish`) that must resolve to an installed absolute executable.
- **#44** — `config.toml` and the SQLite DB are created `0600`, parent dirs `0700`.

## #43 — exec.shell allowlist
- New `valid_exec_shell` validator in `config.py`: basename must be allowlisted **and** `shutil.which()` must resolve it to an absolute path.
- Wired into the `exec.shell` `FieldSpec`, so `koda config set exec.shell /tmp/evil` is rejected.
- Re-validated at exec time in `main.py` before `os.execvp`, which closes the **config-file tampering** path.

## #44 — file permissions
- `ConfigManager.write_raw`: `chmod 0700` on the config dir, `0600` on `config.toml`.
- `MemoDatabase.init_db`: `chmod 0700` on the DB dir, `0600` on the DB file after creation.

## Tests
- `test_config.py::TestExecShell` and `test_permissions.py`; full suite 109 passed.

## Acceptance criteria
**#43**: validator (abs path + allowlist), shutil.which check, test, README. **#44**: chmod 0600 config/DB, 0700 dirs, stat test.

Closes #43
Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)