### PR TITLE
refactor(sync): straighten MemoMerger.merge INSERT path

### DIFF
--- a/src/koda/git_sync.py
+++ b/src/koda/git_sync.py
@@ -11,7 +11,7 @@ from rich.console import Console
 from .cli_utils import exit_error
 from .config import GIT_SYNC_FORMAT_JSONL, Config
 from .constants import DATETIME_FMT
-from .db import IntegrityErrors, MemoDatabase
+from .db import MemoDatabase
 
 console = Console()
 
@@ -305,29 +305,35 @@ class GitSyncRepo:
 # ── Merge into local DB ─────────────────────────────────────────────────────
 
 
+def pick_idx(conn, preferred: int) -> int:
+    """Return an idx free for a brand-new row: ``preferred`` if unoccupied,
+    otherwise the next free idx. The memos.idx UNIQUE constraint is therefore
+    satisfied without needing an INSERT retry."""
+    if conn.execute("SELECT 1 FROM memos WHERE idx = ?", (preferred,)).fetchone() is None:
+        return preferred
+    return MemoDatabase.next_idx(conn)
+
+
+def pick_shortcut(conn, uid: str, shortcut: str | None) -> str | None:
+    """Return ``shortcut`` if it is usable for ``uid`` (empty/None, unclaimed,
+    or already owned by this uid), else None. Keeps the partial-unique shortcut
+    index satisfied without needing an INSERT retry."""
+    if shortcut is None or shortcut == "":
+        return shortcut
+    existing = conn.execute("SELECT uid FROM memos WHERE shortcut = ?", (shortcut,)).fetchone()
+    if existing is None:
+        return shortcut
+    (existing_uid,) = existing
+    if existing_uid == uid:
+        return shortcut
+    return None
+
+
 class MemoMerger:
     """Merge remote JSONL entries into the local memos table by uid + modified_at."""
 
     def __init__(self, db: MemoDatabase) -> None:
         self.db = db
-
-    @staticmethod
-    def _shortcut_usable(conn, uid: str, shortcut: str | None) -> str | None:
-        if shortcut is None or shortcut == "":
-            return shortcut
-        existing = conn.execute("SELECT uid FROM memos WHERE shortcut = ?", (shortcut,)).fetchone()
-        if existing is None:
-            return shortcut
-        (existing_uid,) = existing
-        if existing_uid == uid:
-            return shortcut
-        return None
-
-    @staticmethod
-    def _pick_idx(conn, preferred: int) -> int:
-        if conn.execute("SELECT 1 FROM memos WHERE idx = ?", (preferred,)).fetchone() is None:
-            return preferred
-        return MemoDatabase.next_idx(conn)
 
     @staticmethod
     def _apply_idx_for_row(conn, memo_id: int, preferred: int) -> None:
@@ -380,38 +386,20 @@ class MemoMerger:
                     (uid,),
                 ).fetchone()
                 if local_row is None:
-                    pick_idx = self._pick_idx(conn, want_idx)
-                    use_sc = self._shortcut_usable(conn, uid, sc)
+                    # uid is absent (local_row is None), idx and shortcut are
+                    # pre-resolved to free values, so this INSERT cannot violate
+                    # any UNIQUE constraint — no retry needed.
+                    new_idx = pick_idx(conn, want_idx)
+                    use_sc = pick_shortcut(conn, uid, sc)
                     if use_sc is None and sc:
                         shortcut_dropped += 1
-                    try:
-                        conn.execute(
-                            "INSERT INTO memos "
-                            "(uid, idx, shortcut, content, tags, created_at, modified_at) "
-                            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                            (uid, pick_idx, use_sc, content, tags, created_at, modified_at),
-                        )
-                        inserted += 1
-                    except IntegrityErrors:
-                        pick_idx = MemoDatabase.next_idx(conn)
-                        try:
-                            conn.execute(
-                                "INSERT INTO memos "
-                                "(uid, idx, shortcut, content, tags, created_at, modified_at) "
-                                "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                                (uid, pick_idx, use_sc, content, tags, created_at, modified_at),
-                            )
-                            inserted += 1
-                        except IntegrityErrors:
-                            conn.execute(
-                                "INSERT INTO memos "
-                                "(uid, idx, shortcut, content, tags, created_at, modified_at) "
-                                "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                                (uid, pick_idx, None, content, tags, created_at, modified_at),
-                            )
-                            inserted += 1
-                            if use_sc:
-                                shortcut_dropped += 1
+                    conn.execute(
+                        "INSERT INTO memos "
+                        "(uid, idx, shortcut, content, tags, created_at, modified_at) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        (uid, new_idx, use_sc, content, tags, created_at, modified_at),
+                    )
+                    inserted += 1
                     continue
 
                 memo_id = local_row[0]
@@ -422,7 +410,7 @@ class MemoMerger:
                     skipped += 1
                     continue
 
-                use_sc = self._shortcut_usable(conn, uid, sc)
+                use_sc = pick_shortcut(conn, uid, sc)
                 if use_sc is None and sc:
                     shortcut_dropped += 1
                 self._apply_idx_for_row(conn, memo_id, want_idx)

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -1,6 +1,6 @@
 """Tests for MemoMerger.merge: insert / update / skip / conflict paths."""
 
-from koda.git_sync import MemoMerger
+from koda.git_sync import MemoMerger, pick_idx, pick_shortcut
 
 
 def entry(
@@ -107,3 +107,57 @@ def test_batch_mixed_outcomes(db):
     assert inserted == 2
     assert updated == 1
     assert skipped == 0
+
+
+def test_two_new_entries_claim_same_idx(db):
+    """Both remote entries want idx 0; the second must be relocated, not retried."""
+    inserted, _, _, dropped = MemoMerger(db).merge(
+        [entry("uid0001", 0, content="first"), entry("uid0002", 0, content="second")]
+    )
+    assert (inserted, dropped) == (2, 0)
+    idxs = sorted(r.idx for r in db.get_memos(limit=None))
+    assert len(set(idxs)) == 2  # no UNIQUE(idx) collision
+
+
+def test_insert_with_both_idx_and_shortcut_conflict(db):
+    """A new entry colliding on BOTH idx and shortcut: idx relocated, shortcut dropped."""
+    db.add_memo("uid0001", 0, "ab", "owner", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+    inserted, _, _, dropped = MemoMerger(db).merge(
+        [entry("uid0002", 0, content="wants-both", shortcut="ab")]
+    )
+    assert (inserted, dropped) == (1, 1)
+    new_row = db.get_memo_by_uid("uid0002")
+    assert new_row.idx != 0
+    assert new_row.shortcut is None
+
+
+class TestPickIdx:
+    def test_returns_preferred_when_free(self, db):
+        with db.connection() as conn:
+            assert pick_idx(conn, 5) == 5
+
+    def test_returns_next_when_occupied(self, db):
+        db.add_memo("uid0001", 5, None, "x", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+        with db.connection() as conn:
+            assert pick_idx(conn, 5) == 6
+
+
+class TestPickShortcut:
+    def test_none_and_empty_pass_through(self, db):
+        with db.connection() as conn:
+            assert pick_shortcut(conn, "uid0001", None) is None
+            assert pick_shortcut(conn, "uid0001", "") == ""
+
+    def test_unclaimed_is_usable(self, db):
+        with db.connection() as conn:
+            assert pick_shortcut(conn, "uid0001", "ab") == "ab"
+
+    def test_claimed_by_other_uid_is_dropped(self, db):
+        db.add_memo("uid0001", 0, "ab", "owner", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+        with db.connection() as conn:
+            assert pick_shortcut(conn, "uid0002", "ab") is None
+
+    def test_owned_by_same_uid_is_kept(self, db):
+        db.add_memo("uid0001", 0, "ab", "owner", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+        with db.connection() as conn:
+            assert pick_shortcut(conn, "uid0001", "ab") == "ab"


### PR DESCRIPTION
## Summary
The new-entry branch of `MemoMerger.merge` used a three-stage `try/except IntegrityError` retry to deal with `idx` and `shortcut` UNIQUE conflicts. But by the time the INSERT runs:
- `uid` is known absent (we're in the `local_row is None` branch),
- `idx` is pre-resolved to a free value by the idx picker,
- `shortcut` is pre-resolved to a usable value by the shortcut picker.

So the first INSERT can never actually violate a UNIQUE constraint — the second and third stages were dead defensive code that obscured the control flow.

### Changes
- Extract **`pick_idx`** / **`pick_shortcut`** as standalone module-level functions (formerly the `_pick_idx` / `_shortcut_usable` staticmethods), so conflict resolution is independently testable.
- Replace the three-stage retry with a single INSERT after pre-resolving idx + shortcut.
- Remove the now-unused `IntegrityErrors` import from `git_sync.py`.

No behavior change: idx still relocates on conflict, shortcut still drops (and is counted) when claimed by another uid.

## Test
`tests/test_merger.py` additions:
- Two new entries claiming the same idx → second relocated, no collision.
- Entry colliding on **both** idx and shortcut → idx relocated, shortcut dropped + counted.
- Direct unit tests for `pick_idx` (preferred-free / occupied→next) and `pick_shortcut` (None/empty pass-through, unclaimed, other-uid dropped, same-uid kept).

- `uv run ruff check src tests` / `ruff format --check` — clean
- `uv run pytest` — 155 passed

Closes #84 (E7-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)