### PR TITLE
fix(add): prioritize text arguments over piped stdin (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ history | grep ffmpeg | tail -1 | koda a -t ffmpeg
 kubectl get pods -o wide    | koda a -t k8s
 ```
 
+Content source precedence: **text arguments > piped stdin > `$EDITOR`**. When
+arguments are given, piped stdin is ignored (with a warning on stderr). This
+keeps `koda a "text"` working in non-interactive shells (cron, IDE tasks,
+sandboxes) where stdin is not a TTY.
+
 ---
 
 ### Raw — body-only output

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -304,10 +304,15 @@ def _add_impl(
     init_db()
     content = ""
 
-    if not sys.stdin.isatty():
-        content = sys.stdin.read().strip()
-    elif text:
+    if text:
         content = " ".join(text)
+        if not sys.stdin.isatty() and sys.stdin.read().strip():
+            print(
+                "Warning: ignoring piped stdin because text arguments were given.",
+                file=sys.stderr,
+            )
+    elif not sys.stdin.isatty():
+        content = sys.stdin.read().strip()
     else:
         editor = os.environ.get('EDITOR', 'vim')
         with tempfile.NamedTemporaryFile(suffix=".tmp", mode='w+', delete=False) as tf:

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -1,0 +1,71 @@
+"""Tests for `add` content sourcing: argument vs piped stdin vs editor."""
+
+from pathlib import Path
+
+import pytest
+
+import koda.main as main
+
+
+class FakeStdin:
+    def __init__(self, data="", tty=True):
+        self._data = data
+        self._tty = tty
+
+    def isatty(self):
+        return self._tty
+
+    def read(self):
+        return self._data
+
+
+@pytest.fixture
+def wired_db(db, monkeypatch):
+    """Point koda.main's module-level db at a fresh temp database."""
+    monkeypatch.setattr(main, "db", db)
+    return db
+
+
+def _latest_content(db):
+    row = db.get_latest_entry()
+    return row.content if row else None
+
+
+def test_arg_only_uses_arg(wired_db, monkeypatch):
+    monkeypatch.setattr("sys.stdin", FakeStdin(tty=True))
+    main._add_impl(text=["hello", "world"])
+    assert _latest_content(wired_db) == "hello world"
+
+
+def test_stdin_only_uses_stdin(wired_db, monkeypatch):
+    monkeypatch.setattr("sys.stdin", FakeStdin(data="piped body\n", tty=False))
+    main._add_impl(text=None)
+    assert _latest_content(wired_db) == "piped body"
+
+
+def test_arg_wins_over_stdin_and_warns(wired_db, monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", FakeStdin(data="ignored stdin", tty=False))
+    main._add_impl(text=["arg body"])
+    assert _latest_content(wired_db) == "arg body"
+    assert "ignoring piped stdin" in capsys.readouterr().err
+
+
+def test_arg_with_empty_noninteractive_stdin_no_warning(wired_db, monkeypatch, capsys):
+    """The original bug: non-interactive shell with empty stdin (e.g. /dev/null)
+    must still save the argument and not abort or warn."""
+    monkeypatch.setattr("sys.stdin", FakeStdin(data="", tty=False))
+    main._add_impl(text=["hello"])
+    assert _latest_content(wired_db) == "hello"
+    assert "ignoring piped stdin" not in capsys.readouterr().err
+
+
+def test_no_arg_no_stdin_uses_editor(wired_db, monkeypatch):
+    monkeypatch.setattr("sys.stdin", FakeStdin(tty=True))
+
+    def fake_call(cmd):
+        Path(cmd[1]).write_text("from editor")
+        return 0
+
+    monkeypatch.setattr(main.subprocess, "call", fake_call)
+    main._add_impl(text=None)
+    assert _latest_content(wired_db) == "from editor"


### PR DESCRIPTION
## Summary
- `add` no longer lets non-TTY stdin silently override positional arguments.
- New content-source precedence: **text arguments > piped stdin > `$EDITOR`**.

## The bug
In a non-interactive shell (cron, IDE task, sandbox), `koda a "hello"` died with `Aborted: Empty content.` because the old logic read stdin whenever it was not a TTY — and an empty non-TTY stdin (e.g. `/dev/null`) produced empty content, discarding the argument.

## Fix (`src/koda/main.py` `_add_impl`)
- If text arguments are given → use them. If stdin is also piped **and non-empty**, print `Warning: ignoring piped stdin because text arguments were given.` to stderr.
- Else if stdin is piped → use stdin.
- Else → open `$EDITOR`.

## Tests (`tests/test_add.py`)
All four arg/stdin combinations plus the editor path, including the original-bug case (argument + empty non-TTY stdin must save the argument without warning or abort). Full suite: 114 passed.

## Manual verification
- `koda a "hello from arg"` (no pipe) → saved (previously aborted).
- `echo piped | koda a "arg wins"` → saves `arg wins`, warns on stderr.
- `echo only piped | koda a` → saves `only piped`.

## Acceptance criteria
- [x] arguments take precedence; no args + stdin → stdin
- [x] both present → arguments win + stderr warning
- [x] pytest covers all 4 arg/stdin combinations
- [x] documented (README Add section; repo has no CHANGELOG file)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)