### PR TITLE
feat(pick): add --multi for fzf multi-select with bulk-friendly output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changed) between the local database and the remote payload.
 - `koda backup --out PATH` writes a consistent single-file SQLite snapshot
   (`VACUUM INTO`).
+- `koda pick --multi/-m` for fzf multi-select: prints selected IDXs (pipe to
+  `remove`/`tag`) or applies `--raw`/`--show` per selection. Extra fzf flags
+  via the `KODA_FZF_OPTS` environment variable.
 
 ## [1.2.0] - 2026-06-06
 

--- a/src/koda/cmd_helpers/interactive.py
+++ b/src/koda/cmd_helpers/interactive.py
@@ -1,5 +1,7 @@
 """Interactive entry pickers (fzf integration and action resolution)."""
 
+import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -39,7 +41,11 @@ def pick_candidates(
     )
 
 
-def pick_with_fzf(candidates: list[MemoRow]) -> str | None:
+def _run_fzf(candidates: list[MemoRow], multi: bool) -> list[str]:
+    """Run fzf over the candidates and return the selected entry refs (idx strings).
+
+    Honors the ``KODA_FZF_OPTS`` environment variable for extra fzf arguments.
+    """
     if shutil.which("fzf") is None:
         exit_error("fzf is not installed. Install fzf to use `koda pick`.")
 
@@ -59,34 +65,52 @@ def pick_with_fzf(candidates: list[MemoRow]) -> str | None:
     # Keep list area readable on narrower terminals by switching to bottom preview.
     preview_window = "right:55%:wrap" if term_cols >= 170 else "down:55%:wrap"
 
+    cmd = [
+        "fzf",
+        "--delimiter",
+        "\t",
+        "--with-nth",
+        "1,3,4,6",
+        "--prompt",
+        "koda> ",
+        "--preview",
+        (
+            "printf 'IDX: %s\\nUID: %s\\nSC: %s\\nTags: %s\\nCreated: %s\\n\\n%s\\n' "
+            "{1} {2} {3} {4} {5} {6}"
+        ),
+        "--preview-window",
+        preview_window,
+    ]
+    if multi:
+        cmd.append("--multi")
+    extra = os.environ.get("KODA_FZF_OPTS", "").strip()
+    if extra:
+        cmd.extend(shlex.split(extra))
+
     proc = subprocess.run(
-        [
-            "fzf",
-            "--delimiter",
-            "\t",
-            "--with-nth",
-            "1,3,4,6",
-            "--prompt",
-            "koda> ",
-            "--preview",
-            (
-                "printf 'IDX: %s\\nUID: %s\\nSC: %s\\nTags: %s\\nCreated: %s\\n\\n%s\\n' "
-                "{1} {2} {3} {4} {5} {6}"
-            ),
-            "--preview-window",
-            preview_window,
-        ],
+        cmd,
         input="\n".join(lines),
         text=True,
         stdout=subprocess.PIPE,
     )
     if proc.returncode != 0:
-        return None
+        return []
 
-    selected = proc.stdout.strip()
-    if not selected:
-        return None
-    return selected.split("\t", 1)[0].strip()
+    refs = []
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line:
+            refs.append(line.split("\t", 1)[0].strip())
+    return refs
+
+
+def pick_with_fzf(candidates: list[MemoRow]) -> str | None:
+    refs = _run_fzf(candidates, multi=False)
+    return refs[0] if refs else None
+
+
+def pick_with_fzf_multi(candidates: list[MemoRow]) -> list[str]:
+    return _run_fzf(candidates, multi=True)
 
 
 def resolve_pick_action(

--- a/src/koda/commands/exec.py
+++ b/src/koda/commands/exec.py
@@ -7,7 +7,12 @@ import typer
 
 from ..cli_utils import exit_error
 from ..cmd_helpers.display import print_memo as _print_memo
-from ..cmd_helpers.interactive import pick_candidates, pick_with_fzf, resolve_pick_action
+from ..cmd_helpers.interactive import (
+    pick_candidates,
+    pick_with_fzf,
+    pick_with_fzf_multi,
+    resolve_pick_action,
+)
 from ..config import ConfigManager, ValidationError
 from ..main import app
 from ..runtime import (
@@ -115,16 +120,22 @@ def pick(
     show_mode: bool = typer.Option(
         False, "--show", "-s", help="Show selected entry with metadata."
     ),
+    multi: bool = typer.Option(
+        False,
+        "--multi",
+        "-m",
+        help="Multi-select. Prints selected IDXs (pipe to remove/tag), or applies --raw/--show.",
+    ),
 ):
-    """Pick an entry with fzf, then run an action (or print IDX). Alias: `koda p`."""
+    """Pick an entry with fzf, then run an action (or print IDX). Alias: `koda p`.
+
+    With --multi, select several entries: by default their IDXs are printed
+    (one per line) for piping, e.g. `koda pick -m | xargs koda remove -f`.
+    --raw/--show apply the action to each selection; --edit/--exec are
+    single-entry only. Extra fzf flags can be set via KODA_FZF_OPTS.
+    """
     if print_id and (edit_mode or exec_mode or raw_mode or show_mode):
         exit_error("--print-id/-p cannot be combined with action flags.")
-
-    action: str | None = (
-        None
-        if print_id
-        else resolve_pick_action(get_config(), edit_mode, exec_mode, raw_mode, show_mode, print_id)
-    )
 
     init_db()
     candidates = pick_candidates(
@@ -132,6 +143,30 @@ def pick(
     )
     if not candidates:
         exit_error("No entries found.", style="yellow")
+
+    if multi:
+        if edit_mode or exec_mode:
+            exit_error(
+                "--multi cannot be combined with --edit/--exec; use --raw/--show, "
+                "or pipe --print-id output to `koda remove`/`koda tag`."
+            )
+        refs = pick_with_fzf_multi(candidates)
+        if not refs:
+            raise typer.Exit(code=0)
+        if not (raw_mode or show_mode):
+            for ref in refs:
+                sys.stdout.write(ref + "\n")
+            return
+        action = "raw" if raw_mode else "show"
+        for ref in refs:
+            _run_pick_action(action, ref)
+        return
+
+    action: str | None = (
+        None
+        if print_id
+        else resolve_pick_action(get_config(), edit_mode, exec_mode, raw_mode, show_mode, print_id)
+    )
 
     selected_ref = pick_with_fzf(candidates)
     if selected_ref is None:

--- a/tests/test_pick_multi.py
+++ b/tests/test_pick_multi.py
@@ -1,0 +1,66 @@
+"""Tests for pick multi-select fzf integration (#72).
+
+fzf is not available in CI, so subprocess.run and TTY/availability checks are
+mocked; these tests cover ref parsing, the --multi flag, and KODA_FZF_OPTS.
+"""
+
+import subprocess
+
+import pytest
+
+from koda.cmd_helpers import interactive
+from koda.models import MemoRow
+
+
+def _row(idx, uid):
+    return MemoRow(
+        id=idx,
+        uid=uid,
+        idx=idx,
+        content=f"body {idx}",
+        tags="",
+        shortcut=None,
+        created_at="2026-01-01 00:00:00",
+        modified_at="2026-01-01 00:00:00",
+    )
+
+
+@pytest.fixture
+def fzf_env(monkeypatch):
+    monkeypatch.setattr(interactive.shutil, "which", lambda _: "/usr/bin/fzf")
+    monkeypatch.setattr(interactive.sys.stdin, "isatty", lambda: True)
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout=captured["stdout"])
+
+    monkeypatch.setattr(interactive.subprocess, "run", fake_run)
+    return captured
+
+
+def test_single_pick_returns_first_ref(fzf_env):
+    fzf_env["stdout"] = "3\tuid3\t-\t-\t2026\tbody 3\n"
+    assert interactive.pick_with_fzf([_row(3, "uid3")]) == "3"
+    assert "--multi" not in fzf_env["cmd"]
+
+
+def test_multi_pick_returns_all_refs(fzf_env):
+    fzf_env["stdout"] = "1\tuid1\t-\t-\t2026\tbody 1\n2\tuid2\t-\t-\t2026\tbody 2\n"
+    refs = interactive.pick_with_fzf_multi([_row(1, "uid1"), _row(2, "uid2")])
+    assert refs == ["1", "2"]
+    assert "--multi" in fzf_env["cmd"]
+
+
+def test_multi_no_selection_returns_empty(fzf_env):
+    fzf_env["stdout"] = ""
+    assert interactive.pick_with_fzf_multi([_row(1, "uid1")]) == []
+
+
+def test_koda_fzf_opts_appended(fzf_env, monkeypatch):
+    monkeypatch.setenv("KODA_FZF_OPTS", "--height 40% --reverse")
+    fzf_env["stdout"] = "1\tuid1\t-\t-\t2026\tbody 1\n"
+    interactive.pick_with_fzf([_row(1, "uid1")])
+    assert "--height" in fzf_env["cmd"]
+    assert "40%" in fzf_env["cmd"]
+    assert "--reverse" in fzf_env["cmd"]


### PR DESCRIPTION
## Summary
- `koda pick --multi/-m` enables fzf multi-select. By default the selected IDXs are printed one per line, so they pipe straight into bulk edits:
  ```bash
  koda pick -m | xargs koda remove -f
  koda pick -m | xargs koda tag -t archived
  ```
- `--raw` / `--show` apply the action to each selection; `--edit` / `--exec` stay single-entry only (error with `--multi`).
- New **`KODA_FZF_OPTS`** environment variable appends extra arguments to every fzf call (single and multi).

Refactors the fzf invocation into a shared `_run_fzf(candidates, multi)` returning all selected refs; `pick_with_fzf` keeps its single-ref API and adds `pick_with_fzf_multi`.

## Test
- New `tests/test_pick_multi.py` (fzf mocked — unavailable in CI): single vs multi ref parsing, empty selection, `--multi` flag passed, and `KODA_FZF_OPTS` appended.
- `ruff` clean; `uv run pytest` — 185 passed.

Closes #72 (E5-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)