### PR TITLE
feat(cli): add --dry-run to compact / shift / move / tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--json` output for `list`, `show`, and `config` for scripting (jq-friendly).
 - `koda list <idx|shortcut>` is now shorthand for `koda show <idx|shortcut>`
   instead of erroring on an unexpected argument.
+- `--dry-run` on `compact`, `shift`, `move`, and `tag` previews changes
+  without modifying the database.
 
 ## [1.2.0] - 2026-06-06
 

--- a/src/koda/commands/index.py
+++ b/src/koda/commands/index.py
@@ -12,6 +12,9 @@ from ..runtime import console, get_db, init_db
 def move(
     from_idx: int = typer.Argument(..., help="Source display index."),
     to_idx: int = typer.Argument(..., help="Destination display index (must be empty)."),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would change without modifying the database."
+    ),
 ):
     """Move entry at FROM to an unoccupied display position TO. Alias: `koda m`."""
     init_db()
@@ -27,6 +30,9 @@ def move(
                 f"or `koda shift {to_idx}` to make room first.[/dim]"
             )
             raise typer.Exit(code=1)
+        if dry_run:
+            console.print(f"[cyan]Would move {from_idx} → {to_idx}.[/cyan]")
+            return
         conn.execute("UPDATE memos SET idx = ? WHERE idx = ?", (to_idx, from_idx))
     console.print(f"[green]Moved {from_idx} → {to_idx}.[/green]")
 
@@ -36,6 +42,9 @@ def shift_cmd(
     start: int = typer.Argument(..., help="Shift entries at this index and above."),
     count: int = typer.Option(
         1, "--count", "-n", help="Positions to shift (negative = shift down)."
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would change without modifying the database."
     ),
 ):
     """Shift all entries at START and above by COUNT positions. Alias: `koda h`."""
@@ -58,6 +67,15 @@ def shift_cmd(
                     f"Cannot shift down by {abs(count)}: "
                     f"entries exist in [{start + count}, {start - 1}]."
                 )
+        if dry_run:
+            affected = conn.execute(
+                "SELECT COUNT(*) FROM memos WHERE idx >= ?", (start,)
+            ).fetchone()[0]
+            console.print(
+                f"[cyan]Would shift {affected} entr{'y' if affected == 1 else 'ies'} "
+                f"from index {start} by {count:+d}.[/cyan]"
+            )
+            return
         # Two-step update to avoid UNIQUE constraint violations during bulk shift
         conn.execute(
             "UPDATE memos SET idx = idx + ? WHERE idx >= ?",
@@ -94,7 +112,11 @@ def swap(
 
 
 @app.command(name="compact")
-def compact_indices():
+def compact_indices(
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would change without modifying the database."
+    ),
+):
     """Fill index gaps by reassigning idx to contiguous values from 0. Alias: `koda k`."""
     init_db()
     with get_db().connection() as conn:
@@ -106,6 +128,13 @@ def compact_indices():
         changed = sum(1 for new_idx, (_, old_idx) in enumerate(rows) if old_idx != new_idx)
         if changed == 0:
             console.print("[green]Indices are already contiguous from 0.[/green]")
+            return
+
+        if dry_run:
+            console.print(
+                f"[cyan]Would compact indices for {changed} "
+                f"entr{'y' if changed == 1 else 'ies'}.[/cyan]"
+            )
             return
 
         max_idx = max(idx for _, idx in rows)

--- a/src/koda/commands/memo.py
+++ b/src/koda/commands/memo.py
@@ -594,6 +594,9 @@ def tag(
     indices: list[str] = typer.Argument(..., help="Entry indices or ranges (e.g. 1 3 5-8)."),
     tags: list[str] | None = typer.Option(None, "--tag", "-t", help="Tag(s) to add."),
     untag: list[str] | None = typer.Option(None, "--untag", "-T", help="Tag(s) to remove."),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would change without modifying the database."
+    ),
 ):
     """Add or remove tags on one or more entries. Supports ranges (e.g. 2-5). Alias: `koda t`."""
     if not tags and not untag:
@@ -621,17 +624,20 @@ def tag(
             new_tags = kept + added
             if new_tags == current:
                 continue
-            conn.execute(
-                "UPDATE memos SET tags = ? WHERE id = ?",
-                (TAG_SEPARATOR.join(new_tags), row_id),
-            )
+            if not dry_run:
+                conn.execute(
+                    "UPDATE memos SET tags = ? WHERE id = ?",
+                    (TAG_SEPARATOR.join(new_tags), row_id),
+                )
             updated += 1
             added_count += len(added)
             removed_count += len(removed)
 
     entry_word = "entry" if updated == 1 else "entries"
+    verb = "Would update" if dry_run else "Updated"
+    color = "cyan" if dry_run else "green"
     console.print(
-        f"[green]Updated {updated} {entry_word} "
+        f"[{color}]{verb} {updated} {entry_word} "
         f"(added {added_count} tag{'' if added_count == 1 else 's'}, "
-        f"removed {removed_count} tag{'' if removed_count == 1 else 's'}).[/green]"
+        f"removed {removed_count} tag{'' if removed_count == 1 else 's'}).[/{color}]"
     )

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,60 @@
+"""--dry-run on compact / shift / move / tag must not touch the DB (#75)."""
+
+import pytest
+
+import koda.runtime as runtime
+from koda.commands import index, memo
+from koda.constants import TAG_SEPARATOR
+
+
+@pytest.fixture
+def wired_db(db, monkeypatch):
+    monkeypatch.setattr(runtime, "_db", db)
+    return db
+
+
+def _seed(db, idx, content="x", tags=()):
+    db.add_memo(
+        uid=f"uid{idx:04d}",
+        idx=idx,
+        shortcut=None,
+        content=content,
+        tags=TAG_SEPARATOR.join(tags),
+        created_at="2026-01-01 00:00:00",
+        modified_at="2026-01-01 00:00:00",
+    )
+
+
+def _idxs(db):
+    return sorted(r.idx for r in db.get_memos(limit=None))
+
+
+def test_move_dry_run_does_not_change(wired_db, capsys):
+    _seed(wired_db, 0)
+    index.move(from_idx=0, to_idx=5, dry_run=True)
+    assert _idxs(wired_db) == [0]
+    assert "Would move" in capsys.readouterr().out
+
+
+def test_shift_dry_run_does_not_change(wired_db, capsys):
+    _seed(wired_db, 0)
+    _seed(wired_db, 1)
+    index.shift_cmd(start=0, count=3, dry_run=True)
+    assert _idxs(wired_db) == [0, 1]
+    assert "Would shift 2 entries" in capsys.readouterr().out
+
+
+def test_compact_dry_run_does_not_change(wired_db, capsys):
+    _seed(wired_db, 0)
+    _seed(wired_db, 5)
+    index.compact_indices(dry_run=True)
+    assert _idxs(wired_db) == [0, 5]
+    assert "Would compact" in capsys.readouterr().out
+
+
+def test_tag_dry_run_does_not_change(wired_db, capsys):
+    _seed(wired_db, 0, tags=["keep"])
+    memo.tag(indices=["0"], tags=["new"], untag=None, dry_run=True)
+    row = wired_db.get_memo_by_idx(0)
+    assert row.tags == "keep"
+    assert "Would update 1 entry (added 1 tag, removed 0 tags)" in capsys.readouterr().out

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -43,7 +43,7 @@ def test_add_and_remove_counts_differ(wired_db, capsys):
     _seed(wired_db, 2, [])
     _seed(wired_db, 3, ["bar"])
 
-    memo.tag(indices=["1", "2", "3"], tags=["foo"], untag=["bar"])
+    memo.tag(indices=["1", "2", "3"], tags=["foo"], untag=["bar"], dry_run=False)
 
     out = capsys.readouterr().out
     # foo added to all 3 entries; bar removed only from entries 1 and 3.
@@ -55,7 +55,7 @@ def test_add_and_remove_counts_differ(wired_db, capsys):
 
 def test_singular_wording(wired_db, capsys):
     _seed(wired_db, 1, [])
-    memo.tag(indices=["1"], tags=["solo"], untag=None)
+    memo.tag(indices=["1"], tags=["solo"], untag=None, dry_run=False)
     out = capsys.readouterr().out
     assert "Updated 1 entry (added 1 tag, removed 0 tags)." in out
 
@@ -63,7 +63,7 @@ def test_singular_wording(wired_db, capsys):
 def test_noop_when_nothing_changes(wired_db, capsys):
     """Adding a tag the entry already has, or removing one it lacks, is a no-op."""
     _seed(wired_db, 1, ["keep"])
-    memo.tag(indices=["1"], tags=["keep"], untag=["absent"])
+    memo.tag(indices=["1"], tags=["keep"], untag=["absent"], dry_run=False)
     out = capsys.readouterr().out
     assert "Updated 0 entries (added 0 tags, removed 0 tags)." in out
     assert _tags(wired_db, 1) == ["keep"]


### PR DESCRIPTION
## Summary
Adds `--dry-run` to `move`, `shift`, `compact`, and `tag`. Each previews the change and returns without writing:
- `move` → "Would move X → Y"
- `shift` → "Would shift N entries from index S by ±C"
- `compact` → "Would compact indices for N entries"
- `tag` → "Would update N entries (added X tags, removed Y tags)"

Existing validation (occupied target, negative-index collisions, missing entries) still runs in dry-run mode.

## Test
- New `tests/test_dry_run.py`: each command leaves the DB unchanged and prints the preview.
- Smoke-tested end to end (indexes/tags unchanged after dry-run).
- `ruff` clean; `uv run pytest` — 166 passed.

Closes #75 (E5-7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)