### PR TITLE
chore(lint): add ruff config and apply lint/format (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,6 +1037,20 @@ koda x llm -V "Summarize the last git commit"
 
 ---
 
+## Development
+
+```bash
+uv sync                       # editable install of the project + dev tools
+uv run pytest                 # run the test suite
+uv run ruff check src tests   # lint
+uv run ruff format src tests  # auto-format
+```
+
+Lint and format are configured under `[tool.ruff]` in `pyproject.toml`
+(line length 100; rule sets `E`, `F`, `I`, `UP`).
+
+---
+
 ## License
 
 MIT (c) 2026 ngt22

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 turso = ["libsql-experimental>=0.0.1"]
 
 [dependency-groups]
-dev = ["pytest", "pytest-cov"]
+dev = ["pytest", "pytest-cov", "ruff"]
 
 [project.urls]
 Homepage = "https://github.com/ngt22/koda-cli"
@@ -51,3 +51,13 @@ build-backend = "hatchling.build"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--cov=koda --cov-report=term-missing"
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/src/koda/cli_utils.py
+++ b/src/koda/cli_utils.py
@@ -7,7 +7,6 @@ from typing import NoReturn
 import typer
 from rich.console import Console
 
-
 console = Console()
 stderr_console = Console(stderr=True)
 

--- a/src/koda/cmd_helpers/display.py
+++ b/src/koda/cmd_helpers/display.py
@@ -1,9 +1,6 @@
 """Rich-formatted memo display."""
 
-from typing import Optional
-
 from rich.console import Console
-
 
 console = Console()
 
@@ -11,15 +8,13 @@ console = Console()
 def print_memo(
     uid: str,
     idx: int,
-    shortcut: Optional[str],
-    content: Optional[str],
-    tags: Optional[str],
-    created_at: Optional[str],
+    shortcut: str | None,
+    content: str | None,
+    tags: str | None,
+    created_at: str | None,
 ) -> None:
     sc_str = f" | SC: [bold green]{shortcut}[/bold green]" if shortcut else ""
     console.print(
         f"\n[bold cyan]IDX: {idx}[/bold cyan] ({uid}){sc_str} | {created_at}\n"
-        f"Tags: [magenta]{tags}[/magenta]\n"
-        + "-" * 20
-        + f"\n{content}"
+        f"Tags: [magenta]{tags}[/magenta]\n" + "-" * 20 + f"\n{content}"
     )

--- a/src/koda/cmd_helpers/interactive.py
+++ b/src/koda/cmd_helpers/interactive.py
@@ -3,15 +3,13 @@
 import shutil
 import subprocess
 import sys
-from typing import List, Optional
 
 from rich.console import Console
 
 from ..cli_utils import exit_error
-from ..config import Config, VALID_SORT_COLUMNS
+from ..config import VALID_SORT_COLUMNS, Config
 from ..db import MemoDatabase
 from ..models import MemoRow
-
 
 console = Console()
 
@@ -19,13 +17,13 @@ console = Console()
 def pick_candidates(
     db: MemoDatabase,
     config: Config,
-    query: Optional[str],
-    tag: Optional[str],
-    exclude_tag: Optional[str],
+    query: str | None,
+    tag: str | None,
+    exclude_tag: str | None,
     shortcuts_only: bool,
-    sort_by: Optional[str],
-    desc: Optional[bool],
-) -> List[MemoRow]:
+    sort_by: str | None,
+    desc: bool | None,
+) -> list[MemoRow]:
     effective_sort = (sort_by or config.list_sort_by).lower()
     if effective_sort not in VALID_SORT_COLUMNS:
         valid = ", ".join(sorted(VALID_SORT_COLUMNS))
@@ -41,18 +39,19 @@ def pick_candidates(
     )
 
 
-def pick_with_fzf(candidates: List[MemoRow]) -> Optional[str]:
+def pick_with_fzf(candidates: list[MemoRow]) -> str | None:
     if shutil.which("fzf") is None:
         exit_error("fzf is not installed. Install fzf to use `koda pick`.")
 
     if not sys.stdin.isatty():
         exit_error("`koda pick` requires an interactive TTY.")
 
-    lines: List[str] = []
+    lines: list[str] = []
     for row in candidates:
         first_line = (row.content or "").splitlines()[0] if row.content else ""
         display = (
-            f"{row.idx}\t{row.uid}\t{row.shortcut or '-'}\t{row.tags or '-'}\t{row.created_at}\t{first_line}"
+            f"{row.idx}\t{row.uid}\t{row.shortcut or '-'}\t"
+            f"{row.tags or '-'}\t{row.created_at}\t{first_line}"
         )
         lines.append(display)
 
@@ -63,12 +62,19 @@ def pick_with_fzf(candidates: List[MemoRow]) -> Optional[str]:
     proc = subprocess.run(
         [
             "fzf",
-            "--delimiter", "\t",
-            "--with-nth", "1,3,4,6",
-            "--prompt", "koda> ",
+            "--delimiter",
+            "\t",
+            "--with-nth",
+            "1,3,4,6",
+            "--prompt",
+            "koda> ",
             "--preview",
-            "printf 'IDX: %s\\nUID: %s\\nSC: %s\\nTags: %s\\nCreated: %s\\n\\n%s\\n' {1} {2} {3} {4} {5} {6}",
-            "--preview-window", preview_window,
+            (
+                "printf 'IDX: %s\\nUID: %s\\nSC: %s\\nTags: %s\\nCreated: %s\\n\\n%s\\n' "
+                "{1} {2} {3} {4} {5} {6}"
+            ),
+            "--preview-window",
+            preview_window,
         ],
         input="\n".join(lines),
         text=True,

--- a/src/koda/cmd_helpers/metadata.py
+++ b/src/koda/cmd_helpers/metadata.py
@@ -1,7 +1,6 @@
 """Editor metadata footer parsing (used by `koda edit`)."""
 
 import re
-from typing import List, Optional
 
 
 def normalize_footer_segment(segment: str) -> str:
@@ -29,14 +28,14 @@ def looks_like_koda_footer(segment: str) -> bool:
     return bool(lines and lines[0].strip().startswith("tags:"))
 
 
-def first_footer_index(parts: List[str]) -> Optional[int]:
+def first_footer_index(parts: list[str]) -> int | None:
     for i in range(1, len(parts)):
         if looks_like_koda_footer(parts[i]):
             return i
     return None
 
 
-def last_footer_segment(parts: List[str]) -> Optional[str]:
+def last_footer_segment(parts: list[str]) -> str | None:
     for seg in reversed(parts):
         if looks_like_koda_footer(seg):
             return normalize_footer_segment(seg)

--- a/src/koda/cmd_helpers/parsing.py
+++ b/src/koda/cmd_helpers/parsing.py
@@ -2,16 +2,15 @@
 
 import csv
 import re
-from typing import List, Optional
 
 from ..cli_utils import exit_error
 from ..constants import TAG_SEPARATOR
 
 
-def parse_indices(specs: List[str]) -> List[int]:
-    result: List[int] = []
+def parse_indices(specs: list[str]) -> list[int]:
+    result: list[int] = []
     for spec in specs:
-        m = re.fullmatch(r'(\d+)-(\d+)', spec)
+        m = re.fullmatch(r"(\d+)-(\d+)", spec)
         if m:
             result.extend(range(int(m.group(1)), int(m.group(2)) + 1))
         elif spec.isdigit():
@@ -21,14 +20,14 @@ def parse_indices(specs: List[str]) -> List[int]:
     return result
 
 
-def parse_tag_args(tag_args: Optional[List[str]]) -> List[str]:
-    result: List[str] = []
-    for t in (tag_args or []):
+def parse_tag_args(tag_args: list[str] | None) -> list[str]:
+    result: list[str] = []
+    for t in tag_args or []:
         result.extend(item.strip() for item in t.split(TAG_SEPARATOR) if item.strip())
     return result
 
 
-def parse_var_items(var_spec: str) -> List[str]:
+def parse_var_items(var_spec: str) -> list[str]:
     """Parse a var spec into items using CSV rules: comma-delimited, "..." for quoting."""
-    reader = csv.reader([var_spec], quotechar='"', delimiter=',', skipinitialspace=True)
+    reader = csv.reader([var_spec], quotechar='"', delimiter=",", skipinitialspace=True)
     return list(reader)[0]

--- a/src/koda/config.py
+++ b/src/koda/config.py
@@ -3,14 +3,14 @@
 import json
 import os
 import shutil
-import tomllib
-from dataclasses import asdict, dataclass, field, fields, replace
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any
 
+import tomllib
 from rich.console import Console
-
 
 console = Console()
 
@@ -24,18 +24,24 @@ CONFIG_PATH = Path(os.getenv("KODA_CONFIG_PATH", DEFAULT_CONFIG_PATH))
 
 
 VALID_SORT_COLUMNS = {
-    "id", "idx", "uid", "tags", "content",
-    "created_at", "modified_at", "shortcut",
+    "id",
+    "idx",
+    "uid",
+    "tags",
+    "content",
+    "created_at",
+    "modified_at",
+    "shortcut",
 }
 VALID_LIST_COLUMNS = ["idx", "uid", "sc", "tags", "content", "created_at"]
 REQUIRED_LIST_COLUMNS = {"idx"}
 
 COLUMN_DEFS: dict = {
-    "idx":        ("IDX",        {"justify": "right", "width": 4}),
-    "uid":        ("UID",        {"width": 7, "style": "dim"}),
-    "sc":         ("SC",         {"width": 10, "style": "bold green"}),
-    "tags":       ("Tags",       {"style": "magenta", "width": 15}),
-    "content":    ("Content",    {"ratio": 1}),
+    "idx": ("IDX", {"justify": "right", "width": 4}),
+    "uid": ("UID", {"width": 7, "style": "dim"}),
+    "sc": ("SC", {"width": 10, "style": "bold green"}),
+    "tags": ("Tags", {"style": "magenta", "width": 15}),
+    "content": ("Content", {"ratio": 1}),
     "created_at": ("Created At", {"width": 19}),
 }
 
@@ -72,13 +78,14 @@ class DbBackend(str, Enum):
 @dataclass
 class Config:
     """Typed snapshot of resolved configuration (defaults < file < env)."""
+
     defaults_cmd: str = "raw"
     list_per_page: int = 20
     list_rows: int = 1
     list_truncate: int = 80
     list_sort_by: str = "idx"
     list_desc: bool = False
-    list_columns: List[str] = field(default_factory=lambda: ["idx", "sc", "tags", "content"])
+    list_columns: list[str] = field(default_factory=lambda: ["idx", "sc", "tags", "content"])
     db_path: str = str(DEFAULT_DB_PATH)
     db_backend: str = "local"
     turso_url: str = ""
@@ -101,26 +108,26 @@ def _attr(dotkey: str) -> str:
 @dataclass(frozen=True)
 class FieldSpec:
     type: type
-    validator: Optional[Callable[[Any], bool]] = None
+    validator: Callable[[Any], bool] | None = None
     error: str = ""
 
 
-_FIELD_SPECS: Dict[str, FieldSpec] = {
-    "defaults.cmd":  FieldSpec(
+_FIELD_SPECS: dict[str, FieldSpec] = {
+    "defaults.cmd": FieldSpec(
         str,
         lambda v: v in tuple(c.value for c in DefaultCmd),
         "must be 'raw', 'list', 'show', or 'add'",
     ),
     "list.per_page": FieldSpec(int, lambda v: v >= 1, "must be >= 1"),
-    "list.rows":     FieldSpec(int, lambda v: v >= 0, "must be >= 0"),
+    "list.rows": FieldSpec(int, lambda v: v >= 0, "must be >= 0"),
     "list.truncate": FieldSpec(int, lambda v: v >= 0, "must be >= 0"),
-    "list.sort_by":  FieldSpec(
+    "list.sort_by": FieldSpec(
         str,
         lambda v: v in VALID_SORT_COLUMNS,
         f"must be one of: {', '.join(sorted(VALID_SORT_COLUMNS))}",
     ),
-    "list.desc":     FieldSpec(bool),
-    "list.columns":  FieldSpec(
+    "list.desc": FieldSpec(bool),
+    "list.columns": FieldSpec(
         list,
         lambda v: (
             isinstance(v, list)
@@ -130,14 +137,14 @@ _FIELD_SPECS: Dict[str, FieldSpec] = {
         ),
         f'must include "idx"; available: {", ".join(VALID_LIST_COLUMNS)}',
     ),
-    "db.path":       FieldSpec(str),
-    "db.backend":    FieldSpec(
+    "db.path": FieldSpec(str),
+    "db.backend": FieldSpec(
         str,
         lambda v: v in tuple(b.value for b in DbBackend),
         "must be 'local' or 'turso'",
     ),
-    "turso.url":     FieldSpec(str),
-    "turso.token":   FieldSpec(str),
+    "turso.url": FieldSpec(str),
+    "turso.token": FieldSpec(str),
     "git.sync_path": FieldSpec(str),
     "git.payload_file": FieldSpec(
         str,
@@ -154,7 +161,7 @@ _FIELD_SPECS: Dict[str, FieldSpec] = {
         lambda v: str(v).strip().lower() == GIT_SYNC_FORMAT_JSONL,
         f"must be {GIT_SYNC_FORMAT_JSONL!r} (case-insensitive)",
     ),
-    "exec.shell":    FieldSpec(
+    "exec.shell": FieldSpec(
         str,
         valid_exec_shell,
         f"must be an installed shell ({', '.join(EXEC_SHELL_ALLOWLIST)}) "
@@ -162,17 +169,17 @@ _FIELD_SPECS: Dict[str, FieldSpec] = {
     ),
 }
 
-ALL_KEYS: List[str] = list(_FIELD_SPECS.keys())
+ALL_KEYS: list[str] = list(_FIELD_SPECS.keys())
 
 
-_ENV_OVERRIDES: List[Tuple[str, str, Callable[[str], Any]]] = [
-    ("defaults.cmd",      "KODA_DEFAULT_CMD",      lambda v: v),
-    ("db.path",           "KODA_DB_PATH",          lambda v: v),
-    ("turso.url",         "KODA_TURSO_URL",        lambda v: v),
-    ("turso.token",       "KODA_TURSO_TOKEN",      lambda v: v),
-    ("git.sync_path",     "KODA_GIT_SYNC_PATH",    lambda v: v),
-    ("git.payload_file",  "KODA_GIT_PAYLOAD_FILE", lambda v: v),
-    ("git.sync_format",   "KODA_GIT_SYNC_FORMAT",  lambda v: v.strip().lower()),
+_ENV_OVERRIDES: list[tuple[str, str, Callable[[str], Any]]] = [
+    ("defaults.cmd", "KODA_DEFAULT_CMD", lambda v: v),
+    ("db.path", "KODA_DB_PATH", lambda v: v),
+    ("turso.url", "KODA_TURSO_URL", lambda v: v),
+    ("turso.token", "KODA_TURSO_TOKEN", lambda v: v),
+    ("git.sync_path", "KODA_GIT_SYNC_PATH", lambda v: v),
+    ("git.payload_file", "KODA_GIT_PAYLOAD_FILE", lambda v: v),
+    ("git.sync_format", "KODA_GIT_SYNC_FORMAT", lambda v: v.strip().lower()),
 ]
 
 
@@ -186,10 +193,10 @@ class ConfigManager:
     def __init__(self, config_path: Path = CONFIG_PATH) -> None:
         self.config_path = config_path
 
-    def load(self) -> Tuple[Config, Dict[str, str]]:
+    def load(self) -> tuple[Config, dict[str, str]]:
         """Return (Config, source_map). source_map[dotkey] = 'default'|'file'|'env'."""
         cfg = Config()
-        sources: Dict[str, str] = {k: "default" for k in ALL_KEYS}
+        sources: dict[str, str] = {k: "default" for k in ALL_KEYS}
 
         if self.config_path.exists():
             try:
@@ -228,7 +235,7 @@ class ConfigManager:
         """Serialize data to TOML and write to config_path."""
         self.config_path.parent.mkdir(parents=True, exist_ok=True)
         os.chmod(self.config_path.parent, 0o700)
-        lines: List[str] = []
+        lines: list[str] = []
         for section, values in data.items():
             lines.append(f"[{section}]")
             for k, v in values.items():
@@ -294,9 +301,9 @@ class ConfigManager:
         return getattr(cfg, _attr(key))
 
 
-def config_defaults_dict() -> Dict[str, Dict[str, Any]]:
+def config_defaults_dict() -> dict[str, dict[str, Any]]:
     """Build the nested {section: {key: default}} dict from Config()."""
-    out: Dict[str, Dict[str, Any]] = {}
+    out: dict[str, dict[str, Any]] = {}
     cfg = Config()
     for dotkey in ALL_KEYS:
         section, _, key = dotkey.partition(".")

--- a/src/koda/constants.py
+++ b/src/koda/constants.py
@@ -1,8 +1,5 @@
 """Shared constants for koda: timestamps, separators, schema column names."""
 
-from typing import Tuple
-
-
 DATETIME_FMT = "%Y-%m-%d %H:%M:%S"
 
 TAG_SEPARATOR = ","
@@ -11,7 +8,13 @@ TAG_SEPARATOR = ","
 # during the swap; chosen high enough to fit any realistic memo count.
 IDX_TEMP_OFFSET = 2_000_000
 
-COLUMN_NAMES: Tuple[str, ...] = (
-    "id", "uid", "idx", "content", "tags", "shortcut",
-    "created_at", "modified_at",
+COLUMN_NAMES: tuple[str, ...] = (
+    "id",
+    "uid",
+    "idx",
+    "content",
+    "tags",
+    "shortcut",
+    "created_at",
+    "modified_at",
 )

--- a/src/koda/db.py
+++ b/src/koda/db.py
@@ -2,15 +2,15 @@
 
 import os
 import sqlite3
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, List, Optional
 
 from .models import MemoRow
 
-
 try:
     import libsql_experimental as _libsql
+
     LIBSQL_AVAILABLE = True
     try:
         IntegrityErrors: tuple = (sqlite3.IntegrityError, _libsql.IntegrityError)
@@ -23,8 +23,14 @@ except ImportError:
 
 
 VALID_SORT_COLUMNS = {
-    "id", "idx", "uid", "tags", "content",
-    "created_at", "modified_at", "shortcut",
+    "id",
+    "idx",
+    "uid",
+    "tags",
+    "content",
+    "created_at",
+    "modified_at",
+    "shortcut",
 }
 
 
@@ -38,7 +44,7 @@ class MemoDatabase:
     def __init__(
         self,
         backend: str = "local",
-        path: Optional[Path] = None,
+        path: Path | None = None,
         turso_url: str = "",
         turso_token: str = "",
     ) -> None:
@@ -52,8 +58,7 @@ class MemoDatabase:
         if self.backend == "turso":
             if not LIBSQL_AVAILABLE:
                 raise DatabaseError(
-                    "libsql-experimental is not installed. "
-                    "Run: pip install libsql-experimental"
+                    "libsql-experimental is not installed. Run: pip install libsql-experimental"
                 )
             if not self.turso_url:
                 raise DatabaseError(
@@ -145,7 +150,7 @@ class MemoDatabase:
         offset=0,
         sort_by="idx",
         desc=False,
-    ) -> List[MemoRow]:
+    ) -> list[MemoRow]:
         order_column = sort_by if sort_by in VALID_SORT_COLUMNS else "idx"
         order_direction = "DESC" if desc else "ASC"
         where_sql, params = self._filters(query, tag, exclude_tag, shortcuts_only)
@@ -171,7 +176,7 @@ class MemoDatabase:
         shortcuts_only=False,
         sort_by="idx",
         desc=False,
-    ) -> List[MemoRow]:
+    ) -> list[MemoRow]:
         order_column = sort_by if sort_by in VALID_SORT_COLUMNS else "idx"
         order_direction = "DESC" if desc else "ASC"
         where_sql, params = self._filters(query, tag, exclude_tag, shortcuts_only)
@@ -182,15 +187,14 @@ class MemoDatabase:
         with self.connection() as conn:
             return [MemoRow.from_row(r) for r in conn.execute(sql, params).fetchall()]
 
-    def get_latest_entry(self) -> Optional[MemoRow]:
+    def get_latest_entry(self) -> MemoRow | None:
         with self.connection() as conn:
             row = conn.execute(
-                f"SELECT {self._MEMO_COLUMNS} FROM memos "
-                "ORDER BY created_at DESC, id DESC LIMIT 1"
+                f"SELECT {self._MEMO_COLUMNS} FROM memos ORDER BY created_at DESC, id DESC LIMIT 1"
             ).fetchone()
         return MemoRow.from_row(row)
 
-    def get_memo_by_idx(self, idx: int) -> Optional[MemoRow]:
+    def get_memo_by_idx(self, idx: int) -> MemoRow | None:
         with self.connection() as conn:
             row = conn.execute(
                 f"SELECT {self._MEMO_COLUMNS} FROM memos WHERE idx = ?",
@@ -198,7 +202,7 @@ class MemoDatabase:
             ).fetchone()
         return MemoRow.from_row(row)
 
-    def get_memo_by_shortcut(self, shortcut: str) -> Optional[MemoRow]:
+    def get_memo_by_shortcut(self, shortcut: str) -> MemoRow | None:
         with self.connection() as conn:
             row = conn.execute(
                 f"SELECT {self._MEMO_COLUMNS} FROM memos WHERE shortcut = ?",
@@ -206,7 +210,7 @@ class MemoDatabase:
             ).fetchone()
         return MemoRow.from_row(row)
 
-    def get_memo_by_uid(self, uid: str) -> Optional[MemoRow]:
+    def get_memo_by_uid(self, uid: str) -> MemoRow | None:
         with self.connection() as conn:
             row = conn.execute(
                 f"SELECT {self._MEMO_COLUMNS} FROM memos WHERE uid = ?",
@@ -218,7 +222,7 @@ class MemoDatabase:
         self,
         uid: str,
         idx: int,
-        shortcut: Optional[str],
+        shortcut: str | None,
         content: str,
         tags: str,
         created_at: str,
@@ -236,7 +240,7 @@ class MemoDatabase:
         memo_id: int,
         content: str,
         tags: str,
-        shortcut: Optional[str],
+        shortcut: str | None,
         created_at: str,
         modified_at: str,
     ) -> None:

--- a/src/koda/git_sync.py
+++ b/src/koda/git_sync.py
@@ -5,20 +5,19 @@ import shutil
 import subprocess
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 from rich.console import Console
 
 from .cli_utils import exit_error
-from .config import Config, GIT_SYNC_FORMAT_JSONL
+from .config import GIT_SYNC_FORMAT_JSONL, Config
 from .constants import DATETIME_FMT
 from .db import IntegrityErrors, MemoDatabase
-
 
 console = Console()
 
 
 # ── Top-level helpers ────────────────────────────────────────────────────────
+
 
 def require_git_cli() -> None:
     if shutil.which("git") is None:
@@ -67,7 +66,7 @@ def atomic_write_bytes(path: Path, data: bytes) -> None:
     tmp.replace(path)
 
 
-def parse_memo_datetime(s: Optional[str]) -> datetime:
+def parse_memo_datetime(s: str | None) -> datetime:
     if not s or not str(s).strip():
         return datetime.min.replace(microsecond=0)
     try:
@@ -77,6 +76,7 @@ def parse_memo_datetime(s: Optional[str]) -> datetime:
 
 
 # ── JSONL payload (de)serialization ──────────────────────────────────────────
+
 
 class GitSyncPayload:
     """Encode/decode the shared JSONL memo payload."""
@@ -130,7 +130,7 @@ class GitSyncPayload:
         }
 
     @staticmethod
-    def load(data: bytes) -> List[dict]:
+    def load(data: bytes) -> list[dict]:
         if not data.strip():
             return []
         try:
@@ -158,7 +158,7 @@ class GitSyncPayload:
                 "SELECT uid, idx, shortcut, content, tags, created_at, modified_at "
                 "FROM memos ORDER BY uid ASC, id ASC"
             ).fetchall()
-        memos: List[dict] = []
+        memos: list[dict] = []
         for uid, idx, shortcut, content, tags, created_at, modified_at in rows:
             ca = created_at or ""
             ma = modified_at if modified_at else (ca or "")
@@ -183,6 +183,7 @@ class GitSyncPayload:
 
 # ── Git CLI wrapper ──────────────────────────────────────────────────────────
 
+
 class GitSyncRepo:
     """Thin wrapper around git operations in the sync clone."""
 
@@ -206,7 +207,7 @@ class GitSyncRepo:
         )
         return bool((r.stdout or "").strip())
 
-    def preferred_remote(self) -> Optional[str]:
+    def preferred_remote(self) -> str | None:
         r = subprocess.run(
             ["git", "-C", str(self.sync_root), "remote"],
             capture_output=True,
@@ -221,7 +222,7 @@ class GitSyncRepo:
             return "origin"
         return names[0]
 
-    def current_branch(self) -> Optional[str]:
+    def current_branch(self) -> str | None:
         r = subprocess.run(
             ["git", "-C", str(self.sync_root), "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True,
@@ -251,17 +252,19 @@ class GitSyncRepo:
         branch = self.current_branch()
         if not branch:
             exit_error(
-                "Cannot git pull in detached HEAD in the sync clone. Check out a branch, then retry."
+                "Cannot git pull in detached HEAD in the sync clone. "
+                "Check out a branch, then retry."
             )
         if self.has_upstream():
-            cmd: List[str] = ["git", "-C", str(self.sync_root), "pull", "--rebase"]
+            cmd: list[str] = ["git", "-C", str(self.sync_root), "pull", "--rebase"]
         else:
             cmd = ["git", "-C", str(self.sync_root), "pull", "--rebase", remote, branch]
         try:
             subprocess.run(cmd, check=True, capture_output=True, text=True)
         except subprocess.CalledProcessError as e:
             console.print(
-                "[red]git pull --rebase failed in the sync clone. Resolve conflicts there, then retry.[/red]"
+                "[red]git pull --rebase failed in the sync clone. "
+                "Resolve conflicts there, then retry.[/red]"
             )
             if e.stderr:
                 console.print(f"[dim]{e.stderr.strip()}[/dim]")
@@ -270,7 +273,8 @@ class GitSyncRepo:
     def push_if_remote(self) -> None:
         if not self.has_remote():
             console.print(
-                "[yellow]No Git remotes configured; payload committed locally only (skipping push).[/yellow]"
+                "[yellow]No Git remotes configured; "
+                "payload committed locally only (skipping push).[/yellow]"
             )
             return
         remote = self.preferred_remote()
@@ -279,17 +283,19 @@ class GitSyncRepo:
         branch = self.current_branch()
         if not branch:
             exit_error(
-                "Cannot git push in detached HEAD in the sync clone. Check out a branch, then retry."
+                "Cannot git push in detached HEAD in the sync clone. "
+                "Check out a branch, then retry."
             )
         if self.has_upstream():
-            cmd: List[str] = ["git", "-C", str(self.sync_root), "push"]
+            cmd: list[str] = ["git", "-C", str(self.sync_root), "push"]
         else:
             cmd = ["git", "-C", str(self.sync_root), "push", "-u", remote, branch]
         try:
             subprocess.run(cmd, check=True, capture_output=True, text=True)
         except subprocess.CalledProcessError as e:
             console.print(
-                "[red]git push failed. Configure upstream/remotes or run push from that clone manually.[/red]"
+                "[red]git push failed. "
+                "Configure upstream/remotes or run push from that clone manually.[/red]"
             )
             if e.stderr:
                 console.print(f"[dim]{e.stderr.strip()}[/dim]")
@@ -298,6 +304,7 @@ class GitSyncRepo:
 
 # ── Merge into local DB ─────────────────────────────────────────────────────
 
+
 class MemoMerger:
     """Merge remote JSONL entries into the local memos table by uid + modified_at."""
 
@@ -305,12 +312,10 @@ class MemoMerger:
         self.db = db
 
     @staticmethod
-    def _shortcut_usable(conn, uid: str, shortcut: Optional[str]) -> Optional[str]:
+    def _shortcut_usable(conn, uid: str, shortcut: str | None) -> str | None:
         if shortcut is None or shortcut == "":
             return shortcut
-        existing = conn.execute(
-            "SELECT uid FROM memos WHERE shortcut = ?", (shortcut,)
-        ).fetchone()
+        existing = conn.execute("SELECT uid FROM memos WHERE shortcut = ?", (shortcut,)).fetchone()
         if existing is None:
             return shortcut
         (existing_uid,) = existing
@@ -338,7 +343,7 @@ class MemoMerger:
                 (MemoDatabase.next_idx(conn), memo_id),
             )
 
-    def merge(self, entries: List[dict]) -> Tuple[int, int, int, int]:
+    def merge(self, entries: list[dict]) -> tuple[int, int, int, int]:
         """Return (inserted, updated, skipped, shortcut_dropped)."""
         inserted = updated = skipped = shortcut_dropped = 0
         with self.db.connection() as conn:
@@ -361,9 +366,8 @@ class MemoMerger:
                     continue
                 content = rm.get("content") if rm.get("content") is not None else ""
                 tags = rm.get("tags") if rm.get("tags") is not None else ""
-                created_at = (
-                    str(rm.get("created_at") or "").strip()
-                    or datetime.now().strftime(DATETIME_FMT)
+                created_at = str(rm.get("created_at") or "").strip() or datetime.now().strftime(
+                    DATETIME_FMT
                 )
                 modified_at = str(rm.get("modified_at") or "").strip() or created_at
                 raw_sc = rm.get("shortcut")
@@ -382,7 +386,8 @@ class MemoMerger:
                         shortcut_dropped += 1
                     try:
                         conn.execute(
-                            "INSERT INTO memos (uid, idx, shortcut, content, tags, created_at, modified_at) "
+                            "INSERT INTO memos "
+                            "(uid, idx, shortcut, content, tags, created_at, modified_at) "
                             "VALUES (?, ?, ?, ?, ?, ?, ?)",
                             (uid, pick_idx, use_sc, content, tags, created_at, modified_at),
                         )
@@ -391,14 +396,16 @@ class MemoMerger:
                         pick_idx = MemoDatabase.next_idx(conn)
                         try:
                             conn.execute(
-                                "INSERT INTO memos (uid, idx, shortcut, content, tags, created_at, modified_at) "
+                                "INSERT INTO memos "
+                                "(uid, idx, shortcut, content, tags, created_at, modified_at) "
                                 "VALUES (?, ?, ?, ?, ?, ?, ?)",
                                 (uid, pick_idx, use_sc, content, tags, created_at, modified_at),
                             )
                             inserted += 1
                         except IntegrityErrors:
                             conn.execute(
-                                "INSERT INTO memos (uid, idx, shortcut, content, tags, created_at, modified_at) "
+                                "INSERT INTO memos "
+                                "(uid, idx, shortcut, content, tags, created_at, modified_at) "
                                 "VALUES (?, ?, ?, ?, ?, ?, ?)",
                                 (uid, pick_idx, None, content, tags, created_at, modified_at),
                             )

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -1,41 +1,43 @@
-import typer
-import sys
 import hashlib
-from typer.core import TyperGroup
 import os
-import subprocess
-import tempfile
 import re
+import subprocess
+import sys
+import tempfile
 from datetime import datetime
 from importlib.metadata import version
 from pathlib import Path
-from typing import Optional, List
+
+import typer
 from rich.console import Console
 from rich.table import Table
+from typer.core import TyperGroup
 
-from .db import MemoDatabase, DatabaseError, IntegrityErrors as _IntegrityErrors
+from . import git_sync
 from .cli_utils import confirm, exit_error
-from .config import (
-    ALL_KEYS as _ALL_KEYS,
-    COLUMN_DEFS,
-    CONFIG_PATH,
-    ConfigManager,
-    DEFAULT_DB_PATH,
-    GIT_SYNC_FORMAT_JSONL,
-    VALID_LIST_COLUMNS,
-    VALID_SORT_COLUMNS,
-    ValidationError,
-)
 from .cmd_helpers.display import print_memo as _print_memo
-from .cmd_helpers.metadata import first_footer_index, last_footer_segment
-from .cmd_helpers.parsing import parse_indices, parse_tag_args, parse_var_items
 from .cmd_helpers.interactive import (
     pick_candidates,
     pick_with_fzf,
     resolve_pick_action,
 )
-from . import git_sync
+from .cmd_helpers.metadata import first_footer_index, last_footer_segment
+from .cmd_helpers.parsing import parse_indices, parse_tag_args, parse_var_items
+from .config import (
+    ALL_KEYS as _ALL_KEYS,
+)
+from .config import (
+    COLUMN_DEFS,
+    CONFIG_PATH,
+    DEFAULT_DB_PATH,
+    VALID_LIST_COLUMNS,
+    VALID_SORT_COLUMNS,
+    ConfigManager,
+    ValidationError,
+)
 from .constants import DATETIME_FMT, IDX_TEMP_OFFSET, TAG_SEPARATOR
+from .db import DatabaseError, MemoDatabase
+from .db import IntegrityErrors as _IntegrityErrors
 
 __app_name__ = "koda"
 __version__ = version("koda-cli")
@@ -98,11 +100,12 @@ config, _config_sources = _config_manager.load()
 DB_PATH = Path(config.db_path).expanduser()
 
 
-def _validate_list_columns(columns: List[str], source: str) -> None:
+def _validate_list_columns(columns: list[str], source: str) -> None:
     try:
         ConfigManager.validate("list.columns", columns)
     except ValidationError:
         exit_error(f"Invalid {source}: {ConfigManager.error_message('list.columns')}")
+
 
 db = MemoDatabase(
     backend=config.db_backend,
@@ -134,7 +137,7 @@ def init_db():
         exit_error(f"Database Error: {e}")
 
 
-def resolve_ref(ref: Optional[str]):
+def resolve_ref(ref: str | None):
     """Return (id, uid, idx, content, tags, shortcut, created_at) or exit.
 
     ref=None → latest; digit string → idx lookup; other string → shortcut lookup.
@@ -155,25 +158,25 @@ def resolve_ref(ref: Optional[str]):
     return row
 
 
-def _validate_shortcut(shortcut: Optional[str]) -> Optional[str]:
+def _validate_shortcut(shortcut: str | None) -> str | None:
     if shortcut and len(shortcut) == 1 and shortcut in RESERVED_SHORTCUTS:
         exit_error(f"Shortcut {shortcut!r} is reserved as a 1-letter subcommand alias.")
     return shortcut
 
 
-def _apply_vars(content: str, vars: Optional[List[str]]) -> str:
+def _apply_vars(content: str, vars: list[str] | None) -> str:
     if not vars:
         return content
     pos_index = 1
     for var_spec in vars:
         stripped = var_spec.strip()
-        m = re.match(r'^(\w+)=(.*)', stripped, re.DOTALL)
+        m = re.match(r"^(\w+)=(.*)", stripped, re.DOTALL)
         if m:
             key, value = m.group(1), m.group(2)
             content = content.replace(f"${{{key}}}", value)
         else:
             for item in parse_var_items(stripped):
-                content = re.sub(rf'\${pos_index}(?!\d)', item.replace('\\', '\\\\'), content)
+                content = re.sub(rf"\${pos_index}(?!\d)", item.replace("\\", "\\\\"), content)
                 pos_index += 1
     return content
 
@@ -228,7 +231,7 @@ def _strip_raw_inline_comments(content: str) -> str:
     return "".join(stripped_lines)
 
 
-def emit_raw(ref: Optional[str], vars: Optional[List[str]] = None) -> None:
+def emit_raw(ref: str | None, vars: list[str] | None = None) -> None:
     init_db()
     row = resolve_ref(ref)
     content = _apply_vars(row.content if row.content is not None else "", vars)
@@ -240,7 +243,7 @@ def emit_raw(ref: Optional[str], vars: Optional[List[str]] = None) -> None:
     sys.stdout.write(content)
 
 
-def _read_stdin_refs() -> List[str]:
+def _read_stdin_refs() -> list[str]:
     """Read whitespace-separated entry refs from stdin (non-interactive only)."""
     if sys.stdin.isatty():
         return []
@@ -248,6 +251,7 @@ def _read_stdin_refs() -> List[str]:
     if not data:
         return []
     return [part for part in data.split() if part]
+
 
 def _run_pick_action(action: str, ref: str) -> None:
     if action == "raw":
@@ -270,7 +274,7 @@ def _run_pick_action(action: str, ref: str) -> None:
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
-    version: Optional[bool] = typer.Option(
+    version: bool | None = typer.Option(
         None,
         "--version",
         "-v",
@@ -294,15 +298,15 @@ def main(
             emit_raw(None)
 
 
-def update_memo_full(memo_id: int, content: str, tags: str, shortcut: Optional[str], created_at: str):
+def update_memo_full(memo_id: int, content: str, tags: str, shortcut: str | None, created_at: str):
     now = datetime.now().strftime(DATETIME_FMT)
     db.update_memo(memo_id, content, tags, shortcut, created_at, now)
 
 
 def _add_impl(
-    text: Optional[List[str]] = None,
-    tag: Optional[List[str]] = None,
-    shortcut: Optional[str] = None,
+    text: list[str] | None = None,
+    tag: list[str] | None = None,
+    shortcut: str | None = None,
 ) -> None:
     shortcut = _validate_shortcut(shortcut)
     init_db()
@@ -318,12 +322,12 @@ def _add_impl(
     elif not sys.stdin.isatty():
         content = sys.stdin.read().strip()
     else:
-        editor = os.environ.get('EDITOR', 'vim')
-        with tempfile.NamedTemporaryFile(suffix=".tmp", mode='w+', delete=False) as tf:
+        editor = os.environ.get("EDITOR", "vim")
+        with tempfile.NamedTemporaryFile(suffix=".tmp", mode="w+", delete=False) as tf:
             temp_path = tf.name
         try:
             subprocess.call([editor, temp_path])
-            with open(temp_path, 'r') as f:
+            with open(temp_path) as f:
                 content = f.read().strip()
         finally:
             Path(temp_path).unlink(missing_ok=True)
@@ -331,7 +335,7 @@ def _add_impl(
     if not content:
         exit_error("Aborted: Empty content.", style="yellow")
 
-    content = content.encode('utf-8', 'surrogateescape').decode('utf-8', 'ignore')
+    content = content.encode("utf-8", "surrogateescape").decode("utf-8", "ignore")
 
     formatted_tags = TAG_SEPARATOR.join(dict.fromkeys(parse_tag_args(tag)))
 
@@ -341,8 +345,10 @@ def _add_impl(
         with db.connection() as conn:
             new_idx = MemoDatabase.next_idx(conn)
             conn.execute(
-                "INSERT INTO memos (uid, idx, shortcut, content, tags, created_at, modified_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (uid, new_idx, shortcut or None, content, formatted_tags, now, now)
+                "INSERT INTO memos "
+                "(uid, idx, shortcut, content, tags, created_at, modified_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (uid, new_idx, shortcut or None, content, formatted_tags, now, now),
             )
     except _IntegrityErrors:
         exit_error(f"Shortcut {shortcut!r} is already in use.")
@@ -353,13 +359,13 @@ def _add_impl(
 
 @app.command()
 def add(
-    text: Optional[List[str]] = typer.Argument(
+    text: list[str] | None = typer.Argument(
         None, help="Text to save (optional if using stdin or $EDITOR)."
     ),
-    tag: Optional[List[str]] = typer.Option(
+    tag: list[str] | None = typer.Option(
         None, "--tag", "-t", help="Comma-separated tag(s); repeat -t for more."
     ),
-    shortcut: Optional[str] = typer.Option(
+    shortcut: str | None = typer.Option(
         None, "--shortcut", "-s", help="Short alias for this entry (e.g. 'deploy')."
     ),
 ):
@@ -369,28 +375,32 @@ def add(
 
 @app.command(name="remove")
 def rm(
-    indices: Optional[List[str]] = typer.Argument(
+    indices: list[str] | None = typer.Argument(
         None, help="Entry indices, ranges (e.g. 1 3 5-8), or a single shortcut. Default: latest."
     ),
-    tag: Optional[str] = typer.Option(
+    tag: str | None = typer.Option(
         None, "--tag", "-t", help="Delete entries whose tags match this substring."
     ),
-    query: Optional[str] = typer.Option(
+    query: str | None = typer.Option(
         None, "--query", "-q", help="Delete entries whose body matches this substring."
     ),
-    all_entries: bool = typer.Option(
-        False, "--all", help="Delete ALL entries (requires -f)."
-    ),
-    force: bool = typer.Option(
-        False, "--force", "-f", help="Delete without prompting."
-    ),
+    all_entries: bool = typer.Option(False, "--all", help="Delete ALL entries (requires -f)."),
+    force: bool = typer.Option(False, "--force", "-f", help="Delete without prompting."),
 ):
-    """Delete entries. Defaults to latest; supports ranges, -t, -q, and --all for batch. Alias: `koda d`."""
+    """Delete entries. Defaults to latest; supports ranges, -t, -q, and --all for batch.
+
+    Alias: `koda d`.
+    """
     if all_entries and not force:
         exit_error("--all requires -f/--force.")
 
     init_db()
-    is_batch = bool(tag or query or all_entries or (indices and (len(indices) > 1 or re.search(r'\d-\d', indices[0]))))
+    is_batch = bool(
+        tag
+        or query
+        or all_entries
+        or (indices and (len(indices) > 1 or re.search(r"\d-\d", indices[0])))
+    )
 
     if is_batch:
         if indices:
@@ -443,7 +453,7 @@ def rm(
 
 @app.command(name="copy")
 def copy(
-    ref: Optional[str] = typer.Argument(
+    ref: str | None = typer.Argument(
         None, help="Source entry index or shortcut (default: latest)."
     ),
 ):
@@ -455,15 +465,17 @@ def copy(
     with db.connection() as conn:
         new_idx = MemoDatabase.next_idx(conn)
         conn.execute(
-            "INSERT INTO memos (uid, idx, shortcut, content, tags, created_at, modified_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (new_uid, new_idx, None, row.content, row.tags, now, now)
+            "INSERT INTO memos "
+            "(uid, idx, shortcut, content, tags, created_at, modified_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (new_uid, new_idx, None, row.content, row.tags, now, now),
         )
     console.print(f"[green]Copied [{row.idx}] → [{new_idx}] ({new_uid}).[/green]")
 
 
 @app.command()
 def edit(
-    ref: Optional[str] = typer.Argument(
+    ref: str | None = typer.Argument(
         None, help="Entry index or shortcut to edit (default: latest)."
     ),
 ):
@@ -472,13 +484,19 @@ def edit(
     row = resolve_ref(ref)
     memo_id = row.id
     content, tags, shortcut, created_at, idx = (
-        row.content, row.tags, row.shortcut, row.created_at, row.idx,
+        row.content,
+        row.tags,
+        row.shortcut,
+        row.created_at,
+        row.idx,
     )
 
     sc_line = f"shortcut: {shortcut}" if shortcut else "shortcut: "
-    template = f"{content}\n\n---\n# Metadata\ntags: {tags}\n{sc_line}\ncreated_at: {created_at}\n---"
+    template = (
+        f"{content}\n\n---\n# Metadata\ntags: {tags}\n{sc_line}\ncreated_at: {created_at}\n---"
+    )
 
-    editor = os.environ.get('EDITOR', 'vim')
+    editor = os.environ.get("EDITOR", "vim")
     with tempfile.NamedTemporaryFile(
         suffix=".tmp", mode="w+", delete=False, encoding="utf-8"
     ) as tf:
@@ -487,10 +505,10 @@ def edit(
 
     try:
         subprocess.call([editor, temp_path])
-        with open(temp_path, 'r') as f:
+        with open(temp_path) as f:
             new_data = f.read()
 
-        parts = re.split(r'\n---+\s*\n', new_data)
+        parts = re.split(r"\n---+\s*\n", new_data)
         while parts and not parts[-1].strip():
             parts.pop()
 
@@ -525,17 +543,17 @@ def edit(
 
 
 def _list_memos_impl(
-    query: Optional[str] = None,
-    tag: Optional[str] = None,
-    exclude_tag: Optional[str] = None,
+    query: str | None = None,
+    tag: str | None = None,
+    exclude_tag: str | None = None,
     shortcuts_only: bool = False,
-    per_page: Optional[int] = None,
+    per_page: int | None = None,
     page: int = 1,
-    sort_by: Optional[str] = None,
-    desc: Optional[bool] = None,
-    rows: Optional[str] = None,
-    truncate: Optional[int] = None,
-    columns: Optional[List[str]] = None,
+    sort_by: str | None = None,
+    desc: bool | None = None,
+    rows: str | None = None,
+    truncate: int | None = None,
+    columns: list[str] | None = None,
 ) -> None:
     init_db()
 
@@ -562,7 +580,7 @@ def _list_memos_impl(
         valid = ", ".join(sorted(VALID_SORT_COLUMNS))
         exit_error(f"Invalid --sort-by '{sort_by}'. Use one of: {valid}.")
 
-    rows_value: Optional[int]
+    rows_value: int | None
     try:
         parsed_rows = int(rows)
         if parsed_rows < 0:
@@ -645,42 +663,50 @@ def _list_memos_impl(
 
 @app.command(name="list")
 def list_memos(
-    query: Optional[str] = typer.Option(
-        None, "--query", "-q", help="Substring match on memo body."
-    ),
-    tag: Optional[str] = typer.Option(
-        None, "--tag", "-t", help="Substring match on tags."
-    ),
-    exclude_tag: Optional[str] = typer.Option(
-        None, "--exclude-tag", "-T",
+    query: str | None = typer.Option(None, "--query", "-q", help="Substring match on memo body."),
+    tag: str | None = typer.Option(None, "--tag", "-t", help="Substring match on tags."),
+    exclude_tag: str | None = typer.Option(
+        None,
+        "--exclude-tag",
+        "-T",
         help="Exclude entries whose tags include this substring.",
     ),
     shortcuts_only: bool = typer.Option(
         False, "--shortcuts", "-S", help="Show only entries that have a shortcut."
     ),
-    per_page: Optional[int] = typer.Option(
+    per_page: int | None = typer.Option(
         None, "--per-page", "-n", help="Entries per page. [config: list.per_page]"
     ),
-    page: int = typer.Option(
-        1, "--page", "-p", min=1, help="1-based page number to display."
+    page: int = typer.Option(1, "--page", "-p", min=1, help="1-based page number to display."),
+    sort_by: str | None = typer.Option(
+        None,
+        "--sort-by",
+        "-s",
+        case_sensitive=False,
+        help=(
+            "Sort column: id, idx, uid, tags, content, created_at, modified_at, shortcut. "
+            "[config: list.sort_by]"
+        ),
     ),
-    sort_by: Optional[str] = typer.Option(
-        None, "--sort-by", "-s", case_sensitive=False,
-        help="Sort column: id, idx, uid, tags, content, created_at, modified_at, shortcut. [config: list.sort_by]",
+    desc: bool | None = typer.Option(
+        None,
+        "--desc/--asc",
+        help="Sort order. [config: list.desc]",
     ),
-    desc: Optional[bool] = typer.Option(
-        None, "--desc/--asc", help="Sort order. [config: list.desc]",
-    ),
-    rows: Optional[str] = typer.Option(
-        None, "--rows", "-r",
+    rows: str | None = typer.Option(
+        None,
+        "--rows",
+        "-r",
         help="Content preview lines per entry (0 = all lines). [config: list.rows]",
     ),
-    truncate: Optional[int] = typer.Option(
-        None, "--truncate",
+    truncate: int | None = typer.Option(
+        None,
+        "--truncate",
         help="Max characters per content line (0 = no truncation). [config: list.truncate]",
     ),
-    columns: Optional[str] = typer.Option(
-        None, "--columns",
+    columns: str | None = typer.Option(
+        None,
+        "--columns",
         help=(
             "Comma-separated columns to display. idx is required. "
             f"Available: {', '.join(VALID_LIST_COLUMNS)}. [config: list.columns]"
@@ -688,46 +714,55 @@ def list_memos(
     ),
 ):
     """Show entries as a table with paging and sortable columns. Alias: `koda l`."""
-    parsed_columns: Optional[List[str]] = None
+    parsed_columns: list[str] | None = None
     if columns is not None:
         parsed_columns = [c.strip() for c in columns.split(",") if c.strip()]
         _validate_list_columns(parsed_columns, "--columns")
-    _list_memos_impl(query, tag, exclude_tag, shortcuts_only, per_page, page, sort_by, desc, rows, truncate, parsed_columns)
+    _list_memos_impl(
+        query,
+        tag,
+        exclude_tag,
+        shortcuts_only,
+        per_page,
+        page,
+        sort_by,
+        desc,
+        rows,
+        truncate,
+        parsed_columns,
+    )
 
 
 @app.command()
 def pick(
-    query: Optional[str] = typer.Option(
-        None, "--query", "-q", help="Substring match on memo body."
-    ),
-    tag: Optional[str] = typer.Option(
-        None, "--tag", "-t", help="Substring match on tags."
-    ),
-    exclude_tag: Optional[str] = typer.Option(
+    query: str | None = typer.Option(None, "--query", "-q", help="Substring match on memo body."),
+    tag: str | None = typer.Option(None, "--tag", "-t", help="Substring match on tags."),
+    exclude_tag: str | None = typer.Option(
         None, "--exclude-tag", "-T", help="Exclude entries whose tags include this substring."
     ),
     shortcuts_only: bool = typer.Option(
         False, "--shortcuts", "-S", help="Show only entries that have a shortcut."
     ),
-    sort_by: Optional[str] = typer.Option(
-        None, "--sort-by", case_sensitive=False,
-        help="Sort column: id, idx, uid, tags, content, created_at, modified_at, shortcut. [config: list.sort_by]",
+    sort_by: str | None = typer.Option(
+        None,
+        "--sort-by",
+        case_sensitive=False,
+        help=(
+            "Sort column: id, idx, uid, tags, content, created_at, modified_at, shortcut. "
+            "[config: list.sort_by]"
+        ),
     ),
-    desc: Optional[bool] = typer.Option(
-        None, "--desc/--asc", help="Sort order. [config: list.desc]",
+    desc: bool | None = typer.Option(
+        None,
+        "--desc/--asc",
+        help="Sort order. [config: list.desc]",
     ),
     print_id: bool = typer.Option(
         False, "--print-id", "-p", help="Print selected IDX and exit without running a command."
     ),
-    edit_mode: bool = typer.Option(
-        False, "--edit", "-e", help="Open selected entry in editor."
-    ),
-    exec_mode: bool = typer.Option(
-        False, "--exec", "-x", help="Execute selected entry."
-    ),
-    raw_mode: bool = typer.Option(
-        False, "--raw", "-r", help="Print selected entry body."
-    ),
+    edit_mode: bool = typer.Option(False, "--edit", "-e", help="Open selected entry in editor."),
+    exec_mode: bool = typer.Option(False, "--exec", "-x", help="Execute selected entry."),
+    raw_mode: bool = typer.Option(False, "--raw", "-r", help="Print selected entry body."),
     show_mode: bool = typer.Option(
         False, "--show", "-s", help="Show selected entry with metadata."
     ),
@@ -736,8 +771,10 @@ def pick(
     if print_id and (edit_mode or exec_mode or raw_mode or show_mode):
         exit_error("--print-id/-p cannot be combined with action flags.")
 
-    action: Optional[str] = None if print_id else resolve_pick_action(
-        config, edit_mode, exec_mode, raw_mode, show_mode, print_id
+    action: str | None = (
+        None
+        if print_id
+        else resolve_pick_action(config, edit_mode, exec_mode, raw_mode, show_mode, print_id)
     )
 
     init_db()
@@ -758,11 +795,8 @@ def pick(
 
 @app.command()
 def show(
-    ref: Optional[str] = typer.Argument(
-        None, help="Entry index or shortcut (default: latest)."
-    ),
+    ref: str | None = typer.Argument(None, help="Entry index or shortcut (default: latest)."),
 ):
-
     """Print one entry with index, uid, tags, and timestamps (Rich formatted). Alias: `koda s`.
 
     When no argument is given, this command also accepts one ref from stdin.
@@ -781,24 +815,28 @@ def show(
 
 @app.command()
 def raw(
-    entry_refs: Optional[List[str]] = typer.Argument(
+    entry_refs: list[str] | None = typer.Argument(
         None,
-        help="Entry index(es) or shortcut(s) (default: latest). Body only, for pipes and shell substitution.",
+        help=(
+            "Entry index(es) or shortcut(s) (default: latest). "
+            "Body only, for pipes and shell substitution."
+        ),
     ),
-    vars: Optional[List[str]] = typer.Option(
-        None, "--var", "-V",
+    vars: list[str] | None = typer.Option(
+        None,
+        "--var",
+        "-V",
         help=(
             "Variable substitution. Named: KEY=VALUE → replaces ${KEY}. "
             "Positional: VALUE → replaces $1,$2,... in order. "
             'Comma-separate multiple values; use "..." to include spaces or commas. '
-            'Examples: -V \'localhost,5432\' -V \'name=prod\' -V \'"hello world","foo,bar"\''
+            "Examples: -V 'localhost,5432' -V 'name=prod' -V '\"hello world\",\"foo,bar\"'"
         ),
     ),
 ):
+    """Print memo body to stdout only (plain text, no Rich). Same as bare `koda <idx>`.
 
-    """Print memo body to stdout only (plain text, no Rich). Same as bare `koda <idx>`. Alias: `koda r`.
-
-    When no argument is given, refs can also be passed from stdin.
+    Alias: `koda r`. When no argument is given, refs can also be passed from stdin.
     """
     refs = entry_refs
     if not refs:
@@ -806,7 +844,6 @@ def raw(
         refs = stdin_refs or None
 
     if not refs:
-
         emit_raw(None, vars)
     else:
         for ref in refs:
@@ -815,20 +852,21 @@ def raw(
 
 @app.command(name="exec")
 def exec_memo(
-    ref: Optional[str] = typer.Argument(
+    ref: str | None = typer.Argument(
         None, help="Entry index or shortcut to execute (default: latest)."
     ),
-    vars: Optional[List[str]] = typer.Option(
-        None, "--var", "-V",
+    vars: list[str] | None = typer.Option(
+        None,
+        "--var",
+        "-V",
         help=(
             "Variable substitution. Named: KEY=VALUE → replaces ${KEY}. "
             "Positional: VALUE → replaces $1,$2,... in order. "
             'Comma-separate multiple values; use "..." to include spaces or commas. '
-            'Examples: -V \'localhost,5432\' -V \'name=prod\' -V \'"hello world","foo,bar"\''
+            "Examples: -V 'localhost,5432' -V 'name=prod' -V '\"hello world\",\"foo,bar\"'"
         ),
     ),
 ):
-
     """Execute the memo body as a shell command. Alias: `koda x`.
 
     When no argument is given, this command also accepts one ref from stdin.
@@ -856,9 +894,9 @@ def exec_memo(
 
 @app.command()
 def tag(
-    indices: List[str] = typer.Argument(..., help="Entry indices or ranges (e.g. 1 3 5-8)."),
-    tags: Optional[List[str]] = typer.Option(None, "--tag", "-t", help="Tag(s) to add."),
-    untag: Optional[List[str]] = typer.Option(None, "--untag", "-T", help="Tag(s) to remove."),
+    indices: list[str] = typer.Argument(..., help="Entry indices or ranges (e.g. 1 3 5-8)."),
+    tags: list[str] | None = typer.Option(None, "--tag", "-t", help="Tag(s) to add."),
+    untag: list[str] | None = typer.Option(None, "--untag", "-T", help="Tag(s) to remove."),
 ):
     """Add or remove tags on one or more entries. Supports ranges (e.g. 2-5). Alias: `koda t`."""
     if not tags and not untag:
@@ -890,10 +928,12 @@ def tag(
     if add_list:
         parts.append(f"Added to {updated} entr{'y' if updated == 1 else 'ies'}")
     if remove_list:
-        parts.append(f"removed from {updated} entr{'y' if updated == 1 else 'ies'}" if add_list
-                     else f"Removed from {updated} entr{'y' if updated == 1 else 'ies'}")
+        parts.append(
+            f"removed from {updated} entr{'y' if updated == 1 else 'ies'}"
+            if add_list
+            else f"Removed from {updated} entr{'y' if updated == 1 else 'ies'}"
+        )
     console.print(f"[green]{'; '.join(parts)}.[/green]")
-
 
 
 @app.command(name="move")
@@ -921,11 +961,14 @@ def move(
 
 @app.command()
 def push(
-    payload_file: Optional[Path] = typer.Option(
+    payload_file: Path | None = typer.Option(
         None, "--file", help="Use this JSONL file instead of exporting the local database."
     ),
 ):
-    """Write memo export (JSON Lines, uid-sorted) into the Git clone, commit, and push. Alias: `koda push`."""
+    """Write memo export (JSON Lines, uid-sorted) into the Git clone, commit, and push.
+
+    Alias: `koda push`.
+    """
     init_db()
     git_sync.require_jsonl_format(config)
     git_sync.require_git_cli()
@@ -978,11 +1021,14 @@ def push(
 
 @app.command()
 def pull(
-    local_payload_path: Optional[Path] = typer.Option(
+    local_payload_path: Path | None = typer.Option(
         None, "--file", help="Import from this JSONL file (skip git pull in the clone)."
     ),
 ):
-    """Pull memo JSONL from the Git clone (--file skips git); merge into local DB (uid + modified_at). Alias: `koda pull`."""
+    """Pull memo JSONL from the Git clone (--file skips git); merge into local DB.
+
+    Merge key is uid + modified_at. Alias: `koda pull`.
+    """
     init_db()
     git_sync.require_jsonl_format(config)
     if local_payload_path is not None:
@@ -1006,7 +1052,11 @@ def pull(
         exit_error(f"Invalid sync payload: {e}")
 
     ins, upd, skp, dsc = git_sync.MemoMerger(db).merge(rows)
-    tail = f", [yellow]{dsc}[/yellow] shortcut(s) dropped (conflicts with local shortcuts)" if dsc else ""
+    tail = (
+        f", [yellow]{dsc}[/yellow] shortcut(s) dropped (conflicts with local shortcuts)"
+        if dsc
+        else ""
+    )
     console.print(
         f"merged remote memos: [cyan]{ins}[/cyan] inserted, [cyan]{upd}[/cyan] updated, "
         f"[dim]{skp}[/dim] skipped (older or invalid entries){tail}."
@@ -1017,7 +1067,9 @@ def pull(
 @app.command(name="shift")
 def shift_cmd(
     start: int = typer.Argument(..., help="Shift entries at this index and above."),
-    count: int = typer.Option(1, "--count", "-n", help="Positions to shift (negative = shift down)."),
+    count: int = typer.Option(
+        1, "--count", "-n", help="Positions to shift (negative = shift down)."
+    ),
 ):
     """Shift all entries at START and above by COUNT positions. Alias: `koda h`."""
     init_db()
@@ -1041,7 +1093,8 @@ def shift_cmd(
                 )
         # Two-step update to avoid UNIQUE constraint violations during bulk shift
         conn.execute(
-            "UPDATE memos SET idx = idx + ? WHERE idx >= ?", (IDX_TEMP_OFFSET, start),
+            "UPDATE memos SET idx = idx + ? WHERE idx >= ?",
+            (IDX_TEMP_OFFSET, start),
         )
         conn.execute(
             "UPDATE memos SET idx = idx - ? + ? WHERE idx >= ?",
@@ -1123,8 +1176,8 @@ def config_show(ctx: typer.Context) -> None:
     key_width = max(len(k) for k in _ALL_KEYS)
     src_labels = {
         "default": "[dim]default[/dim]",
-        "file":    "[green]file[/green]",
-        "env":     "[cyan]env[/cyan]",
+        "file": "[green]file[/green]",
+        "env": "[cyan]env[/cyan]",
     }
     for dotkey in _ALL_KEYS:
         val = ConfigManager.get(config, dotkey)
@@ -1140,9 +1193,7 @@ def config_get(
 ) -> None:
     """Print a single config value (plain text, for scripting)."""
     if key not in _ALL_KEYS:
-        exit_error(
-            f"Unknown key: {key!r}. Valid keys: {', '.join(sorted(_ALL_KEYS))}"
-        )
+        exit_error(f"Unknown key: {key!r}. Valid keys: {', '.join(sorted(_ALL_KEYS))}")
     sys.stdout.write(str(ConfigManager.get(config, key)) + "\n")
 
 
@@ -1153,9 +1204,7 @@ def config_set_cmd(
 ) -> None:
     """Write a setting to the config file."""
     if key not in _ALL_KEYS:
-        exit_error(
-            f"Unknown key: {key!r}. Valid keys: {', '.join(sorted(_ALL_KEYS))}"
-        )
+        exit_error(f"Unknown key: {key!r}. Valid keys: {', '.join(sorted(_ALL_KEYS))}")
     try:
         coerced = ConfigManager.coerce(key, value)
         ConfigManager.validate(key, coerced)
@@ -1179,9 +1228,7 @@ def config_unset(
 ) -> None:
     """Remove a key from the config file (reverts to default)."""
     if key not in _ALL_KEYS:
-        exit_error(
-            f"Unknown key: {key!r}. Valid keys: {', '.join(sorted(_ALL_KEYS))}"
-        )
+        exit_error(f"Unknown key: {key!r}. Valid keys: {', '.join(sorted(_ALL_KEYS))}")
     sec, subkey = key.split(".", 1)
     try:
         file_data = _config_manager.read_raw()

--- a/src/koda/models.py
+++ b/src/koda/models.py
@@ -12,14 +12,15 @@ class MemoRow:
     database layer: id, uid, idx, content, tags, shortcut, created_at,
     modified_at.
     """
+
     id: int
     uid: str
     idx: int
-    content: Optional[str]
-    tags: Optional[str]
-    shortcut: Optional[str]
-    created_at: Optional[str]
-    modified_at: Optional[str] = ""
+    content: str | None
+    tags: str | None
+    shortcut: str | None
+    created_at: str | None
+    modified_at: str | None = ""
 
     @classmethod
     def from_row(cls, row) -> Optional["MemoRow"]:

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -7,8 +7,6 @@ CLI as a real subprocess and inspect its output.
 import subprocess
 import sys
 
-import pytest
-
 from koda.db import MemoDatabase
 
 ENV_KEYS = ("PATH", "HOME")
@@ -53,7 +51,7 @@ def test_three_line_script_runs_in_one_shell(tmp_path):
 
 
 def test_for_loop_body(tmp_path):
-    result = _run_x(tmp_path, "for i in 1 2 3; do\n  echo \"n=$i\"\ndone")
+    result = _run_x(tmp_path, 'for i in 1 2 3; do\n  echo "n=$i"\ndone')
     assert result.returncode == 0, result.stderr
     assert result.stdout.split() == ["n=1", "n=2", "n=3"]
 

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -54,10 +54,7 @@ def test_dump_is_sorted_by_uid(db):
 
 
 def test_load_dedup_keeps_last_line():
-    data = (
-        b'{"uid":"uid0001","idx":0,"content":"old"}\n'
-        b'{"uid":"uid0001","idx":0,"content":"new"}\n'
-    )
+    data = b'{"uid":"uid0001","idx":0,"content":"old"}\n{"uid":"uid0001","idx":0,"content":"new"}\n'
     loaded = GitSyncPayload.load(data)
     assert len(loaded) == 1
     assert loaded[0]["content"] == "new"

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -3,8 +3,15 @@
 from koda.git_sync import MemoMerger
 
 
-def entry(uid, idx, content="body", tags="", shortcut=None,
-          created_at="2026-01-01 00:00:00", modified_at=None):
+def entry(
+    uid,
+    idx,
+    content="body",
+    tags="",
+    shortcut=None,
+    created_at="2026-01-01 00:00:00",
+    modified_at=None,
+):
     return {
         "uid": uid,
         "idx": idx,
@@ -90,11 +97,13 @@ def test_shortcut_kept_when_owned_by_same_uid(db):
 
 def test_batch_mixed_outcomes(db):
     db.add_memo("uid0001", 0, None, "existing", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
-    inserted, updated, skipped, _ = MemoMerger(db).merge([
-        entry("uid0002", 1, content="brand-new"),
-        entry("uid0001", 0, content="updated", modified_at="2026-05-01 00:00:00"),
-        entry("uid0003", 2, content="another-new"),
-    ])
+    inserted, updated, skipped, _ = MemoMerger(db).merge(
+        [
+            entry("uid0002", 1, content="brand-new"),
+            entry("uid0001", 0, content="updated", modified_at="2026-05-01 00:00:00"),
+            entry("uid0003", 2, content="another-new"),
+        ]
+    )
     assert inserted == 2
     assert updated == 1
     assert skipped == 0

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -77,7 +77,7 @@ class TestStripInlineComment:
         assert _strip_inline_comment('echo "a # b"') == 'echo "a # b"'
 
     def test_escaped_quote_handled(self):
-        assert _strip_inline_comment(r'echo \# literal') == r'echo \# literal'
+        assert _strip_inline_comment(r"echo \# literal") == r"echo \# literal"
 
     def test_no_comment(self):
         assert _strip_inline_comment("plain text") == "plain text"

--- a/uv.lock
+++ b/uv.lock
@@ -189,6 +189,7 @@ turso = [
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -203,6 +204,7 @@ provides-extras = ["turso"]
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 
 [[package]]
@@ -318,6 +320,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
+    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
+    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Implements **E3-2** (sub-issue of Epic #38): introduce ruff for linting and formatting.

- Add `[tool.ruff]` (`line-length = 100`), `[tool.ruff.lint]` (`select = ["E", "F", "I", "UP"]`) and `[tool.ruff.format]` to `pyproject.toml`; add `ruff` to the dev dependency group.
- Apply ruff autofixes (PEP 585/604 annotations, import sorting, unused-import removal) and `ruff format` across `src` and `tests`.
- Wrap long string literals / docstrings to satisfy `E501` with no behavior change.
- Add a **Development** section to the README documenting `pytest`, `ruff check`, and `ruff format`.

## Acceptance criteria
- [x] `pyproject.toml` has ruff config (`line-length = 100`, `select = ["E","F","I","UP"]`)
- [x] `[tool.ruff.format]` configured
- [x] `uv run ruff check src tests` passes
- [x] README Development section mentions `ruff check`

## Verification
- `uv run ruff check src tests` → All checks passed!
- `uv run ruff format --check src tests` → already formatted
- `uv run pytest` → 125 passed

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)