### PR TITLE
feat(cli): add diff and backup commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entry's uid / idx to stdout for pipelines.
 - `koda export [--out PATH]` writes all entries as JSON Lines to stdout or a
   file, and `koda import <file>` merges a JSONL file into the local database.
+- `koda diff [--file PATH]` shows a uid-level diff (local-only / remote-only /
+  changed) between the local database and the remote payload.
+- `koda backup --out PATH` writes a consistent single-file SQLite snapshot
+  (`VACUUM INTO`).
 
 ## [1.2.0] - 2026-06-06
 

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -12,6 +12,24 @@ from ..main import app
 from ..runtime import console, get_config, get_db, init_db
 
 
+def _obtain_remote_payload(local_payload_path: Path | None) -> bytes:
+    """Return payload bytes from a local --file or, failing that, the Git clone."""
+    git_sync.require_jsonl_format(get_config())
+    if local_payload_path is not None:
+        if not local_payload_path.is_file():
+            exit_error(f"--file does not exist: {local_payload_path}")
+        return local_payload_path.read_bytes()
+    git_sync.require_git_cli()
+    sync_root = git_sync.resolve_sync_root(get_config())
+    repo = git_sync.GitSyncRepo(sync_root)
+    repo.ensure_worktree()
+    payload_path = git_sync.resolve_payload_path(get_config(), sync_root)
+    repo.pull_rebase_if_remote()
+    if not payload_path.is_file():
+        exit_error(f"Payload file missing after pull: {payload_path}")
+    return payload_path.read_bytes()
+
+
 def _merge_payload(data: bytes) -> None:
     """Load a JSONL payload and merge it into the local DB, printing a summary."""
     try:
@@ -102,22 +120,7 @@ def pull(
     Merge key is uid + modified_at. Alias: `koda pull`.
     """
     init_db()
-    git_sync.require_jsonl_format(get_config())
-    if local_payload_path is not None:
-        if not local_payload_path.is_file():
-            exit_error(f"--file does not exist: {local_payload_path}")
-        data = local_payload_path.read_bytes()
-    else:
-        git_sync.require_git_cli()
-        sync_root = git_sync.resolve_sync_root(get_config())
-        repo = git_sync.GitSyncRepo(sync_root)
-        repo.ensure_worktree()
-        payload_path = git_sync.resolve_payload_path(get_config(), sync_root)
-        repo.pull_rebase_if_remote()
-        if not payload_path.is_file():
-            exit_error(f"Payload file missing after pull: {payload_path}")
-        data = payload_path.read_bytes()
-
+    data = _obtain_remote_payload(local_payload_path)
     _merge_payload(data)
     console.print("[green]Pull complete.[/green]")
 
@@ -155,3 +158,71 @@ def import_memos(
     data = file.read_bytes()
     _merge_payload(data)
     console.print("[green]Import complete.[/green]")
+
+
+@app.command()
+def diff(
+    local_payload_path: Path | None = typer.Option(
+        None, "--file", help="Diff against this JSONL file instead of the Git clone."
+    ),
+):
+    """Show a uid-level diff between the local database and the remote payload.
+
+    Reports entries that are local-only, remote-only, or present in both but
+    changed (different content, tags, shortcut, or modified_at).
+    """
+    init_db()
+    data = _obtain_remote_payload(local_payload_path)
+    try:
+        remote_rows = git_sync.GitSyncPayload.load(data)
+    except Exception as e:
+        exit_error(f"Invalid sync payload: {e}")
+
+    remote = {r["uid"]: r for r in remote_rows}
+    local = {r.uid: r for r in get_db().get_memos(limit=None)}
+
+    local_only = sorted(set(local) - set(remote))
+    remote_only = sorted(set(remote) - set(local))
+    changed = []
+    for uid in set(local) & set(remote):
+        lrow, rrow = local[uid], remote[uid]
+        if (
+            (lrow.content or "") != (rrow.get("content") or "")
+            or (lrow.tags or "") != (rrow.get("tags") or "")
+            or (lrow.shortcut or None) != (rrow.get("shortcut") or None)
+            or (lrow.modified_at or "") != (rrow.get("modified_at") or "")
+        ):
+            changed.append(uid)
+    changed.sort()
+
+    if not (local_only or remote_only or changed):
+        console.print("[green]No differences — local and remote are in sync.[/green]")
+        return
+
+    for uid in local_only:
+        console.print(f"[green]+ local-only[/green]  {uid}  [{local[uid].idx}]")
+    for uid in remote_only:
+        console.print(f"[red]- remote-only[/red] {uid}")
+    for uid in changed:
+        console.print(f"[yellow]~ changed[/yellow]     {uid}  [{local[uid].idx}]")
+    console.print(
+        f"[dim]{len(local_only)} local-only, {len(remote_only)} remote-only, "
+        f"{len(changed)} changed[/dim]"
+    )
+
+
+@app.command()
+def backup(
+    out: Path = typer.Option(
+        ..., "--out", "-o", help="Destination file for the SQLite snapshot (must not exist)."
+    ),
+):
+    """Write a consistent single-file snapshot of the local database (VACUUM INTO)."""
+    init_db()
+    if get_config().db_backend != "local":
+        exit_error("backup is only supported for the local sqlite backend.")
+    if out.exists():
+        exit_error(f"Destination already exists: {out}")
+    with get_db().connection() as conn:
+        conn.execute("VACUUM INTO ?", (str(out),))
+    console.print(f"[green]Backup written to {out}.[/green]")

--- a/tests/test_diff_backup.py
+++ b/tests/test_diff_backup.py
@@ -1,0 +1,76 @@
+"""Tests for the diff and backup commands (#74)."""
+
+import pytest
+
+import koda.runtime as runtime
+from koda.commands import git as git_cmd
+from koda.db import MemoDatabase
+
+
+@pytest.fixture
+def wired_db(db, monkeypatch):
+    monkeypatch.setattr(runtime, "_db", db)
+    return db
+
+
+def _seed(db, idx, content, tags=""):
+    db.add_memo(
+        uid=f"uid{idx:04d}",
+        idx=idx,
+        shortcut=None,
+        content=content,
+        tags=tags,
+        created_at="2026-01-01 00:00:00",
+        modified_at="2026-01-01 00:00:00",
+    )
+
+
+def test_diff_reports_local_only_and_changed(wired_db, tmp_path, capsys):
+    _seed(wired_db, 0, "alpha")
+    _seed(wired_db, 1, "beta")
+    remote = tmp_path / "remote.jsonl"
+    git_cmd.export(out=remote)
+
+    # Diverge: add a local-only entry and change an existing one.
+    _seed(wired_db, 2, "gamma")
+    with wired_db.connection() as conn:
+        conn.execute(
+            "UPDATE memos SET tags = ?, modified_at = ? WHERE idx = 1",
+            ("edited", "2026-02-01 00:00:00"),
+        )
+
+    git_cmd.diff(local_payload_path=remote)
+    out = capsys.readouterr().out
+    assert "1 local-only" in out
+    assert "1 changed" in out
+    assert "uid0002" in out  # local-only gamma
+
+
+def test_diff_in_sync(wired_db, tmp_path, capsys):
+    _seed(wired_db, 0, "alpha")
+    remote = tmp_path / "remote.jsonl"
+    git_cmd.export(out=remote)
+    git_cmd.diff(local_payload_path=remote)
+    assert "No differences" in capsys.readouterr().out
+
+
+def test_backup_creates_snapshot(wired_db, tmp_path, capsys):
+    _seed(wired_db, 0, "alpha")
+    _seed(wired_db, 1, "beta")
+    dest = tmp_path / "snap.db"
+    git_cmd.backup(out=dest)
+    assert dest.is_file()
+    assert "Backup written" in capsys.readouterr().out
+
+    # The snapshot is a usable database with the same rows.
+    snap = MemoDatabase(backend="local", path=dest)
+    assert {r.content for r in snap.get_memos(limit=None)} == {"alpha", "beta"}
+
+
+def test_backup_refuses_existing(wired_db, tmp_path):
+    import typer
+
+    dest = tmp_path / "exists.db"
+    dest.write_text("x")
+    with pytest.raises(typer.Exit):
+        git_cmd.backup(out=dest)


### PR DESCRIPTION
## Summary
- `koda diff [--file PATH]` — compares the local database against the remote payload (the Git clone, or a local JSONL file with `--file`) and reports a **uid-level** diff: local-only, remote-only, and changed (different content / tags / shortcut / modified_at) entries, with a count summary.
- `koda backup --out PATH` — writes a consistent single-file SQLite snapshot via `VACUUM INTO` (local backend only; refuses to overwrite an existing file).

Refactors the payload-fetch logic shared by `pull` and `diff` into `_obtain_remote_payload`.

## Test
- New `tests/test_diff_backup.py`: diff reports local-only + changed, in-sync case, backup produces a usable snapshot with the same rows, and backup refuses an existing destination.
- Smoke-tested both end to end.
- `ruff` clean; `uv run pytest` — 181 passed.

Closes #74 (E5-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)