### PR TITLE
chore(models): drop dead 7-column fallback in MemoRow.from_row

### DIFF
--- a/src/koda/models.py
+++ b/src/koda/models.py
@@ -26,6 +26,5 @@ class MemoRow:
     def from_row(cls, row) -> Optional["MemoRow"]:
         if row is None:
             return None
-        if len(row) == 7:
-            return cls(*row, modified_at="")
+        assert len(row) == 8, f"expected 8 columns, got {len(row)}"
         return cls(*row)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,34 @@
+"""Tests for koda data models."""
+
+import pytest
+
+from koda.models import MemoRow
+
+# Canonical 8-column row matching _MEMO_COLUMNS in db.py:
+# id, uid, idx, content, tags, shortcut, created_at, modified_at
+_ROW = (1, "abc1234", 5, "hello", "work,home", "hi", "2026-01-01 00:00:00", "2026-01-02 00:00:00")
+
+
+class TestFromRow:
+    def test_none_returns_none(self):
+        assert MemoRow.from_row(None) is None
+
+    def test_eight_columns_materializes(self):
+        memo = MemoRow.from_row(_ROW)
+        assert memo is not None
+        assert memo.id == 1
+        assert memo.uid == "abc1234"
+        assert memo.idx == 5
+        assert memo.content == "hello"
+        assert memo.tags == "work,home"
+        assert memo.shortcut == "hi"
+        assert memo.created_at == "2026-01-01 00:00:00"
+        assert memo.modified_at == "2026-01-02 00:00:00"
+
+    def test_seven_columns_raises_assertion(self):
+        with pytest.raises(AssertionError):
+            MemoRow.from_row(_ROW[:7])
+
+    def test_nine_columns_raises_assertion(self):
+        with pytest.raises(AssertionError):
+            MemoRow.from_row((*_ROW, "extra"))


### PR DESCRIPTION
## Summary
`_MEMO_COLUMNS` always projects 8 columns (`id, uid, idx, content, tags, shortcut, created_at, modified_at`), so the `if len(row) == 7:` fallback in `MemoRow.from_row` was dead code. Worse, its presence implied that 7-column SELECTs were a supported input shape, which they are not.

- Remove the 7-column branch.
- Replace with `assert len(row) == 8` to fail fast on any unexpected projection (a programming error in the DB layer, not user input).
- Add `tests/test_models.py` covering the 8-column happy path, `None`, and assertion firing on 7- and 9-column rows.

## Test
- `uv run ruff check src tests` / `ruff format --check` — clean
- `uv run pytest` — 135 passed

Closes #54 (E2-6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)