### PR TITLE
fix(add): prioritize argument over stdin to avoid empty-content abort (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- `add`: a positional text argument now takes priority over piped stdin.
+  Previously, on non-interactive shells (sandboxes, cron, IDE tasks) an empty
+  stdin silently overrode the argument and `koda a "hello"` aborted with
+  "Empty content." When both an argument and stdin are supplied, the argument
+  is used and a warning is printed to stderr. (#49)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ history | grep ffmpeg | tail -1 | koda a -t ffmpeg
 kubectl get pods -o wide    | koda a -t k8s
 ```
 
+Input priority is **argument > stdin > `$EDITOR`**. If you pass a text
+argument it always wins; piped stdin is only used when no argument is given.
+When both are supplied the argument is used and a warning is printed to stderr.
+
 ---
 
 ### Raw — body-only output

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -92,6 +92,7 @@ app = typer.Typer(
     no_args_is_help=False,
 )
 console = Console()
+err_console = Console(stderr=True)
 
 _config_manager = ConfigManager()
 config, _config_sources = _config_manager.load()
@@ -295,6 +296,40 @@ def update_memo_full(memo_id: int, content: str, tags: str, shortcut: Optional[s
     db.update_memo(memo_id, content, tags, shortcut, created_at, now)
 
 
+def _resolve_add_content(text: Optional[List[str]]) -> str:
+    """Resolve entry content with priority: argument > stdin > $EDITOR.
+
+    An argument always wins; piped stdin is only used when no argument is
+    given. When both are present the stdin data is ignored with a warning
+    on stderr (#49). $EDITOR only opens on an interactive stdin.
+    """
+    stdin_content = "" if sys.stdin.isatty() else sys.stdin.read().strip()
+
+    if text:
+        if stdin_content:
+            err_console.print(
+                "[yellow]Warning: both argument and stdin provided; using argument.[/yellow]"
+            )
+        return " ".join(text)
+
+    if stdin_content:
+        return stdin_content
+
+    if not sys.stdin.isatty():
+        # Non-interactive with empty stdin: cannot open $EDITOR.
+        return ""
+
+    editor = os.environ.get('EDITOR', 'vim')
+    with tempfile.NamedTemporaryFile(suffix=".tmp", mode='w+', delete=False) as tf:
+        temp_path = tf.name
+    try:
+        subprocess.call([editor, temp_path])
+        with open(temp_path, 'r') as f:
+            return f.read().strip()
+    finally:
+        Path(temp_path).unlink(missing_ok=True)
+
+
 def _add_impl(
     text: Optional[List[str]] = None,
     tag: Optional[List[str]] = None,
@@ -302,22 +337,7 @@ def _add_impl(
 ) -> None:
     shortcut = _validate_shortcut(shortcut)
     init_db()
-    content = ""
-
-    if not sys.stdin.isatty():
-        content = sys.stdin.read().strip()
-    elif text:
-        content = " ".join(text)
-    else:
-        editor = os.environ.get('EDITOR', 'vim')
-        with tempfile.NamedTemporaryFile(suffix=".tmp", mode='w+', delete=False) as tf:
-            temp_path = tf.name
-        try:
-            subprocess.call([editor, temp_path])
-            with open(temp_path, 'r') as f:
-                content = f.read().strip()
-        finally:
-            Path(temp_path).unlink(missing_ok=True)
+    content = _resolve_add_content(text)
 
     if not content:
         console.print("[yellow]Aborted: Empty content.[/yellow]")

--- a/tests/test_add_input.py
+++ b/tests/test_add_input.py
@@ -1,0 +1,66 @@
+"""Tests for `koda add` input resolution: argument vs stdin priority (#49).
+
+Covers all four combinations of (argument present?, stdin piped?):
+- arg + no stdin   → argument
+- no arg + stdin   → stdin
+- arg + stdin      → argument, with a warning on stderr
+- no arg + no stdin (non-interactive) → empty, aborts cleanly
+"""
+
+import pytest
+from typer.testing import CliRunner
+
+from koda import main as koda_main
+
+
+@pytest.fixture
+def runner(tmp_path, monkeypatch):
+    """A CliRunner whose koda app writes to a fresh temp DB."""
+    from koda.db import MemoDatabase
+
+    database = MemoDatabase(backend="local", path=tmp_path / "test.db")
+    database.init_db()
+    monkeypatch.setattr(koda_main, "db", database)
+    return CliRunner()
+
+
+def _latest_content(monkeypatched_db):
+    row = monkeypatched_db.get_latest_entry()
+    return row.content if row else None
+
+
+def test_arg_only(runner):
+    result = runner.invoke(koda_main.app, ["add", "hello from arg"])
+    assert result.exit_code == 0
+    assert _latest_content(koda_main.db) == "hello from arg"
+
+
+def test_stdin_only(runner):
+    result = runner.invoke(koda_main.app, ["add"], input="hello from stdin\n")
+    assert result.exit_code == 0
+    assert _latest_content(koda_main.db) == "hello from stdin"
+
+
+def test_arg_wins_over_stdin(runner):
+    result = runner.invoke(
+        koda_main.app, ["add", "hello from arg"], input="hello from stdin\n"
+    )
+    assert result.exit_code == 0
+    assert _latest_content(koda_main.db) == "hello from arg"
+    assert "Warning" in result.stderr
+    assert "argument" in result.stderr
+
+
+def test_no_arg_no_stdin_aborts(runner):
+    # Non-interactive stdin that is empty: must not hang on $EDITOR and must
+    # abort with empty content instead of dying obscurely.
+    result = runner.invoke(koda_main.app, ["add"], input="")
+    assert result.exit_code == 0
+    assert _latest_content(koda_main.db) is None
+    assert "Empty content" in result.stdout
+
+
+def test_multiword_arg_joined(runner):
+    result = runner.invoke(koda_main.app, ["add", "one", "two", "three"])
+    assert result.exit_code == 0
+    assert _latest_content(koda_main.db) == "one two three"


### PR DESCRIPTION
## Summary

Fixes #49. On non-interactive shells (sandboxes, cron, IDE tasks), an empty piped stdin silently overrode a positional text argument, so `koda a "hello"` aborted with `Aborted: Empty content.`

Input is now resolved with the priority **argument > stdin > `$EDITOR`**:
- An argument always wins.
- stdin is only read when no argument is given.
- When **both** are present, the argument is used and a warning is printed to **stderr**.
- `$EDITOR` only opens on an interactive stdin (never blocks in non-interactive contexts).

## Changes
- `src/koda/main.py`: extract `_resolve_add_content()` with the new priority logic; add a stderr `Console`.
- `tests/test_add_input.py`: pytest coverage for all four (argument, stdin) combinations + multi-word arg join.
- `README.md`: document input priority.
- `CHANGELOG.md`: add changelog (new file).

## Acceptance criteria
- [x] Argument present → argument wins (stdin skipped)
- [x] No argument & stdin present → stdin
- [x] Both present → argument + stderr warning
- [x] Tests: all four stdin/arg combinations
- [x] CHANGELOG entry

## Verification
```
$ koda a "hello" < /dev/null     # was: Aborted: Empty content.
Saved [0] ...
$ echo "from pipe" | koda a
Saved [1] ...
$ echo "ignored" | koda a "wins"
Saved [2] ...  (stderr) Warning: both argument and stdin provided; using argument.
```
`uv run pytest` → 114 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)