### PR TITLE
fix(tag): report accurate add/remove counts in completion message

### DIFF
--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -955,6 +955,8 @@ def tag(
     remove_list = parse_tag_args(untag)
 
     updated = 0
+    added_count = 0
+    removed_count = 0
     with get_db().connection() as conn:
         for idx in idx_list:
             row = conn.execute("SELECT id, tags FROM memos WHERE idx = ?", (idx,)).fetchone()
@@ -963,24 +965,26 @@ def tag(
                 continue
             row_id, current_tags = row
             current = [t for t in (current_tags or "").split(TAG_SEPARATOR) if t.strip()]
-            new_tags = [t for t in current if t not in remove_list]
-            new_tags = new_tags + [t for t in add_list if t not in new_tags]
+            removed = [t for t in current if t in remove_list]
+            kept = [t for t in current if t not in remove_list]
+            added = [t for t in add_list if t not in kept]
+            new_tags = kept + added
+            if new_tags == current:
+                continue
             conn.execute(
                 "UPDATE memos SET tags = ? WHERE id = ?",
                 (TAG_SEPARATOR.join(new_tags), row_id),
             )
             updated += 1
+            added_count += len(added)
+            removed_count += len(removed)
 
-    parts = []
-    if add_list:
-        parts.append(f"Added to {updated} entr{'y' if updated == 1 else 'ies'}")
-    if remove_list:
-        parts.append(
-            f"removed from {updated} entr{'y' if updated == 1 else 'ies'}"
-            if add_list
-            else f"Removed from {updated} entr{'y' if updated == 1 else 'ies'}"
-        )
-    console.print(f"[green]{'; '.join(parts)}.[/green]")
+    entry_word = "entry" if updated == 1 else "entries"
+    console.print(
+        f"[green]Updated {updated} {entry_word} "
+        f"(added {added_count} tag{'' if added_count == 1 else 's'}, "
+        f"removed {removed_count} tag{'' if removed_count == 1 else 's'}).[/green]"
+    )
 
 
 @app.command(name="move")

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -1,0 +1,68 @@
+"""Tests for the `tag` command completion message (#55).
+
+The old message reported "Added to N entries; removed from N entries" where N
+was a single loop counter, so add and remove counts were always identical even
+when a tag was only added (e.g. removing a tag the entry never had). The fixed
+message reports actual per-tag add/remove totals.
+"""
+
+import pytest
+
+import koda.main as main
+from koda.constants import TAG_SEPARATOR
+
+
+@pytest.fixture
+def wired_db(db, monkeypatch):
+    """Point koda.main's lazy DB cache at a fresh temp database."""
+    monkeypatch.setattr(main, "_db", db)
+    return db
+
+
+def _seed(db, idx, tags):
+    db.add_memo(
+        uid=f"uid{idx:04d}",
+        idx=idx,
+        shortcut=None,
+        content=f"entry {idx}",
+        tags=TAG_SEPARATOR.join(tags),
+        created_at="2026-01-01 00:00:00",
+        modified_at="2026-01-01 00:00:00",
+    )
+
+
+def _tags(db, idx):
+    row = db.get_memo_by_idx(idx)
+    return [t for t in (row.tags or "").split(TAG_SEPARATOR) if t.strip()]
+
+
+def test_add_and_remove_counts_differ(wired_db, capsys):
+    """Only some entries actually have the tag being removed: counts must differ."""
+    _seed(wired_db, 1, ["bar"])
+    _seed(wired_db, 2, [])
+    _seed(wired_db, 3, ["bar"])
+
+    main.tag(indices=["1", "2", "3"], tags=["foo"], untag=["bar"])
+
+    out = capsys.readouterr().out
+    # foo added to all 3 entries; bar removed only from entries 1 and 3.
+    assert "Updated 3 entries (added 3 tags, removed 2 tags)." in out
+    assert _tags(wired_db, 1) == ["foo"]
+    assert _tags(wired_db, 2) == ["foo"]
+    assert _tags(wired_db, 3) == ["foo"]
+
+
+def test_singular_wording(wired_db, capsys):
+    _seed(wired_db, 1, [])
+    main.tag(indices=["1"], tags=["solo"], untag=None)
+    out = capsys.readouterr().out
+    assert "Updated 1 entry (added 1 tag, removed 0 tags)." in out
+
+
+def test_noop_when_nothing_changes(wired_db, capsys):
+    """Adding a tag the entry already has, or removing one it lacks, is a no-op."""
+    _seed(wired_db, 1, ["keep"])
+    main.tag(indices=["1"], tags=["keep"], untag=["absent"])
+    out = capsys.readouterr().out
+    assert "Updated 0 entries (added 0 tags, removed 0 tags)." in out
+    assert _tags(wired_db, 1) == ["keep"]


### PR DESCRIPTION
## Summary
`koda tag` printed `Added to N entries; removed from N entries` where `N` was a single loop counter (`updated`), incremented once per processed entry. Because the same counter fed both halves, the add and remove counts were **always identical** — even when a tag was added to more entries than it was removed from.

### Example of the bug
Entries: idx 1 = `bar`, idx 2 = (no tags), idx 3 = `bar`.

```
koda tag 1 2 3 -t foo -T bar
```

`foo` is added to all 3 entries, but `bar` is only removed from entries 1 and 3 (entry 2 never had it). The old message nonetheless reported `removed from 3 entries`.

### Fix
- Track `added_count` / `removed_count` as actual per-tag change totals.
- Count an entry as updated only when its tag set actually changes (skip no-op writes).
- New message: `Updated N entries (added X tags, removed Y tags).`, with singular/plural wording.

For the example above it now prints: `Updated 3 entries (added 3 tags, removed 2 tags).`

## Test
- New `tests/test_tag.py`: divergent add/remove counts, singular wording, no-op case.
- `uv run ruff check src tests` / `ruff format --check` — clean
- `uv run pytest` — 138 passed

Closes #55 (E2-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)