### PR TITLE
docs(readme): add table of contents and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
 # koda-cli
 
 [![CI](https://github.com/ngt22/koda-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/ngt22/koda-cli/actions/workflows/ci.yml)
+[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue)](https://github.com/ngt22/koda-cli/blob/main/pyproject.toml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](https://github.com/ngt22/koda-cli/blob/main/LICENSE)
 
 A **text store** for the terminal. Save any text — commands, paths, templates, notes — to SQLite and recall it instantly by index, shortcut, or fuzzy search. Saved entries can be executed as shell commands, making koda a **terminal launcher**. Sync via a private Git repository to share the same store across machines, giving you a **cross-machine clipboard** that works from any terminal. Built with Python, Typer, and Rich.
+
+## Contents
+
+- [Why koda?](#why-koda)
+- [Features](#features)
+- [In action](#in-action)
+- [Quick reference](#quick-reference)
+- [Installation](#installation)
+- [Update](#update)
+- [Command reference](#command-reference)
+- [Options](#options)
+- [Recommended aliases](#recommended-aliases)
+- [Configuration](#configuration)
+- [Environment variables](#environment-variables)
+- [Turso (remote database)](#turso-remote-database)
+- [Git sync](#git-sync-multi-machine-sharing-via-github)
+- [Example uses](#example-uses)
+- [Development](#development)
+- [License](#license)
 
 ## Why koda?
 


### PR DESCRIPTION
## Summary
- Adds a mini **Contents** TOC below the intro, linking the top-level sections.
- Adds **Python versions** and **MIT license** shield badges next to the existing CI badge.

The PyPI version badge is intentionally deferred until the package is actually published (E4-5 / #66, which is out of scope for now).

## Test
Docs only. TOC anchors match the current `##` headings.

Closes #78 (E6-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)