### PR TITLE
feat(cli): add --quiet and --print-uid/--print-idx to mutating commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of erroring on an unexpected argument.
 - `--dry-run` on `compact`, `shift`, `move`, and `tag` previews changes
   without modifying the database.
+- `--quiet/-q` on `add`, `edit`, `tag`, `move`, and `swap` suppresses the
+  success message; `add --print-uid` / `add --print-idx` print the new
+  entry's uid / idx to stdout for pipelines.
 
 ## [1.2.0] - 2026-06-06
 

--- a/src/koda/commands/index.py
+++ b/src/koda/commands/index.py
@@ -15,6 +15,7 @@ def move(
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Show what would change without modifying the database."
     ),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress the success message."),
 ):
     """Move entry at FROM to an unoccupied display position TO. Alias: `koda m`."""
     init_db()
@@ -34,7 +35,8 @@ def move(
             console.print(f"[cyan]Would move {from_idx} → {to_idx}.[/cyan]")
             return
         conn.execute("UPDATE memos SET idx = ? WHERE idx = ?", (to_idx, from_idx))
-    console.print(f"[green]Moved {from_idx} → {to_idx}.[/green]")
+    if not quiet:
+        console.print(f"[green]Moved {from_idx} → {to_idx}.[/green]")
 
 
 @app.command(name="shift")
@@ -92,6 +94,7 @@ def shift_cmd(
 def swap(
     idx1: int = typer.Argument(..., help="First display index."),
     idx2: int = typer.Argument(..., help="Second display index."),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress the success message."),
 ):
     """Swap the display positions of two entries. Alias: `koda w`."""
     init_db()
@@ -108,7 +111,8 @@ def swap(
         conn.execute("UPDATE memos SET idx = -1 WHERE id = ?", (a[0],))
         conn.execute("UPDATE memos SET idx = ? WHERE id = ?", (idx1, b[0]))
         conn.execute("UPDATE memos SET idx = ? WHERE id = ?", (idx2, a[0]))
-    console.print(f"[green]Swapped {idx1} ↔ {idx2}.[/green]")
+    if not quiet:
+        console.print(f"[green]Swapped {idx1} ↔ {idx2}.[/green]")
 
 
 @app.command(name="compact")

--- a/src/koda/commands/memo.py
+++ b/src/koda/commands/memo.py
@@ -54,6 +54,9 @@ def _add_impl(
     text: list[str] | None = None,
     tag: list[str] | None = None,
     shortcut: str | None = None,
+    quiet: bool = False,
+    print_uid: bool = False,
+    print_idx: bool = False,
 ) -> None:
     shortcut = _validate_shortcut(shortcut)
     init_db()
@@ -100,8 +103,13 @@ def _add_impl(
     except _IntegrityErrors:
         exit_error(f"Shortcut {shortcut!r} is already in use.")
 
-    sc_str = f" sc=[bold green]{shortcut}[/bold green]" if shortcut else ""
-    console.print(f"[green]Saved [{new_idx}] ({uid}) tags: {formatted_tags}{sc_str}[/green]")
+    if print_uid:
+        sys.stdout.write(uid + "\n")
+    if print_idx:
+        sys.stdout.write(str(new_idx) + "\n")
+    if not quiet:
+        sc_str = f" sc=[bold green]{shortcut}[/bold green]" if shortcut else ""
+        console.print(f"[green]Saved [{new_idx}] ({uid}) tags: {formatted_tags}{sc_str}[/green]")
 
 
 @app.command()
@@ -115,9 +123,18 @@ def add(
     shortcut: str | None = typer.Option(
         None, "--shortcut", "-s", help="Short alias for this entry (e.g. 'deploy')."
     ),
+    quiet: bool = typer.Option(
+        False, "--quiet", "-q", help="Suppress the success message (for scripting)."
+    ),
+    print_uid: bool = typer.Option(
+        False, "--print-uid", help="Print the new entry's uid to stdout."
+    ),
+    print_idx: bool = typer.Option(
+        False, "--print-idx", help="Print the new entry's idx to stdout."
+    ),
 ):
     """Create an entry from arguments, stdin, or your editor. Alias: `koda a`."""
-    _add_impl(text, tag, shortcut)
+    _add_impl(text, tag, shortcut, quiet=quiet, print_uid=print_uid, print_idx=print_idx)
 
 
 @app.command(name="remove")
@@ -225,6 +242,7 @@ def edit(
     ref: str | None = typer.Argument(
         None, help="Entry index or shortcut to edit (default: latest)."
     ),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress the success message."),
 ):
     """Open an entry in $EDITOR (body plus tags/shortcut/metadata footer). Alias: `koda e`."""
     init_db()
@@ -278,13 +296,16 @@ def edit(
                 update_memo_full(memo_id, new_content, new_tags, new_shortcut, new_created_at)
             except _IntegrityErrors:
                 exit_error(f"Shortcut {new_shortcut!r} is already in use.")
-            console.print(f"[green]Entry [{idx}] updated.[/green]")
+            if not quiet:
+                console.print(f"[green]Entry [{idx}] updated.[/green]")
         else:
             new_content = "\n---\n".join(parts).strip() if parts else new_data.strip()
             update_memo_full(memo_id, new_content, tags, shortcut, created_at)
-            console.print(
-                "[yellow]No metadata footer found; content updated, metadata preserved.[/yellow]"
-            )
+            if not quiet:
+                console.print(
+                    "[yellow]No metadata footer found; "
+                    "content updated, metadata preserved.[/yellow]"
+                )
     finally:
         Path(temp_path).unlink(missing_ok=True)
 
@@ -597,6 +618,7 @@ def tag(
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Show what would change without modifying the database."
     ),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress the success message."),
 ):
     """Add or remove tags on one or more entries. Supports ranges (e.g. 2-5). Alias: `koda t`."""
     if not tags and not untag:
@@ -633,6 +655,8 @@ def tag(
             added_count += len(added)
             removed_count += len(removed)
 
+    if quiet:
+        return
     entry_word = "entry" if updated == 1 else "entries"
     verb = "Would update" if dry_run else "Updated"
     color = "cyan" if dry_run else "green"

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -54,7 +54,7 @@ def test_compact_dry_run_does_not_change(wired_db, capsys):
 
 def test_tag_dry_run_does_not_change(wired_db, capsys):
     _seed(wired_db, 0, tags=["keep"])
-    memo.tag(indices=["0"], tags=["new"], untag=None, dry_run=True)
+    memo.tag(indices=["0"], tags=["new"], untag=None, dry_run=True, quiet=False)
     row = wired_db.get_memo_by_idx(0)
     assert row.tags == "keep"
     assert "Would update 1 entry (added 1 tag, removed 0 tags)" in capsys.readouterr().out

--- a/tests/test_quiet_print.py
+++ b/tests/test_quiet_print.py
@@ -1,0 +1,79 @@
+"""--quiet / --print-uid / --print-idx on mutating commands (#71)."""
+
+import pytest
+
+import koda.runtime as runtime
+from koda.commands import index, memo
+from koda.constants import TAG_SEPARATOR
+
+
+class FakeStdin:
+    def isatty(self):
+        return True
+
+    def read(self):
+        return ""
+
+
+@pytest.fixture
+def wired_db(db, monkeypatch):
+    monkeypatch.setattr(runtime, "_db", db)
+    monkeypatch.setattr("sys.stdin", FakeStdin())
+    return db
+
+
+def _seed(db, idx, tags=()):
+    db.add_memo(
+        uid=f"uid{idx:04d}",
+        idx=idx,
+        shortcut=None,
+        content=f"e{idx}",
+        tags=TAG_SEPARATOR.join(tags),
+        created_at="2026-01-01 00:00:00",
+        modified_at="2026-01-01 00:00:00",
+    )
+
+
+def test_add_print_uid_only(wired_db, capsys):
+    memo._add_impl(text=["body"], quiet=True, print_uid=True)
+    out = capsys.readouterr().out.strip()
+    assert out == wired_db.get_latest_entry().uid
+    assert "Saved" not in out
+
+
+def test_add_print_idx_only(wired_db, capsys):
+    memo._add_impl(text=["body"], quiet=True, print_idx=True)
+    out = capsys.readouterr().out.strip()
+    assert out == str(wired_db.get_latest_entry().idx)
+
+
+def test_add_quiet_suppresses_message(wired_db, capsys):
+    memo._add_impl(text=["body"], quiet=True)
+    assert capsys.readouterr().out == ""
+    assert wired_db.get_latest_entry().content == "body"
+
+
+def test_add_default_prints_saved(wired_db, capsys):
+    memo._add_impl(text=["body"])
+    assert "Saved" in capsys.readouterr().out
+
+
+def test_tag_quiet(wired_db, capsys):
+    _seed(wired_db, 0)
+    memo.tag(indices=["0"], tags=["x"], untag=None, dry_run=False, quiet=True)
+    assert capsys.readouterr().out == ""
+    assert wired_db.get_memo_by_idx(0).tags == "x"
+
+
+def test_move_quiet(wired_db, capsys):
+    _seed(wired_db, 0)
+    index.move(from_idx=0, to_idx=5, dry_run=False, quiet=True)
+    assert capsys.readouterr().out == ""
+    assert wired_db.get_memo_by_idx(5) is not None
+
+
+def test_swap_quiet(wired_db, capsys):
+    _seed(wired_db, 0)
+    _seed(wired_db, 1)
+    index.swap(idx1=0, idx2=1, quiet=True)
+    assert capsys.readouterr().out == ""

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -43,7 +43,7 @@ def test_add_and_remove_counts_differ(wired_db, capsys):
     _seed(wired_db, 2, [])
     _seed(wired_db, 3, ["bar"])
 
-    memo.tag(indices=["1", "2", "3"], tags=["foo"], untag=["bar"], dry_run=False)
+    memo.tag(indices=["1", "2", "3"], tags=["foo"], untag=["bar"], dry_run=False, quiet=False)
 
     out = capsys.readouterr().out
     # foo added to all 3 entries; bar removed only from entries 1 and 3.
@@ -55,7 +55,7 @@ def test_add_and_remove_counts_differ(wired_db, capsys):
 
 def test_singular_wording(wired_db, capsys):
     _seed(wired_db, 1, [])
-    memo.tag(indices=["1"], tags=["solo"], untag=None, dry_run=False)
+    memo.tag(indices=["1"], tags=["solo"], untag=None, dry_run=False, quiet=False)
     out = capsys.readouterr().out
     assert "Updated 1 entry (added 1 tag, removed 0 tags)." in out
 
@@ -63,7 +63,7 @@ def test_singular_wording(wired_db, capsys):
 def test_noop_when_nothing_changes(wired_db, capsys):
     """Adding a tag the entry already has, or removing one it lacks, is a no-op."""
     _seed(wired_db, 1, ["keep"])
-    memo.tag(indices=["1"], tags=["keep"], untag=["absent"], dry_run=False)
+    memo.tag(indices=["1"], tags=["keep"], untag=["absent"], dry_run=False, quiet=False)
     out = capsys.readouterr().out
     assert "Updated 0 entries (added 0 tags, removed 0 tags)." in out
     assert _tags(wired_db, 1) == ["keep"]


### PR DESCRIPTION
## Summary
Scripting-friendly output control on mutating commands:

- `--quiet/-q` on `add`, `edit`, `tag`, `move`, `swap` suppresses the success message.
- `add --print-uid` / `add --print-idx` write the new entry's uid / idx to stdout.

Enables the target pattern:
```bash
id=$(echo body | koda add -q --print-uid)
```

## Test
- New `tests/test_quiet_print.py`: print-uid/print-idx capture, quiet suppression, default still prints, and quiet on tag/move/swap.
- Smoke-tested the `id=$(...)` capture pattern.
- `ruff` clean; `uv run pytest` — 173 passed.

Closes #71 (E5-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)