### PR TITLE
docs: add CONTRIBUTING.md; clarify AI-agent files (#63, #68)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@ wheels/
 htmlcov/
 .pytest_cache/
 
-# AI coding agents
+# AI coding agents — personal, local-only files (see CONTRIBUTING.md).
+# Contributor-facing rules live in CONTRIBUTING.md, not in these.
 AGENTS.md
 CLAUDE.md
 .claude/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to koda-cli
+
+Thanks for your interest in improving koda! This guide covers everything you
+need to send a pull request.
+
+## Development setup
+
+koda is a [uv](https://docs.astral.sh/uv/) + hatchling project targeting Python
+3.10–3.12.
+
+```bash
+# Clone and create an editable environment in .venv
+git clone https://github.com/ngt22/koda-cli.git
+cd koda-cli
+uv sync                       # installs runtime + dev dependencies
+
+# Run the CLI from the project environment
+uv run koda --help
+
+# Install globally the way a user would (optional)
+uv tool install ".[turso]"    # the turso extra is optional
+```
+
+## Running checks
+
+There is no Makefile; run the tools directly. CI runs exactly these on Python
+3.10/3.11/3.12, so green locally means green in CI.
+
+```bash
+uv run pytest                 # tests (with coverage)
+uv run ruff check src tests   # lint
+uv run ruff format src tests  # auto-format (use --check to verify only)
+```
+
+Optionally install the pre-commit hooks so lint/format run on every commit:
+
+```bash
+uvx pre-commit install
+```
+
+## Branch naming
+
+Use a `type/scope` slug, optionally with the issue number:
+
+- `feat/<scope>` — new functionality (e.g. `feat/json-output`)
+- `fix/<issue>` — bug fixes (e.g. `fix/53-empty-content`)
+- `refactor/<scope>` — internal restructuring
+- `docs/<scope>` / `chore/<scope>` / `ci/<scope>` — everything else
+
+## Commit & PR conventions
+
+- Follow [Conventional Commits](https://www.conventionalcommits.org/):
+  `type(scope): summary`, e.g. `feat(cli): add --json output for list`.
+  Common types: `feat`, `fix`, `refactor`, `docs`, `chore`, `ci`, `test`.
+- **Write commit messages and PR titles/bodies in English.** Existing history is
+  mixed Japanese/English; new work must be English.
+- Reference the issue a PR closes with `Closes #<n>` in the body.
+
+## Pull request checklist
+
+Before opening a PR, make sure:
+
+- [ ] `uv run ruff check src tests` passes
+- [ ] `uv run ruff format --check src tests` passes
+- [ ] `uv run pytest` passes
+- [ ] New behavior has tests
+- [ ] `CHANGELOG.md` has an entry under `## [Unreleased]` (see below)
+- [ ] User-facing changes are reflected in `README.md`
+
+## Changelog
+
+We keep a [Keep a Changelog](https://keepachangelog.com/)-style `CHANGELOG.md`.
+Add a bullet under the `## [Unreleased]` section describing your change, grouped
+by `Added` / `Changed` / `Fixed` / `Removed`.
+
+## Language policy
+
+- **Issues** may be written in Japanese or English — whichever is clearer.
+- **Commits, PR titles, and PR bodies must be in English.**
+
+## A note on AI-agent files
+
+`AGENTS.md`, `CLAUDE.md`, and `opencode.json` are **personal, local-only** files
+used by individual maintainers' AI coding agents. They are intentionally listed
+in `.gitignore` and are **not** part of the repository — you do not need them to
+contribute. The canonical, contributor-facing rules live in this file. If you
+use an AI agent, point it here.


### PR DESCRIPTION
## Summary
Adds a contributor guide and resolves the AGENTS.md/opencode.json gitignore question.

**`CONTRIBUTING.md`** covers:
- Dev setup (`uv sync`, `uv run koda`, `uv tool install`)
- Local checks matching CI (`ruff check`, `ruff format`, `pytest`) + optional pre-commit
- Branch naming (`type/scope`) and Conventional Commits
- PR checklist (ruff / pytest / tests / CHANGELOG / README)
- Changelog workflow (Keep a Changelog `## [Unreleased]`)
- Language policy (Issues JP/EN; commits & PRs English)

**`.gitignore`**: `AGENTS.md`, `CLAUDE.md`, and `opencode.json` already exist only locally and were untracked + gitignored — i.e. personal AI-agent files, not committed (the issue's "committed" premise was outdated). Rather than start tracking them, this confirms them as personal/local and moves the canonical contributor rules into `CONTRIBUTING.md`. The `.gitignore` comment now points there.

## Test
Docs/config only — no code paths affected. `ruff`/`pytest` unaffected.

Closes #63 (E4-2)
Closes #68 (E4-7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)