### PR TITLE
fix: redirect exit_error output to stderr

### DIFF
--- a/src/koda/cli_utils.py
+++ b/src/koda/cli_utils.py
@@ -9,6 +9,7 @@ from rich.console import Console
 
 
 console = Console()
+stderr_console = Console(stderr=True)
 
 
 class ExitCode(IntEnum):
@@ -30,7 +31,7 @@ def exit_error(
     can preserve informational ("not found") wording while still exiting with
     a non-zero status.
     """
-    console.print(f"[{style}]{message}[/{style}]")
+    stderr_console.print(f"[{style}]{message}[/{style}]")
     raise typer.Exit(code=int(code))
 
 


### PR DESCRIPTION
## Summary

`exit_error` uses a Rich `Console` that defaults to `stdout`, so error messages bleed into normal output when piping (`2>/dev/null`) or redirecting (`> file.txt`).

## Fix

Create a dedicated `stderr_console = Console(stderr=True)` and use it in `exit_error` so that error output goes to `stderr` as expected.

## Before
```bash
koda raw 999 2>/dev/null    # error still visible (goes to stdout)
koda raw 999 > out.txt       # error mixed into output file
```

## After
```bash
koda raw 999 2>/dev/null    # error suppressed
koda raw 999 > out.txt       # only real output in file
```

## Changes
- `src/koda/cli_utils.py`: Add `stderr_console = Console(stderr=True)` and use it in `exit_error`

Fixes #50