### PR TITLE
chore(dev): add pre-commit config (#59)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# See https://pre-commit.com for usage. Install the git hook with:
+#   uvx pre-commit install
+default_install_hook_types: [pre-commit]
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.16
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-toml

--- a/README.md
+++ b/README.md
@@ -1051,6 +1051,14 @@ uv run ruff format src tests  # auto-format
 Lint and format are configured under `[tool.ruff]` in `pyproject.toml`
 (line length 100; rule sets `E`, `F`, `I`, `UP`).
 
+Optionally install the [pre-commit](https://pre-commit.com) hooks so lint,
+format, and whitespace checks run automatically before each commit:
+
+```bash
+uvx pre-commit install        # set up the git hook (one time)
+uvx pre-commit run --all-files  # run all hooks on demand
+```
+
 ---
 
 ## License


### PR DESCRIPTION
## Summary
Implements **E3-4** (sub-issue of Epic #38): pre-commit hooks.

Adds `.pre-commit-config.yaml` so linting, formatting, and basic file hygiene run automatically before each commit.

- **astral-sh/ruff-pre-commit** (`v0.15.16`, matching the dev group): `ruff-check --fix` and `ruff-format`.
- **pre-commit/pre-commit-hooks** (`v5.0.0`): `end-of-file-fixer`, `trailing-whitespace`, `check-toml`.
- Documents `uvx pre-commit install` / `run --all-files` in the README Development section.

A standalone `CONTRIBUTING.md` is intentionally left to E4-2 (#63); the install step is documented in the README in the meantime.

## Acceptance criteria
- [x] `.pre-commit-config.yaml` created
- [x] hooks: ruff, ruff-format, end-of-file-fixer, trailing-whitespace, check-toml
- [x] `pre-commit install` documented (README now; CONTRIBUTING.md under #63)

## Verification
- `uvx pre-commit run --all-files` → all 5 hooks Passed
- `uv run ruff check src tests` → All checks passed!
- `uv run pytest` → 131 passed

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)