### PR TITLE
ci: add GitHub Actions workflow (lint + test on Python 3.10/3.11/3.12) (#58)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: lint + test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Lint (ruff check)
+        run: uv run ruff check src tests
+
+      - name: Format check (ruff format)
+        run: uv run ruff format --check src tests
+
+      - name: Import has no side effects (env-free)
+        run: env -i "$PWD/.venv/bin/python" -c "import koda.main; print('import OK')"
+
+      - name: Test (pytest)
+        run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # koda-cli
 
+[![CI](https://github.com/ngt22/koda-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/ngt22/koda-cli/actions/workflows/ci.yml)
+
 A **text store** for the terminal. Save any text — commands, paths, templates, notes — to SQLite and recall it instantly by index, shortcut, or fuzzy search. Saved entries can be executed as shell commands, making koda a **terminal launcher**. Sync via a private Git repository to share the same store across machines, giving you a **cross-machine clipboard** that works from any terminal. Built with Python, Typer, and Rich.
 
 ## Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 dependencies = [
     "typer>=0.12.3",
     "rich>=13.7.1",
+    "tomli>=2.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/src/koda/config.py
+++ b/src/koda/config.py
@@ -3,13 +3,18 @@
 import json
 import os
 import shutil
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Any
 
-import tomllib
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # Python 3.10 has no stdlib tomllib; fall back to the tomli backport.
+    import tomli as tomllib
+
 from rich.console import Console
 
 console = Console()

--- a/uv.lock
+++ b/uv.lock
@@ -177,6 +177,7 @@ version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typer" },
 ]
 
@@ -196,6 +197,7 @@ dev = [
 requires-dist = [
     { name = "libsql-experimental", marker = "extra == 'turso'", specifier = ">=0.0.1" },
     { name = "rich", specifier = ">=13.7.1" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "typer", specifier = ">=0.12.3" },
 ]
 provides-extras = ["turso"]


### PR DESCRIPTION
## Summary
Implements **E3-3** (sub-issue of Epic #38): continuous integration.

Adds `.github/workflows/ci.yml`, triggered on pushes to `main` and on all pull requests.

- **Matrix:** Python 3.10 / 3.11 / 3.12 (`fail-fast: false`).
- **Steps:** install uv → `uv sync --all-extras` → `ruff check src tests` → `ruff format --check src tests` → env-free `import koda.main` smoke test → `pytest`.
- The env-free import step (`env -i .venv/bin/python -c "import koda.main"`) enforces the no-import-time-side-effects guarantee from #60.
- Adds a CI status badge to the top of the README.

## Acceptance criteria
- [x] `.github/workflows/ci.yml` created
- [x] matrix: Python 3.10 / 3.11 / 3.12
- [x] steps: `uv sync --all-extras` → `ruff check` → `pytest`
- [x] triggers on PR + push to main
- [x] README build badge
- [x] (from #60) env-free `python -c "import koda.main"` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)