### PR TITLE
feat(cli): add export and import commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--quiet/-q` on `add`, `edit`, `tag`, `move`, and `swap` suppresses the
   success message; `add --print-uid` / `add --print-idx` print the new
   entry's uid / idx to stdout for pipelines.
+- `koda export [--out PATH]` writes all entries as JSON Lines to stdout or a
+  file, and `koda import <file>` merges a JSONL file into the local database.
 
 ## [1.2.0] - 2026-06-06
 

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -1,6 +1,7 @@
-"""Git sync commands: push, pull."""
+"""Git sync and payload I/O commands: push, pull, export, import."""
 
 import subprocess
+import sys
 from pathlib import Path
 
 import typer
@@ -9,6 +10,25 @@ from .. import git_sync
 from ..cli_utils import exit_error
 from ..main import app
 from ..runtime import console, get_config, get_db, init_db
+
+
+def _merge_payload(data: bytes) -> None:
+    """Load a JSONL payload and merge it into the local DB, printing a summary."""
+    try:
+        rows = git_sync.GitSyncPayload.load(data)
+    except Exception as e:
+        exit_error(f"Invalid sync payload: {e}")
+
+    ins, upd, skp, dsc = git_sync.MemoMerger(get_db()).merge(rows)
+    tail = (
+        f", [yellow]{dsc}[/yellow] shortcut(s) dropped (conflicts with local shortcuts)"
+        if dsc
+        else ""
+    )
+    console.print(
+        f"merged memos: [cyan]{ins}[/cyan] inserted, [cyan]{upd}[/cyan] updated, "
+        f"[dim]{skp}[/dim] skipped (older or invalid entries){tail}."
+    )
 
 
 @app.command()
@@ -98,19 +118,40 @@ def pull(
             exit_error(f"Payload file missing after pull: {payload_path}")
         data = payload_path.read_bytes()
 
-    try:
-        rows = git_sync.GitSyncPayload.load(data)
-    except Exception as e:
-        exit_error(f"Invalid sync payload: {e}")
-
-    ins, upd, skp, dsc = git_sync.MemoMerger(get_db()).merge(rows)
-    tail = (
-        f", [yellow]{dsc}[/yellow] shortcut(s) dropped (conflicts with local shortcuts)"
-        if dsc
-        else ""
-    )
-    console.print(
-        f"merged remote memos: [cyan]{ins}[/cyan] inserted, [cyan]{upd}[/cyan] updated, "
-        f"[dim]{skp}[/dim] skipped (older or invalid entries){tail}."
-    )
+    _merge_payload(data)
     console.print("[green]Pull complete.[/green]")
+
+
+@app.command()
+def export(
+    out: Path | None = typer.Option(
+        None, "--out", "-o", help="Write JSONL to this file instead of stdout."
+    ),
+):
+    """Export all entries as JSON Lines (uid-sorted) to stdout or a file.
+
+    The output is the same payload format used by `push` / `pull`.
+    """
+    init_db()
+    data = git_sync.GitSyncPayload.dump(get_db())
+    if out is not None:
+        git_sync.atomic_write_bytes(out, data)
+        console.print(f"[green]Exported to {out}.[/green]")
+    else:
+        sys.stdout.buffer.write(data)
+
+
+@app.command(name="import")
+def import_memos(
+    file: Path = typer.Argument(..., help="JSONL file to import (merged by uid + modified_at)."),
+):
+    """Import entries from a local JSONL file, merging into the local database.
+
+    Equivalent to `pull --file <file>` but without touching any Git clone.
+    """
+    init_db()
+    if not file.is_file():
+        exit_error(f"File does not exist: {file}")
+    data = file.read_bytes()
+    _merge_payload(data)
+    console.print("[green]Import complete.[/green]")

--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -1,0 +1,69 @@
+"""Tests for the export / import commands (#70)."""
+
+import json
+
+import pytest
+
+import koda.runtime as runtime
+from koda.commands import git as git_cmd
+from koda.db import MemoDatabase
+
+
+@pytest.fixture
+def wired_db(db, monkeypatch):
+    monkeypatch.setattr(runtime, "_db", db)
+    return db
+
+
+def _seed(db, idx, content):
+    db.add_memo(
+        uid=f"uid{idx:04d}",
+        idx=idx,
+        shortcut=None,
+        content=content,
+        tags="",
+        created_at="2026-01-01 00:00:00",
+        modified_at="2026-01-01 00:00:00",
+    )
+
+
+def test_export_stdout_is_jsonl(wired_db, capsysbinary):
+    """capsysbinary is a pytest built-in capturing the raw stdout buffer."""
+    _seed(wired_db, 0, "alpha")
+    _seed(wired_db, 1, "beta")
+    git_cmd.export(out=None)
+    out = capsysbinary.readouterr().out.decode()
+    lines = [json.loads(line) for line in out.splitlines() if line.strip()]
+    assert {r["content"] for r in lines} == {"alpha", "beta"}
+
+
+def test_export_to_file(wired_db, tmp_path):
+    _seed(wired_db, 0, "alpha")
+    dest = tmp_path / "dump.jsonl"
+    git_cmd.export(out=dest)
+    assert dest.is_file()
+    assert "alpha" in dest.read_text()
+
+
+def test_import_roundtrip(wired_db, tmp_path, monkeypatch, capsys):
+    _seed(wired_db, 0, "alpha")
+    _seed(wired_db, 1, "beta")
+    dump = tmp_path / "dump.jsonl"
+    git_cmd.export(out=dump)
+
+    # Fresh DB, import the dump.
+    target = MemoDatabase(backend="local", path=tmp_path / "target.db")
+    target.init_db()
+    monkeypatch.setattr(runtime, "_db", target)
+    git_cmd.import_memos(file=dump)
+
+    contents = {r.content for r in target.get_memos(limit=None)}
+    assert contents == {"alpha", "beta"}
+    assert "Import complete" in capsys.readouterr().out
+
+
+def test_import_missing_file_errors(wired_db, tmp_path):
+    import typer
+
+    with pytest.raises(typer.Exit):
+        git_cmd.import_memos(file=tmp_path / "nope.jsonl")


### PR DESCRIPTION
## Summary
Adds first-class payload I/O, complementing the existing `push`/`pull --file`:

- `koda export [--out PATH]` — write all entries as JSON Lines (uid-sorted; the same format `push`/`pull` use) to **stdout** (default) or a file.
- `koda import <file>` — merge a local JSONL file into the database by `uid` + `modified_at`. Equivalent to `pull --file` but never touches a Git clone.

The `pull` merge+summary logic is refactored into a shared `_merge_payload` helper used by both `pull` and `import`. `push`/`pull --file` behavior is unchanged.

## Test
- New `tests/test_export_import.py`: stdout JSONL (via `capsysbinary`), `--out` file, full export→import roundtrip into a fresh DB, and missing-file error.
- Smoke-tested the roundtrip through the CLI + `jq`.
- `ruff` clean; `uv run pytest` — 177 passed.

Closes #70 (E5-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)