### PR TITLE
feat(config): add explicit `config show` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `koda pick --multi/-m` for fzf multi-select: prints selected IDXs (pipe to
   `remove`/`tag`) or applies `--raw`/`--show` per selection. Extra fzf flags
   via the `KODA_FZF_OPTS` environment variable.
+- `koda config show` as an explicit subcommand, equivalent to bare
+  `koda config`.
 
 ## [1.2.0] - 2026-06-06
 

--- a/src/koda/commands/config.py
+++ b/src/koda/commands/config.py
@@ -26,16 +26,8 @@ config_app = typer.Typer(
 )
 
 
-@config_app.callback(invoke_without_command=True)
-def config_show(
-    ctx: typer.Context,
-    json_output: bool = typer.Option(
-        False, "--json", help="Output the resolved config as hierarchical JSON."
-    ),
-) -> None:
-    """Show all settings with their current values and source."""
-    if ctx.invoked_subcommand is not None:
-        return
+def _render_config(json_output: bool) -> None:
+    """Print every setting with its value (and source, in the table view)."""
     if json_output:
         out: dict[str, dict[str, object]] = {}
         for dotkey in _ALL_KEYS:
@@ -58,6 +50,32 @@ def config_show(
         label = src_labels.get(src, "[dim]default[/dim]")
         display_val = "****" if dotkey == "turso.token" and val else str(val)
         console.print(f"  {dotkey:<{key_width}} = {display_val:<24} {label}")
+
+
+@config_app.callback(invoke_without_command=True)
+def config_show(
+    ctx: typer.Context,
+    json_output: bool = typer.Option(
+        False, "--json", help="Output the resolved config as hierarchical JSON."
+    ),
+) -> None:
+    """Show all settings with their current values and source.
+
+    Running bare `koda config` is equivalent to `koda config show`.
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+    _render_config(json_output)
+
+
+@config_app.command("show")
+def config_show_cmd(
+    json_output: bool = typer.Option(
+        False, "--json", help="Output the resolved config as hierarchical JSON."
+    ),
+) -> None:
+    """Show all settings with their current values and source (same as bare `koda config`)."""
+    _render_config(json_output)
 
 
 @config_app.command("get")

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -67,6 +67,19 @@ def test_config_json_is_hierarchical(wired_db, capsys):
     assert "per_page" in data["list"]
 
 
+def test_config_show_subcommand_matches_callback(wired_db, capsys):
+    """`config show` (explicit subcommand) produces the same JSON as bare `config`."""
+    config_cmd.config_show_cmd(json_output=True)
+    via_subcommand = capsys.readouterr().out
+
+    ctx = type("Ctx", (), {"invoked_subcommand": None})()
+    config_cmd.config_show(ctx, json_output=True)
+    via_callback = capsys.readouterr().out
+
+    assert via_subcommand == via_callback
+    assert json.loads(via_subcommand)["defaults"]["cmd"] == "raw"
+
+
 def test_config_json_masks_token(wired_db, capsys, monkeypatch):
     cfg = runtime.get_config()
     monkeypatch.setattr(cfg, "turso_token", "super-secret-token")


### PR DESCRIPTION
## Summary
Docs referenced `koda config show`, but only a bare `koda config` callback existed (a documentation/implementation mismatch). This adds a real `config show` subcommand that renders the same output (table or `--json`) as the callback, so both `koda config` and `koda config show` work. Shared rendering is factored into `_render_config`.

## Test
- New test: `config show` output equals the bare-`config` callback output.
- Smoke-tested `koda config`, `koda config show`, `koda config show --json`.
- `ruff` clean; `uv run pytest` — 186 passed.

Closes #81 (E6-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)