### PR TITLE
feat(db): add PRAGMA user_version migration framework (#61)

### DIFF
--- a/src/koda/db.py
+++ b/src/koda/db.py
@@ -2,7 +2,7 @@
 
 import os
 import sqlite3
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -36,6 +36,44 @@ VALID_SORT_COLUMNS = {
 
 class DatabaseError(RuntimeError):
     """Backend configuration error (missing driver, missing URL, etc.)."""
+
+
+def _migration_0001_initial_schema(conn) -> None:
+    """Create the memos table, ensure the shortcut column and its index.
+
+    This is the schema that predates versioning, so every statement is
+    idempotent: applying it to an already-migrated database is a no-op,
+    while a fresh database gets the full current schema.
+    """
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS memos (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            uid         TEXT UNIQUE,
+            idx         INTEGER UNIQUE,
+            shortcut    TEXT,
+            content     TEXT,
+            tags        TEXT,
+            created_at  TIMESTAMP,
+            modified_at TIMESTAMP
+        )
+    """)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(memos)").fetchall()}
+    if "shortcut" not in cols:
+        conn.execute("ALTER TABLE memos ADD COLUMN shortcut TEXT")
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_memos_shortcut "
+        "ON memos(shortcut) WHERE shortcut IS NOT NULL"
+    )
+
+
+# Ordered list of schema migrations. Each entry N (0-based) advances the
+# database from PRAGMA user_version N to N+1. Append new migrations to the
+# end; never reorder or rewrite an existing one.
+_MIGRATIONS: list[Callable[[sqlite3.Connection], None]] = [
+    _migration_0001_initial_schema,
+]
+
+SCHEMA_VERSION = len(_MIGRATIONS)
 
 
 class MemoDatabase:
@@ -89,32 +127,29 @@ class MemoDatabase:
                 conn.close()
 
     def init_db(self) -> None:
-        """Create the memos table and required indexes if missing."""
+        """Bring the schema up to date by applying pending migrations."""
         if self.backend == "local" and self.path is not None:
             self.path.parent.mkdir(parents=True, exist_ok=True)
             os.chmod(self.path.parent, 0o700)
         with self.connection() as conn:
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS memos (
-                    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-                    uid         TEXT UNIQUE,
-                    idx         INTEGER UNIQUE,
-                    shortcut    TEXT,
-                    content     TEXT,
-                    tags        TEXT,
-                    created_at  TIMESTAMP,
-                    modified_at TIMESTAMP
-                )
-            """)
-            cols = {row[1] for row in conn.execute("PRAGMA table_info(memos)").fetchall()}
-            if "shortcut" not in cols:
-                conn.execute("ALTER TABLE memos ADD COLUMN shortcut TEXT")
-            conn.execute(
-                "CREATE UNIQUE INDEX IF NOT EXISTS idx_memos_shortcut "
-                "ON memos(shortcut) WHERE shortcut IS NOT NULL"
-            )
+            self._apply_migrations(conn)
         if self.backend == "local" and self.path is not None:
             os.chmod(self.path, 0o600)
+
+    @staticmethod
+    def _apply_migrations(conn) -> None:
+        """Run any migrations newer than the DB's PRAGMA user_version.
+
+        user_version starts at 0 (the default for databases created before
+        versioning existed, and for brand-new ones). Migration N takes the
+        schema from version N to N+1; we run them in order and bump
+        user_version after each so a crash mid-upgrade resumes cleanly.
+        """
+        current = conn.execute("PRAGMA user_version").fetchone()[0]
+        for version in range(current, len(_MIGRATIONS)):
+            _MIGRATIONS[version](conn)
+            # PRAGMA does not accept bound parameters; version is a trusted int.
+            conn.execute(f"PRAGMA user_version = {version + 1}")
 
     @staticmethod
     def next_idx(conn) -> int:

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,72 @@
+"""Schema migration framework tests (E3-6)."""
+
+import sqlite3
+
+from koda.db import SCHEMA_VERSION, MemoDatabase
+
+
+def _user_version(db: MemoDatabase) -> int:
+    with db.connection() as conn:
+        return conn.execute("PRAGMA user_version").fetchone()[0]
+
+
+def _columns(db: MemoDatabase) -> set[str]:
+    with db.connection() as conn:
+        return {row[1] for row in conn.execute("PRAGMA table_info(memos)").fetchall()}
+
+
+def test_fresh_init_applies_all_migrations(tmp_path):
+    db = MemoDatabase(backend="local", path=tmp_path / "fresh.db")
+    db.init_db()
+
+    assert _user_version(db) == SCHEMA_VERSION
+    assert {"id", "uid", "idx", "shortcut", "content", "tags"} <= _columns(db)
+
+
+def test_up_migration_from_pre_versioning_schema(tmp_path):
+    """A pre-versioning DB (no shortcut column, user_version 0) upgrades cleanly."""
+    old_path = tmp_path / "old.db"
+    conn = sqlite3.connect(old_path)
+    conn.execute(
+        """
+        CREATE TABLE memos (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            uid         TEXT UNIQUE,
+            idx         INTEGER UNIQUE,
+            content     TEXT,
+            tags        TEXT,
+            created_at  TIMESTAMP,
+            modified_at TIMESTAMP
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO memos (uid, idx, content, tags, created_at, modified_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("abc1234", 0, "legacy entry", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00"),
+    )
+    conn.commit()
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 0
+    assert "shortcut" not in {r[1] for r in conn.execute("PRAGMA table_info(memos)").fetchall()}
+    conn.close()
+
+    db = MemoDatabase(backend="local", path=old_path)
+    db.init_db()
+
+    assert _user_version(db) == SCHEMA_VERSION
+    assert "shortcut" in _columns(db)
+    # Existing data survives the migration.
+    row = db.get_memo_by_uid("abc1234")
+    assert row is not None and row.content == "legacy entry"
+
+
+def test_init_db_is_idempotent(tmp_path):
+    db = MemoDatabase(backend="local", path=tmp_path / "idem.db")
+    db.init_db()
+    db.add_memo("uid0001", 0, "sc", "content", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+
+    # Re-running init_db must not error, re-run migrations, or drop data.
+    db.init_db()
+
+    assert _user_version(db) == SCHEMA_VERSION
+    assert db.get_memo_by_uid("uid0001") is not None


### PR DESCRIPTION
## Summary
Implements **E3-6** (sub-issue of Epic #38): a real schema-migration framework.

The old `init_db` had a single hard-coded `ALTER TABLE ... ADD COLUMN shortcut` branch — it could only express one schema change and had no way to track or apply future ones.

- Add an ordered `_MIGRATIONS: list[Callable[[sqlite3.Connection], None]]` plus `SCHEMA_VERSION`. Each entry N takes the DB from `user_version` N to N+1.
- `init_db()` reads `PRAGMA user_version` and runs only the pending migrations, bumping the version after each one (crash-safe resume).
- The existing `CREATE TABLE` / shortcut `ALTER` / unique-index logic is ported verbatim into the first migration and remains idempotent for already-migrated databases.

## Acceptance criteria
- [x] `_MIGRATIONS: list[Callable[[sqlite3.Connection], None]]` defined
- [x] `init_db` reads `PRAGMA user_version` and applies pending migrations in order
- [x] existing ALTER logic ported into the first migration
- [x] test: up-migration from an old schema

## Verification
- `uv run pytest` → 131 passed (3 new in `test_migrations.py`)
- `uv run ruff check src tests` → All checks passed!
- Manual: a freshly created DB reports `PRAGMA user_version = 1`.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)