### PR TITLE
refactor(config): move config-edit template to config.py

### DIFF
--- a/src/koda/config.py
+++ b/src/koda/config.py
@@ -56,6 +56,33 @@ GIT_SYNC_FORMAT_JSONL = "jsonl"
 EXEC_SHELL_ALLOWLIST = ("sh", "bash", "zsh", "fish")
 
 
+# Commented-out scaffold written to a fresh config file by `koda config edit`.
+EXAMPLE_TEMPLATE = (
+    "# Koda configuration\n"
+    "# Uncomment and edit values to override defaults.\n\n"
+    "# [defaults]\n"
+    '# cmd = "raw"      # "raw" or "list"\n\n'
+    "# [list]\n"
+    "# per_page = 20\n"
+    "# rows = 1         # 0 = all lines\n"
+    "# truncate = 80    # 0 = no truncation\n"
+    '# sort_by = "idx"\n'
+    "# desc = false\n\n"
+    "# [db]\n"
+    f'# path = "{DEFAULT_DB_PATH}"\n'
+    '# backend = "local"   # "local" or "turso"\n\n'
+    "# [turso]\n"
+    '# url = "libsql://your-db.turso.io"   # or set KODA_TURSO_URL\n'
+    '# token = "your-auth-token"            # or set KODA_TURSO_TOKEN\n\n'
+    "# [git]\n"
+    '# sync_path = "/path/to/koda-sync-repo"    # clone root, or use KODA_GIT_SYNC_PATH\n'
+    '# payload_file = "koda-sync.jsonl"         # relative to sync_path (JSON Lines)\n'
+    '# sync_format = "jsonl"                     # or KODA_GIT_SYNC_FORMAT\n\n'
+    "# [exec]\n"
+    '# shell = "sh"\n'
+)
+
+
 def valid_exec_shell(v: Any) -> bool:
     """True if ``v`` names an allowlisted shell that resolves to an existing
     absolute executable. Guards `koda x` against arbitrary-binary redirection

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -29,7 +29,7 @@ from .config import (
 from .config import (
     COLUMN_DEFS,
     CONFIG_PATH,
-    DEFAULT_DB_PATH,
+    EXAMPLE_TEMPLATE,
     VALID_LIST_COLUMNS,
     VALID_SORT_COLUMNS,
     Config,
@@ -1316,31 +1316,7 @@ def config_edit_cmd() -> None:
     """Open the config file in $EDITOR."""
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     if not CONFIG_PATH.exists():
-        template = (
-            "# Koda configuration\n"
-            "# Uncomment and edit values to override defaults.\n\n"
-            "# [defaults]\n"
-            '# cmd = "raw"      # "raw" or "list"\n\n'
-            "# [list]\n"
-            "# per_page = 20\n"
-            "# rows = 1         # 0 = all lines\n"
-            "# truncate = 80    # 0 = no truncation\n"
-            '# sort_by = "idx"\n'
-            "# desc = false\n\n"
-            "# [db]\n"
-            f'# path = "{DEFAULT_DB_PATH}"\n'
-            '# backend = "local"   # "local" or "turso"\n\n'
-            "# [turso]\n"
-            '# url = "libsql://your-db.turso.io"   # or set KODA_TURSO_URL\n'
-            '# token = "your-auth-token"            # or set KODA_TURSO_TOKEN\n\n'
-            "# [git]\n"
-            '# sync_path = "/path/to/koda-sync-repo"    # clone root, or use KODA_GIT_SYNC_PATH\n'
-            '# payload_file = "koda-sync.jsonl"         # relative to sync_path (JSON Lines)\n'
-            '# sync_format = "jsonl"                     # or KODA_GIT_SYNC_FORMAT\n\n'
-            "# [exec]\n"
-            '# shell = "sh"\n'
-        )
-        CONFIG_PATH.write_text(template, encoding="utf-8")
+        CONFIG_PATH.write_text(EXAMPLE_TEMPLATE, encoding="utf-8")
     editor = os.environ.get("EDITOR", "vim")
     subprocess.call([editor, str(CONFIG_PATH)])
 


### PR DESCRIPTION
## Summary
The commented-out config scaffold that `koda config edit` writes to a fresh config file was a large inline string literal inside `config_edit_cmd` in `main.py`. Move it to `config.py` as a module-level `EXAMPLE_TEMPLATE` constant and import it from `main.py`.

- `config.py` already owns `DEFAULT_DB_PATH` (which the template interpolates), so the constant is now colocated with the config defaults it documents.
- `main.py` drops its now-unused `DEFAULT_DB_PATH` import in favor of `EXAMPLE_TEMPLATE`.
- No behavior change — the written template bytes are identical.

## Test
- `uv run ruff check src tests` / `ruff format --check` — clean
- Sanity check: `EXAMPLE_TEMPLATE` contains the `[exec]` section and `path =` line
- `uv run pytest` — 138 passed

Closes #85 (E7-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)