### PR TITLE
chore(github): add issue forms and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report something that isn't working as expected.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Issues may be written in Japanese or English.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: Running `koda ...` produced ... but I expected ...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands you ran.
+      render: shell
+      placeholder: |
+        koda add "example"
+        koda list
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: koda version
+      description: Output of `koda --version`.
+      placeholder: "koda version: 1.2.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Database backend
+      options:
+        - local (sqlite)
+        - turso (libsql)
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: OS and Python version
+      placeholder: "Ubuntu 24.04, Python 3.12"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or idea (Discussions)
+    url: https://github.com/ngt22/koda-cli/discussions
+    about: Ask a question or float an idea before opening an issue.
+  - name: Contributing guide
+    url: https://github.com/ngt22/koda-cli/blob/main/CONTRIBUTING.md
+    about: Dev setup, conventions, and the PR checklist.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest a new command, flag, or behavior.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Issues may be written in Japanese or English.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do that koda doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: The command, flag, or behavior you'd like. Sketch the CLI usage if you can.
+      render: shell
+      placeholder: koda <new-command> --some-flag
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or existing workarounds.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!-- PR titles and descriptions must be in English (see CONTRIBUTING.md). -->
+
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+Closes #
+
+## Checklist
+
+- [ ] `uv run ruff check src tests` passes
+- [ ] `uv run ruff format --check src tests` passes
+- [ ] `uv run pytest` passes
+- [ ] New behavior has tests
+- [ ] `CHANGELOG.md` updated under `## [Unreleased]` (if user-facing)
+- [ ] `README.md` updated (if user-facing)


### PR DESCRIPTION
## Summary
Adds structured GitHub templates so new issues and PRs arrive with the right context.

- `.github/ISSUE_TEMPLATE/bug_report.yml` — description, repro steps, `koda --version`, backend (local/turso), OS+Python.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — motivation, proposed CLI, alternatives.
- `.github/ISSUE_TEMPLATE/config.yml` — links to Discussions and CONTRIBUTING; blank issues still allowed.
- `.github/pull_request_template.md` — summary, `Closes #`, and the CONTRIBUTING checklist (ruff/pytest/tests/CHANGELOG/README).

## Test
Metadata only — no code paths affected.

Closes #64 (E4-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)