### PR TITLE
fix(add): exit non-zero on empty-content abort (#53)

### DIFF
--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -325,8 +325,7 @@ def _add_impl(
             Path(temp_path).unlink(missing_ok=True)
 
     if not content:
-        console.print("[yellow]Aborted: Empty content.[/yellow]")
-        return
+        exit_error("Aborted: Empty content.", style="yellow")
 
     content = content.encode('utf-8', 'surrogateescape').decode('utf-8', 'ignore')
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+import typer
 
 import koda.main as main
 
@@ -48,6 +49,16 @@ def test_arg_wins_over_stdin_and_warns(wired_db, monkeypatch, capsys):
     main._add_impl(text=["arg body"])
     assert _latest_content(wired_db) == "arg body"
     assert "ignoring piped stdin" in capsys.readouterr().err
+
+
+def test_empty_content_aborts_nonzero(wired_db, monkeypatch, capsys):
+    """#53: empty content must abort with a non-zero exit, not save and exit 0."""
+    monkeypatch.setattr("sys.stdin", FakeStdin(data="", tty=False))
+    with pytest.raises(typer.Exit) as exc_info:
+        main._add_impl(text=None)
+    assert exc_info.value.exit_code == 1
+    assert _latest_content(wired_db) is None
+    assert "Empty content" in capsys.readouterr().err
 
 
 def test_arg_with_empty_noninteractive_stdin_no_warning(wired_db, monkeypatch, capsys):

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1,0 +1,22 @@
+"""`exit_error` must write to stderr, not stdout (issue #50)."""
+
+import pytest
+import typer
+
+from koda.cli_utils import ExitCode, exit_error
+
+
+def test_exit_error_writes_to_stderr_not_stdout(capsys):
+    with pytest.raises(typer.Exit) as exc_info:
+        exit_error("boom")
+    assert exc_info.value.exit_code == ExitCode.INVALID_ARG
+    captured = capsys.readouterr()
+    assert "boom" not in captured.out
+    assert "boom" in captured.err
+
+
+def test_exit_error_honors_custom_code(capsys):
+    with pytest.raises(typer.Exit) as exc_info:
+        exit_error("nope", code=ExitCode.NOT_FOUND)
+    assert exc_info.value.exit_code == ExitCode.NOT_FOUND
+    assert "nope" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
The empty-content abort in `add` printed a notice and `return`ed, so the process exited `0` — scripts misread the abort as a successful save.

## Fix
Route the abort through `exit_error` so it exits with `ExitCode.INVALID_ARG` (1) and, via #50, writes to stderr. The `[yellow]` informational tone is preserved.

## Before / After
```bash
echo -n "" | koda add; echo $?   # before: 0   after: 1
echo -n "" | koda add 2>/dev/null # message now suppressed (stderr), stdout stays empty
```

## Changes
- `src/koda/main.py`: empty content → `exit_error("Aborted: Empty content.", style="yellow")` instead of `console.print(...) + return`
- `tests/test_add.py`: assert non-zero exit, nothing saved, message on stderr
- `tests/test_cli_utils.py`: capsys test for `exit_error`'s stdout/stderr split — the remaining acceptance-criterion test from #50

`uv run pytest` → 117 passed.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)