### PR TITLE
security(sync): reject payload paths under .git/ (#47)

### DIFF
--- a/src/koda/config.py
+++ b/src/koda/config.py
@@ -83,6 +83,20 @@ EXAMPLE_TEMPLATE = (
 )
 
 
+def valid_payload_file(v: Any) -> bool:
+    """True if ``v`` is a safe relative payload path. Rejects empty values,
+    absolute paths, ``..`` traversal, and any path with a ``.git`` component.
+    The last guard stops a tampered config from steering `koda push` into
+    ``.git/hooks/post-merge`` (or any other repo-internal file), which would
+    let a written payload execute on the next git operation."""
+    if not isinstance(v, str) or len(v.strip()) == 0:
+        return False
+    parts = Path(v).parts
+    if Path(v).is_absolute() or ".." in parts or ".git" in parts:
+        return False
+    return True
+
+
 def valid_exec_shell(v: Any) -> bool:
     """True if ``v`` names an allowlisted shell that resolves to an existing
     absolute executable. Guards `koda x` against arbitrary-binary redirection
@@ -180,13 +194,8 @@ _FIELD_SPECS: dict[str, FieldSpec] = {
     "git.sync_path": FieldSpec(str),
     "git.payload_file": FieldSpec(
         str,
-        lambda v: (
-            isinstance(v, str)
-            and len(v.strip()) > 0
-            and not Path(v).is_absolute()
-            and ".." not in Path(v).parts
-        ),
-        "must be a non-empty path relative to git.sync_path without '..' components",
+        valid_payload_file,
+        "must be a non-empty path relative to git.sync_path without '..' or '.git' components",
     ),
     "git.sync_format": FieldSpec(
         str,

--- a/src/koda/git_sync.py
+++ b/src/koda/git_sync.py
@@ -51,6 +51,15 @@ def resolve_payload_path(config: Config, sync_root: Path) -> Path:
     if not rel:
         rel = "koda-sync.jsonl"
     rel_path = Path(rel)
+    if rel_path.is_absolute() or ".." in rel_path.parts or ".git" in rel_path.parts:
+        # The config validator already rejects these, but values loaded from a
+        # hand-edited config.toml or KODA_GIT_PAYLOAD_FILE bypass validate(),
+        # so re-check here before we ever write into the repo. Blocking '.git'
+        # stops the payload from overwriting e.g. .git/hooks/post-merge.
+        exit_error(
+            "git.payload_file must be a relative path inside git.sync_path "
+            "without '..' or '.git' components."
+        )
     payload = (sync_root / rel_path).resolve()
     try:
         payload.relative_to(sync_root)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -106,7 +106,18 @@ class TestValidate:
     def test_payload_file_valid(self):
         assert ConfigManager.validate("git.payload_file", "koda-sync.jsonl") == "koda-sync.jsonl"
 
-    @pytest.mark.parametrize("value", ["", "   ", "/abs/path.jsonl", "../escape.jsonl"])
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "   ",
+            "/abs/path.jsonl",
+            "../escape.jsonl",
+            ".git/hooks/post-merge",
+            ".git/config",
+            "sub/.git/hooks/post-merge",
+        ],
+    )
     def test_payload_file_invalid(self, value):
         with pytest.raises(ValidationError):
             ConfigManager.validate("git.payload_file", value)

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -3,12 +3,31 @@
 import json
 
 import pytest
+import typer
 
-from koda.git_sync import GitSyncPayload
+from koda.config import Config
+from koda.git_sync import GitSyncPayload, resolve_payload_path
 
 
 def test_dump_empty_db(db):
     assert GitSyncPayload.dump(db) == b""
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [".git/hooks/post-merge", ".git/config", "sub/.git/hooks/post-merge", "../escape.jsonl"],
+)
+def test_resolve_payload_path_rejects_unsafe(tmp_path, rel):
+    """Even when validate() is bypassed (file/env config), resolve_payload_path
+    must refuse '.git' and traversal components before writing into the repo."""
+    cfg = Config(git_payload_file=rel)
+    with pytest.raises(typer.Exit):
+        resolve_payload_path(cfg, tmp_path)
+
+
+def test_resolve_payload_path_allows_normal(tmp_path):
+    cfg = Config(git_payload_file="koda-sync.jsonl")
+    assert resolve_payload_path(cfg, tmp_path) == (tmp_path / "koda-sync.jsonl")
 
 
 def test_load_empty_bytes():


### PR DESCRIPTION
## Summary
Closes #47 (sub-issue of epic #36).

The `git.payload_file` validator rejected absolute paths and `..` traversal but allowed relative paths with a `.git` component such as `.git/hooks/post-merge`. An attacker able to tamper with the config could point the sync payload at a git hook, so `koda push` would overwrite it and the hook would execute on the next git operation.

## Changes
- `valid_payload_file()` in `config.py` now also rejects any path containing a `.git` component.
- `resolve_payload_path()` in `git_sync.py` re-checks absolute / `..` / `.git` before writing, as defense in depth — values from a hand-edited `config.toml` or `KODA_GIT_PAYLOAD_FILE` bypass `validate()`.
- Added validator tests (`.git/hooks/post-merge`, `.git/config`, `sub/.git/...`) and `resolve_payload_path` tests.

## Testing
- `uv run pytest` (full suite green)
- `uv run ruff check src tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)