### PR TITLE
security(db): validate db.path to prevent arbitrary file creation (#48)

### DIFF
--- a/src/koda/config.py
+++ b/src/koda/config.py
@@ -83,6 +83,42 @@ EXAMPLE_TEMPLATE = (
 )
 
 
+DB_PATH_OVERRIDE_ENV = "KODA_DB_PATH_OVERRIDE"
+
+
+def allowed_db_roots() -> list[Path]:
+    """Directories a local db.path may live under: the default koda data dir
+    (~/.local/share/koda) and, when set, $XDG_DATA_HOME/koda."""
+    roots = [DEFAULT_DB_DIR]
+    xdg = os.getenv("XDG_DATA_HOME")
+    if xdg and xdg.strip():
+        roots.append(Path(xdg) / "koda")
+    return [r.expanduser() for r in roots]
+
+
+def db_path_allowed(v: Any) -> bool:
+    """True if ``v`` is a local DB path inside an allowed data dir. Blocks
+    ``KODA_DB_PATH=/home/victim/.ssh/authorized_keys`` and similar env/config
+    injection from creating arbitrary files via init_db. The
+    ``KODA_DB_PATH_OVERRIDE`` env var (truthy) lifts the restriction for CI and
+    tests that need a temp location."""
+    if os.getenv(DB_PATH_OVERRIDE_ENV):
+        return True
+    if not isinstance(v, str) or not v.strip():
+        return False
+    try:
+        resolved = Path(v).expanduser().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
+    for root in allowed_db_roots():
+        try:
+            resolved.relative_to(root.resolve())
+            return True
+        except ValueError:
+            continue
+    return False
+
+
 def valid_payload_file(v: Any) -> bool:
     """True if ``v`` is a safe relative payload path. Rejects empty values,
     absolute paths, ``..`` traversal, and any path with a ``.git`` component.
@@ -183,7 +219,12 @@ _FIELD_SPECS: dict[str, FieldSpec] = {
         ),
         f'must include "idx"; available: {", ".join(VALID_LIST_COLUMNS)}',
     ),
-    "db.path": FieldSpec(str),
+    "db.path": FieldSpec(
+        str,
+        db_path_allowed,
+        "must be inside the koda data dir (~/.local/share/koda or "
+        "$XDG_DATA_HOME/koda); set KODA_DB_PATH_OVERRIDE=1 to allow another location",
+    ),
     "db.backend": FieldSpec(
         str,
         lambda v: v in tuple(b.value for b in DbBackend),

--- a/src/koda/runtime.py
+++ b/src/koda/runtime.py
@@ -17,7 +17,7 @@ from rich.console import Console
 
 from .cli_utils import exit_error
 from .cmd_helpers.parsing import parse_var_items
-from .config import Config, ConfigManager, ValidationError
+from .config import Config, ConfigManager, ValidationError, db_path_allowed
 from .db import DatabaseError, MemoDatabase
 
 __app_name__ = "koda"
@@ -68,6 +68,15 @@ def _resolve_db() -> MemoDatabase:
     global _db
     if _db is None:
         cfg = get_config()
+        # db.path from a config file or KODA_DB_PATH env bypasses validate(),
+        # so re-check here before init_db can mkdir/create a file at an
+        # attacker-chosen location (e.g. ~/.ssh/authorized_keys).
+        if cfg.db_backend == "local" and not db_path_allowed(cfg.db_path):
+            exit_error(
+                f"Refusing to use db.path {cfg.db_path!r}: outside the koda data dir "
+                "(~/.local/share/koda or $XDG_DATA_HOME/koda). "
+                "Set KODA_DB_PATH_OVERRIDE=1 to allow another location."
+            )
         _db = MemoDatabase(
             backend=cfg.db_backend,
             path=Path(cfg.db_path).expanduser(),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -129,12 +129,44 @@ class TestValidate:
         with pytest.raises(ValidationError):
             ConfigManager.validate("git.sync_format", "yaml")
 
-    @pytest.mark.parametrize("key", ["db.path", "turso.url", "turso.token", "git.sync_path"])
+    @pytest.mark.parametrize("key", ["turso.url", "turso.token", "git.sync_path"])
     def test_no_validator_passthrough(self, key):
         assert ConfigManager.validate(key, "anything") == "anything"
 
     def test_unknown_key_passthrough(self):
         assert ConfigManager.validate("unknown.key", "x") == "x"
+
+
+class TestDbPath:
+    def test_default_path_valid(self):
+        from koda.config import DEFAULT_DB_PATH
+
+        assert ConfigManager.validate("db.path", str(DEFAULT_DB_PATH)) == str(DEFAULT_DB_PATH)
+
+    def test_inside_data_dir_valid(self):
+        from koda.config import DEFAULT_DB_DIR
+
+        path = str(DEFAULT_DB_DIR / "sub" / "other.db")
+        assert ConfigManager.validate("db.path", path) == path
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/home/victim/.ssh/authorized_keys", "/tmp/evil.db", "relative.db"],
+    )
+    def test_outside_data_dir_invalid(self, path, monkeypatch):
+        monkeypatch.delenv("KODA_DB_PATH_OVERRIDE", raising=False)
+        with pytest.raises(ValidationError):
+            ConfigManager.validate("db.path", path)
+
+    def test_override_env_allows_arbitrary_path(self, monkeypatch):
+        monkeypatch.setenv("KODA_DB_PATH_OVERRIDE", "1")
+        assert ConfigManager.validate("db.path", "/tmp/evil.db") == "/tmp/evil.db"
+
+    def test_xdg_data_home_root_valid(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("KODA_DB_PATH_OVERRIDE", raising=False)
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        path = str(tmp_path / "koda" / "koda.db")
+        assert ConfigManager.validate("db.path", path) == path
 
 
 class TestExecShell:

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -17,6 +17,7 @@ def _base_env(tmp_path, db_path):
 
     env = {k: os.environ[k] for k in ENV_KEYS if k in os.environ}
     env["KODA_DB_PATH"] = str(db_path)
+    env["KODA_DB_PATH_OVERRIDE"] = "1"  # allow the temp DB path outside the data dir
     env["KODA_CONFIG_PATH"] = str(tmp_path / "nonexistent.toml")
     return env
 

--- a/tests/test_lazy_init.py
+++ b/tests/test_lazy_init.py
@@ -9,6 +9,9 @@ without HOME/env and makes it testable.
 import subprocess
 import sys
 
+import pytest
+import typer
+
 import koda.runtime as runtime
 from koda.config import Config
 from koda.db import MemoDatabase
@@ -53,6 +56,9 @@ def test_get_db_is_lazy_and_cached(monkeypatch, tmp_path):
     cfg.turso_url = ""
     cfg.turso_token = ""
 
+    # A temp path lives outside the koda data dir; the override env lets tests
+    # use it (the same escape hatch CI relies on).
+    monkeypatch.setenv("KODA_DB_PATH_OVERRIDE", "1")
     monkeypatch.setattr(runtime, "_db", None)
     monkeypatch.setattr(runtime, "get_config", lambda: cfg)
 
@@ -60,3 +66,18 @@ def test_get_db_is_lazy_and_cached(monkeypatch, tmp_path):
     assert isinstance(db, MemoDatabase)
     # Second call returns the cached handle.
     assert runtime.get_db() is db
+
+
+def test_get_db_rejects_path_outside_data_dir(monkeypatch):
+    """A local db.path outside the data dir (e.g. via KODA_DB_PATH injection)
+    is refused before any file is created."""
+    cfg = Config()
+    cfg.db_backend = "local"
+    cfg.db_path = "/tmp/evil.db"
+
+    monkeypatch.delenv("KODA_DB_PATH_OVERRIDE", raising=False)
+    monkeypatch.setattr(runtime, "_db", None)
+    monkeypatch.setattr(runtime, "get_config", lambda: cfg)
+
+    with pytest.raises(typer.Exit):
+        runtime.get_db()

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -55,6 +55,7 @@ def test_raw_subprocess_is_newline_terminated(tmp_path, monkeypatch):
 
     env = {
         "KODA_DB_PATH": str(db_path),
+        "KODA_DB_PATH_OVERRIDE": "1",  # allow the temp DB path outside the data dir
         "KODA_CONFIG_PATH": str(tmp_path / "nonexistent.toml"),
         "PATH": __import__("os").environ.get("PATH", ""),
     }


### PR DESCRIPTION
## Summary
Closes #48 (sub-issue of epic #36).

`KODA_DB_PATH=/home/victim/.ssh/authorized_keys` (or a tampered `config.toml`) could steer `db.path` at an arbitrary location; `init_db` would `mkdir` the parent and create a SQLite file there. This restricts a local `db.path` to the koda data dir.

## Changes
- `config.allowed_db_roots()` / `db_path_allowed()`: a local `db.path` must resolve inside `~/.local/share/koda` or `$XDG_DATA_HOME/koda`. `KODA_DB_PATH_OVERRIDE=1` lifts the restriction (escape hatch for CI/tests, per the issue).
- `db.path` now has a config validator (so `koda config set db.path …` is checked).
- `runtime._resolve_db()` re-checks before constructing the DB handle, because values from a config file or `KODA_DB_PATH` env bypass `validate()`.
- mkdir of the data dir already uses mode `0o700` (from #44).

## Testing
- Validator accept (data dir, XDG root) / reject (`~/.ssh/...`, `/tmp`, relative) cases; override escape hatch; runtime-level rejection.
- Subprocess tests that legitimately use a temp DB now pass `KODA_DB_PATH_OVERRIDE=1`.
- `uv run pytest` (201 passed), `ruff check`, `ruff format --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)