### PR TITLE
refactor(db): merge get_memos and get_memos_all into one method

### DIFF
--- a/src/koda/cmd_helpers/interactive.py
+++ b/src/koda/cmd_helpers/interactive.py
@@ -29,7 +29,7 @@ def pick_candidates(
         valid = ", ".join(sorted(VALID_SORT_COLUMNS))
         exit_error(f"Invalid --sort-by '{sort_by}'. Use one of: {valid}.")
     effective_desc = config.list_desc if desc is None else desc
-    return db.get_memos_all(
+    return db.get_memos(
         query=query,
         tag=tag,
         exclude_tag=exclude_tag,

--- a/src/koda/db.py
+++ b/src/koda/db.py
@@ -181,19 +181,24 @@ class MemoDatabase:
         tag=None,
         exclude_tag=None,
         shortcuts_only=False,
-        limit=20,
-        offset=0,
+        limit: int | None = None,
+        offset: int = 0,
         sort_by="idx",
         desc=False,
     ) -> list[MemoRow]:
+        """Return filtered, ordered memos. ``limit=None`` returns every match
+        (formerly ``get_memos_all``); a non-None ``limit`` paginates via
+        ``LIMIT/OFFSET``."""
         order_column = sort_by if sort_by in VALID_SORT_COLUMNS else "idx"
         order_direction = "DESC" if desc else "ASC"
         where_sql, params = self._filters(query, tag, exclude_tag, shortcuts_only)
         sql = (
             f"SELECT {self._MEMO_COLUMNS} FROM memos"
-            f"{where_sql} ORDER BY {order_column} {order_direction}, id ASC LIMIT ? OFFSET ?"
+            f"{where_sql} ORDER BY {order_column} {order_direction}, id ASC"
         )
-        params = params + (limit, offset)
+        if limit is not None:
+            sql += " LIMIT ? OFFSET ?"
+            params = params + (limit, offset)
         with self.connection() as conn:
             return [MemoRow.from_row(r) for r in conn.execute(sql, params).fetchall()]
 
@@ -202,25 +207,6 @@ class MemoDatabase:
         sql = f"SELECT COUNT(*), MAX(idx) FROM memos{where_sql}"
         with self.connection() as conn:
             return conn.execute(sql, params).fetchone()
-
-    def get_memos_all(
-        self,
-        query=None,
-        tag=None,
-        exclude_tag=None,
-        shortcuts_only=False,
-        sort_by="idx",
-        desc=False,
-    ) -> list[MemoRow]:
-        order_column = sort_by if sort_by in VALID_SORT_COLUMNS else "idx"
-        order_direction = "DESC" if desc else "ASC"
-        where_sql, params = self._filters(query, tag, exclude_tag, shortcuts_only)
-        sql = (
-            f"SELECT {self._MEMO_COLUMNS} FROM memos"
-            f"{where_sql} ORDER BY {order_column} {order_direction}, id ASC"
-        )
-        with self.connection() as conn:
-            return [MemoRow.from_row(r) for r in conn.execute(sql, params).fetchall()]
 
     def get_latest_entry(self) -> MemoRow | None:
         with self.connection() as conn:

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -458,7 +458,7 @@ def rm(
                 else:
                     target_rows.append(row)
         else:
-            target_rows = get_db().get_memos_all(query=query, tag=tag, sort_by="idx")
+            target_rows = get_db().get_memos(query=query, tag=tag, sort_by="idx")
 
         if not target_rows:
             console.print("[yellow]No matching entries.[/yellow]")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,69 @@
+"""Tests for MemoDatabase.get_memos (unified limit/offset query, #83)."""
+
+from koda.constants import TAG_SEPARATOR
+
+
+def _seed(db, idx, content, tags=()):
+    db.add_memo(
+        uid=f"uid{idx:04d}",
+        idx=idx,
+        shortcut=None,
+        content=content,
+        tags=TAG_SEPARATOR.join(tags),
+        created_at="2026-01-01 00:00:00",
+        modified_at="2026-01-01 00:00:00",
+    )
+
+
+def _seed_many(db, n):
+    for i in range(1, n + 1):
+        _seed(db, i, f"entry {i}")
+
+
+class TestGetMemos:
+    def test_limit_none_returns_all(self, db):
+        """limit=None replaces the old get_memos_all behavior."""
+        _seed_many(db, 25)
+        rows = db.get_memos(limit=None)
+        assert [r.idx for r in rows] == list(range(1, 26))
+
+    def test_default_returns_all(self, db):
+        """The default (no limit kwarg) returns every match, not a 20-row page."""
+        _seed_many(db, 25)
+        assert len(db.get_memos()) == 25
+
+    def test_limit_paginates(self, db):
+        _seed_many(db, 25)
+        assert [r.idx for r in db.get_memos(limit=10)] == list(range(1, 11))
+
+    def test_offset(self, db):
+        _seed_many(db, 25)
+        assert [r.idx for r in db.get_memos(limit=10, offset=10)] == list(range(11, 21))
+
+    def test_offset_without_limit_is_ignored(self, db):
+        """offset only applies when limit is set (no LIMIT clause -> no OFFSET)."""
+        _seed_many(db, 5)
+        assert len(db.get_memos(offset=3)) == 5
+
+    def test_desc_ordering(self, db):
+        _seed_many(db, 3)
+        assert [r.idx for r in db.get_memos(desc=True)] == [3, 2, 1]
+
+    def test_query_filter(self, db):
+        _seed(db, 1, "alpha")
+        _seed(db, 2, "beta")
+        rows = db.get_memos(query="alph")
+        assert [r.content for r in rows] == ["alpha"]
+
+    def test_tag_filter(self, db):
+        _seed(db, 1, "a", tags=["work"])
+        _seed(db, 2, "b", tags=["home"])
+        rows = db.get_memos(tag="work")
+        assert [r.idx for r in rows] == [1]
+
+    def test_limited_matches_all_prefix(self, db):
+        """A limited query is exactly the head of the unlimited query."""
+        _seed_many(db, 30)
+        all_rows = db.get_memos(limit=None)
+        page = db.get_memos(limit=7, offset=0)
+        assert [r.uid for r in page] == [r.uid for r in all_rows[:7]]


### PR DESCRIPTION
## Summary
`get_memos` and `get_memos_all` were near-identical — the only difference was the trailing `LIMIT ? OFFSET ?` clause. Collapse them into a single `get_memos` with an optional limit:

- `limit: int | None = None` — `None` returns every match (the old `get_memos_all`); a non-`None` value paginates via `LIMIT/OFFSET` as before.
- `offset` only takes effect when `limit` is set (no `LIMIT` clause → no `OFFSET`).

### Caller updates
- `cmd_helpers/interactive.py` (fzf candidate fetch) → `get_memos` (limit defaults to `None`).
- `main.py` remove-by-filter path → `get_memos`.
- `main.py` `list` path already passes `limit=per_page` explicitly — unchanged.

### Behavior note
The former `get_memos` default of `limit=20` is dropped in favor of `limit=None`. The only paginating caller (`list`) always passes `limit` explicitly, so there is no behavior change.

## Test
- New `tests/test_db.py`: `limit=None`/default return all, pagination, offset, offset-ignored-without-limit, desc ordering, query/tag filters, and that a limited query equals the head of the unlimited query.
- `uv run ruff check src tests` / `ruff format --check` — clean
- `uv run pytest` — 147 passed

Closes #83 (E7-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)