### PR TITLE
feat(cli): add --json output for list / show / config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--json` output for `list`, `show`, and `config` for scripting (jq-friendly).
+
 ## [1.2.0] - 2026-06-06
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,27 @@ We keep a [Keep a Changelog](https://keepachangelog.com/)-style `CHANGELOG.md`.
 Add a bullet under the `## [Unreleased]` section describing your change, grouped
 by `Added` / `Changed` / `Fixed` / `Removed`.
 
+## JSON output schema
+
+`list`, `show`, and `config` accept `--json` for scripting.
+
+- `koda list --json` → a JSON **array** of entry objects (all matches, paging
+  ignored). `koda show --json` → a single entry **object**. Each entry object is:
+
+  ```json
+  {
+    "id": 1, "uid": "abc1234", "idx": 0,
+    "content": "…", "tags": ["work", "home"],
+    "shortcut": null, "created_at": "…", "modified_at": "…"
+  }
+  ```
+
+  Note `tags` is a list (split on the stored comma separator).
+
+- `koda config --json` → a hierarchical object `{section: {key: value}}`.
+  `turso.token` is always emitted as `"****"`; use `koda config get turso.token`
+  for the raw value.
+
 ## Language policy
 
 - **Issues** may be written in Japanese or English — whichever is clearer.

--- a/src/koda/commands/config.py
+++ b/src/koda/commands/config.py
@@ -5,6 +5,7 @@ with ``app.add_typer``. It must not import ``koda.main`` so that main can import
 ``config_app`` at assembly time without a circular import.
 """
 
+import json
 import os
 import subprocess
 import sys
@@ -26,9 +27,24 @@ config_app = typer.Typer(
 
 
 @config_app.callback(invoke_without_command=True)
-def config_show(ctx: typer.Context) -> None:
+def config_show(
+    ctx: typer.Context,
+    json_output: bool = typer.Option(
+        False, "--json", help="Output the resolved config as hierarchical JSON."
+    ),
+) -> None:
     """Show all settings with their current values and source."""
     if ctx.invoked_subcommand is not None:
+        return
+    if json_output:
+        out: dict[str, dict[str, object]] = {}
+        for dotkey in _ALL_KEYS:
+            section, _, key = dotkey.partition(".")
+            val = ConfigManager.get(get_config(), dotkey)
+            if dotkey == "turso.token" and val:
+                val = "****"  # never emit the token, consistent with the table view
+            out.setdefault(section, {})[key] = val
+        sys.stdout.write(json.dumps(out, ensure_ascii=False, indent=2) + "\n")
         return
     key_width = max(len(k) for k in _ALL_KEYS)
     src_labels = {

--- a/src/koda/commands/memo.py
+++ b/src/koda/commands/memo.py
@@ -1,6 +1,7 @@
 """Memo CRUD and display commands: add, remove, copy, edit, list, show, raw, tag."""
 
 import hashlib
+import json
 import os
 import re
 import subprocess
@@ -288,6 +289,36 @@ def edit(
         Path(temp_path).unlink(missing_ok=True)
 
 
+def _emit_list_json(
+    query: str | None,
+    tag: str | None,
+    exclude_tag: str | None,
+    shortcuts_only: bool,
+    sort_by: str | None,
+    desc: bool | None,
+) -> None:
+    """Print all matching entries as a JSON array (no paging)."""
+    init_db()
+    if sort_by is None:
+        sort_by = get_config().list_sort_by
+    if desc is None:
+        desc = get_config().list_desc
+    normalized_sort = sort_by.lower()
+    if normalized_sort not in VALID_SORT_COLUMNS:
+        valid = ", ".join(sorted(VALID_SORT_COLUMNS))
+        exit_error(f"Invalid --sort-by '{sort_by}'. Use one of: {valid}.")
+    rows = get_db().get_memos(
+        query,
+        tag,
+        exclude_tag,
+        shortcuts_only,
+        limit=None,
+        sort_by=normalized_sort,
+        desc=desc,
+    )
+    sys.stdout.write(json.dumps([r.to_dict() for r in rows], ensure_ascii=False, indent=2) + "\n")
+
+
 def _list_memos_impl(
     query: str | None = None,
     tag: str | None = None,
@@ -458,8 +489,14 @@ def list_memos(
             f"Available: {', '.join(VALID_LIST_COLUMNS)}. [config: list.columns]"
         ),
     ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Output all matching entries as a JSON array (ignores paging)."
+    ),
 ):
     """Show entries as a table with paging and sortable columns. Alias: `koda l`."""
+    if json_output:
+        _emit_list_json(query, tag, exclude_tag, shortcuts_only, sort_by, desc)
+        return
     parsed_columns: list[str] | None = None
     if columns is not None:
         parsed_columns = [c.strip() for c in columns.split(",") if c.strip()]
@@ -482,6 +519,9 @@ def list_memos(
 @app.command()
 def show(
     ref: str | None = typer.Argument(None, help="Entry index or shortcut (default: latest)."),
+    json_output: bool = typer.Option(
+        False, "--json", help="Output the entry as a single JSON object."
+    ),
 ):
     """Print one entry with index, uid, tags, and timestamps (Rich formatted). Alias: `koda s`.
 
@@ -496,6 +536,9 @@ def show(
 
     init_db()
     row = resolve_ref(ref)
+    if json_output:
+        sys.stdout.write(json.dumps(row.to_dict(), ensure_ascii=False, indent=2) + "\n")
+        return
     _print_memo(row.uid, row.idx, row.shortcut, row.content, row.tags, row.created_at)
 
 

--- a/src/koda/models.py
+++ b/src/koda/models.py
@@ -1,7 +1,9 @@
 """Data models for koda memos."""
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
+
+from .constants import TAG_SEPARATOR
 
 
 @dataclass(frozen=True)
@@ -28,3 +30,16 @@ class MemoRow:
             return None
         assert len(row) == 8, f"expected 8 columns, got {len(row)}"
         return cls(*row)
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serializable view of the row. ``tags`` is split into a list."""
+        return {
+            "id": self.id,
+            "uid": self.uid,
+            "idx": self.idx,
+            "content": self.content,
+            "tags": [t for t in (self.tags or "").split(TAG_SEPARATOR) if t],
+            "shortcut": self.shortcut,
+            "created_at": self.created_at,
+            "modified_at": self.modified_at,
+        }

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -1,0 +1,77 @@
+"""Tests for --json output on list / show / config (#69)."""
+
+import json
+
+import pytest
+
+import koda.runtime as runtime
+from koda.commands import config as config_cmd
+from koda.commands import memo
+from koda.constants import TAG_SEPARATOR
+
+
+@pytest.fixture
+def wired_db(db, monkeypatch):
+    monkeypatch.setattr(runtime, "_db", db)
+    return db
+
+
+def _seed(db, idx, content, tags=()):
+    db.add_memo(
+        uid=f"uid{idx:04d}",
+        idx=idx,
+        shortcut=None,
+        content=content,
+        tags=TAG_SEPARATOR.join(tags),
+        created_at="2026-01-01 00:00:00",
+        modified_at="2026-01-01 00:00:00",
+    )
+
+
+def test_list_json_is_array_and_parses(wired_db, capsys):
+    _seed(wired_db, 0, "alpha", ["work", "home"])
+    _seed(wired_db, 1, "beta")
+    memo._emit_list_json(None, None, None, False, None, None)
+    data = json.loads(capsys.readouterr().out)
+    assert isinstance(data, list)
+    assert [d["content"] for d in data] == ["alpha", "beta"]
+    assert data[0]["tags"] == ["work", "home"]  # tags split into a list
+    assert data[1]["tags"] == []
+
+
+def test_list_json_ignores_paging(wired_db, capsys):
+    """The JSON path returns every match regardless of page size."""
+    for i in range(25):
+        _seed(wired_db, i, f"entry {i}")
+    memo._emit_list_json(None, None, None, False, None, None)
+    data = json.loads(capsys.readouterr().out)
+    assert len(data) == 25
+
+
+def test_show_json_is_object(wired_db, capsys):
+    _seed(wired_db, 3, "gamma", ["x"])
+    memo.show(ref="3", json_output=True)
+    obj = json.loads(capsys.readouterr().out)
+    assert isinstance(obj, dict)
+    assert obj["idx"] == 3
+    assert obj["content"] == "gamma"
+    assert obj["tags"] == ["x"]
+
+
+def test_config_json_is_hierarchical(wired_db, capsys):
+    ctx = type("Ctx", (), {"invoked_subcommand": None})()
+    config_cmd.config_show(ctx, json_output=True)
+    data = json.loads(capsys.readouterr().out)
+    assert isinstance(data["list"], dict)
+    assert data["defaults"]["cmd"] == "raw"
+    assert "per_page" in data["list"]
+
+
+def test_config_json_masks_token(wired_db, capsys, monkeypatch):
+    cfg = runtime.get_config()
+    monkeypatch.setattr(cfg, "turso_token", "super-secret-token")
+    ctx = type("Ctx", (), {"invoked_subcommand": None})()
+    config_cmd.config_show(ctx, json_output=True)
+    out = capsys.readouterr().out
+    assert "super-secret-token" not in out
+    assert json.loads(out)["turso"]["token"] == "****"


### PR DESCRIPTION
## Summary
Adds `--json` for scripting (jq-friendly):

- `koda list --json` → JSON **array** of all matching entries (paging ignored).
- `koda show --json` → single entry **object**.
- `koda config --json` → hierarchical `{section: {key: value}}`; `turso.token` masked as `"****"` (use `config get turso.token` for the raw value).

Entry objects come from a new `MemoRow.to_dict()`; `tags` is split into a list. Schema documented in `CONTRIBUTING.md`.

## Test
- New `tests/test_json_output.py`: list array + tags-as-list, JSON path returns all matches, show object, config hierarchy, token masking.
- Smoke-tested through `jq` end to end.
- `ruff` clean; `uv run pytest` — 160 passed.

Closes #69 (E5-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)