### PR TITLE
fix(raw): terminate output with a trailing newline (#51)

### DIFF
--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -233,6 +233,10 @@ def emit_raw(ref: Optional[str], vars: Optional[List[str]] = None) -> None:
     row = resolve_ref(ref)
     content = _apply_vars(row.content if row.content is not None else "", vars)
     content = _strip_raw_inline_comments(content)
+    # POSIX text files end in a newline; append one when the body is non-empty
+    # and not already newline-terminated so `koda raw | wc -l` and friends work.
+    if content and not content.endswith("\n"):
+        content += "\n"
     sys.stdout.write(content)
 
 

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -1,0 +1,69 @@
+"""`raw` output must be newline-terminated for POSIX tool interop (issue #51)."""
+
+import subprocess
+import sys
+
+import pytest
+
+import koda.main as main
+from koda.db import MemoDatabase
+
+
+@pytest.fixture
+def wired_db(db, monkeypatch):
+    """Point koda.main's module-level db at a fresh temp database."""
+    monkeypatch.setattr(main, "db", db)
+    return db
+
+
+def _seed(db, content):
+    db.add_memo(
+        uid="seed001",
+        idx=1,
+        shortcut=None,
+        content=content,
+        tags="",
+        created_at="2026-01-01 00:00:00",
+        modified_at="2026-01-01 00:00:00",
+    )
+
+
+def test_appends_newline_when_missing(wired_db, capsys):
+    _seed(wired_db, "no trailing newline")
+    main.emit_raw(None)
+    assert capsys.readouterr().out == "no trailing newline\n"
+
+
+def test_does_not_double_newline(wired_db, capsys):
+    _seed(wired_db, "already terminated\n")
+    main.emit_raw(None)
+    assert capsys.readouterr().out == "already terminated\n"
+
+
+def test_empty_content_stays_empty(wired_db, capsys):
+    _seed(wired_db, "")
+    main.emit_raw(None)
+    assert capsys.readouterr().out == ""
+
+
+def test_raw_subprocess_is_newline_terminated(tmp_path, monkeypatch):
+    """Acceptance criterion: run `raw` as a real process and inspect the tail."""
+    db_path = tmp_path / "raw.db"
+    seed = MemoDatabase(backend="local", path=db_path)
+    seed.init_db()
+    _seed(seed, "subprocess body")
+
+    env = {
+        "KODA_DB_PATH": str(db_path),
+        "KODA_CONFIG_PATH": str(tmp_path / "nonexistent.toml"),
+        "PATH": __import__("os").environ.get("PATH", ""),
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", "from koda.main import app; app()", "raw"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.endswith("\n")
+    assert result.stdout.count("\n") == 1  # `koda raw | wc -l` == 1


### PR DESCRIPTION
## Summary
`koda raw` emitted the entry body verbatim, so `koda raw | wc -l` reported `0` and chaining into `cat`/`echo` and other Unix text tools felt off — it violated the POSIX definition of a text file (every line, including the last, ends in a newline).

`emit_raw` now appends a single newline when the body is **non-empty and not already newline-terminated**. Already-terminated bodies are left as-is (no double newline) and empty bodies stay empty.

## Acceptance criteria (#51)
- [x] Append one trailing newline to raw output only when the content does not already end with one
- [x] Test: run `raw` via subprocess and verify the tail

## Tests
New `tests/test_raw.py`:
- `emit_raw` appends a newline when missing
- does not double up an existing trailing newline
- leaves empty content empty
- subprocess end-to-end: `koda raw` output is newline-terminated (`wc -l` == 1)

Full suite: 121 passed.

Closes #51. Part of #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)