### PR TITLE
feat(list): treat 'koda list <idx>' as shorthand for 'show <idx>'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `--json` output for `list`, `show`, and `config` for scripting (jq-friendly).
+- `koda list <idx|shortcut>` is now shorthand for `koda show <idx|shortcut>`
+  instead of erroring on an unexpected argument.
 
 ## [1.2.0] - 2026-06-06
 

--- a/src/koda/commands/memo.py
+++ b/src/koda/commands/memo.py
@@ -440,6 +440,10 @@ def _list_memos_impl(
 
 @app.command(name="list")
 def list_memos(
+    ref: str | None = typer.Argument(
+        None,
+        help="If given, show that single entry (index or shortcut) instead of the table.",
+    ),
     query: str | None = typer.Option(None, "--query", "-q", help="Substring match on memo body."),
     tag: str | None = typer.Option(None, "--tag", "-t", help="Substring match on tags."),
     exclude_tag: str | None = typer.Option(
@@ -493,7 +497,13 @@ def list_memos(
         False, "--json", help="Output all matching entries as a JSON array (ignores paging)."
     ),
 ):
-    """Show entries as a table with paging and sortable columns. Alias: `koda l`."""
+    """Show entries as a table with paging and sortable columns. Alias: `koda l`.
+
+    `koda list <idx|shortcut>` is shorthand for `koda show <idx|shortcut>`.
+    """
+    if ref is not None:
+        show(ref, json_output=json_output)
+        return
     if json_output:
         _emit_list_json(query, tag, exclude_tag, shortcuts_only, sort_by, desc)
         return

--- a/tests/test_list_dispatch.py
+++ b/tests/test_list_dispatch.py
@@ -1,0 +1,48 @@
+"""`koda list <idx>` should dispatch to `show` (#73)."""
+
+import pytest
+
+import koda.runtime as runtime
+from koda.commands import memo
+from koda.constants import TAG_SEPARATOR
+
+
+@pytest.fixture
+def wired_db(db, monkeypatch):
+    monkeypatch.setattr(runtime, "_db", db)
+    return db
+
+
+def _seed(db, idx, content, tags=()):
+    db.add_memo(
+        uid=f"uid{idx:04d}",
+        idx=idx,
+        shortcut=None,
+        content=content,
+        tags=TAG_SEPARATOR.join(tags),
+        created_at="2026-01-01 00:00:00",
+        modified_at="2026-01-01 00:00:00",
+    )
+
+
+def test_list_with_idx_shows_single_entry(wired_db, capsys, monkeypatch):
+    _seed(wired_db, 0, "alpha")
+    _seed(wired_db, 1, "beta")
+    called = {}
+
+    def fake_show(ref, json_output=False):
+        called["ref"] = ref
+        called["json"] = json_output
+
+    monkeypatch.setattr(memo, "show", fake_show)
+    memo.list_memos(ref="1", json_output=False)
+    assert called == {"ref": "1", "json": False}
+
+
+def test_list_with_idx_forwards_json(wired_db, monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        memo, "show", lambda ref, json_output=False: called.update(ref=ref, json=json_output)
+    )
+    memo.list_memos(ref="0", json_output=True)
+    assert called == {"ref": "0", "json": True}


### PR DESCRIPTION
## Summary
`koda list 5` previously failed with *"Got unexpected extra argument (5)"*. Now `list` accepts an optional positional: when given, it dispatches to `show` (forwarding `--json`); otherwise the table renders as before. Existing options (`--tag`, `--sort-by`, …) keep working.

## Test
- New `tests/test_list_dispatch.py`: dispatch to `show` and `--json` forwarding.
- Smoke-tested: `koda l`, `koda l 0`, `koda l 0 --json`, `koda l --tag work`.
- `ruff` clean; `uv run pytest` — 162 passed.

Closes #73 (E5-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)