### PR TITLE
security(sync): track remote-origin entries; warn on exec; add pull --dry-run (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A **text store** for the terminal. Save any text — commands, paths, templates,
 - [Turso (remote database)](#turso-remote-database)
 - [Git sync](#git-sync-multi-machine-sharing-via-github)
 - [Example uses](#example-uses)
+- [Security model](#security-model)
 - [Development](#development)
 - [License](#license)
 
@@ -730,6 +731,21 @@ koda pull   # git pull the clone, merge koda-sync.jsonl into local DB
 
 `push` does a `git pull --rebase` before writing the payload so the branch stays linear. `pull` merges by `uid` — entries that already exist locally are updated only if the incoming `modified_at` is newer.
 
+### Remote trust boundary
+
+The sync remote is **outside your trust boundary**. Anyone who can write to it (a compromised account, a shared repo, a malicious collaborator) can change the body of any synced entry — including one bound to a shortcut you `exec`. To contain this:
+
+- **Entries arriving via `pull` are marked `source=remote`.** `koda exec`/`koda x` **prompts for confirmation before running a `source=remote` entry**, so a silently rewritten `deploy` snippet cannot execute unattended. Reviewing the entry with `koda edit` clears the flag back to `local`; `koda x -f/--force` skips the prompt (e.g. in trusted scripts).
+- **Preview before you merge.** `koda pull --dry-run` shows the exact insert/update diff *without* touching the local database, so you can inspect incoming changes first.
+- **The `source` flag never crosses the wire.** It is local-only state and is not written to (or read from) `koda-sync.jsonl`, so a remote cannot label its own entries `local` to dodge the prompt.
+
+```bash
+koda pull --dry-run   # show what would change, write nothing
+koda pull             # merge; new/updated entries become source=remote
+koda x deploy         # prompts because 'deploy' came from the remote
+koda x deploy -f      # run without prompting
+```
+
 ### Setting up a second machine
 
 ```bash
@@ -820,6 +836,30 @@ koda x backup   # creates src-20260505-1430.tar.gz each time
 → **[See all examples in EXAMPLES.md](EXAMPLES.md)**
 
 ---
+
+## Security model
+
+koda runs shell commands and syncs data across machines, so it is worth being
+explicit about what it does and does not defend against.
+
+**Threat model.** koda assumes the local user account and the local filesystem
+are trusted, and that **anything reaching the database from outside — a Git
+sync remote, the `KODA_*` environment variables, a hand-edited
+`config.toml` — is not.** The hardening below targets that boundary.
+
+| Area | Risk | Mitigation |
+|---|---|---|
+| `exec` shell | A tampered `exec.shell` could redirect `koda x` to an arbitrary binary | `exec.shell` is restricted to an allowlist (`sh`, `bash`, `zsh`, `fish`) that must resolve to an absolute executable |
+| Git sync poisoning | A writable remote could rewrite the body of an `exec` entry | `pull`-merged entries are marked `source=remote` and **`koda x` prompts before running them**; `pull --dry-run` previews changes; the `source` flag is local-only and never synced. See [Remote trust boundary](#remote-trust-boundary) |
+| uid collision | The old 7-char (28-bit) `uid` was collidable (~16k entries) / preimage-attackable, enabling sync poisoning | `uid` is 16 hex chars (64-bit); legacy short uids still resolve via prefix match |
+| `git.payload_file` | A relative path like `.git/hooks/post-merge` could overwrite a git hook that then executes | The validator and `push` reject any path with `..` or a `.git` component, or an absolute path |
+| `db.path` | `KODA_DB_PATH=~/.ssh/authorized_keys` could create files at an attacker-chosen location | A local `db.path` is restricted to `~/.local/share/koda` / `$XDG_DATA_HOME/koda`; `KODA_DB_PATH_OVERRIDE=1` is the explicit escape hatch for CI/tests |
+| File permissions | World-readable secrets on disk | `config.toml` and the database are written `0600`, their parent dirs `0700` |
+
+**Not in scope.** Entries are stored **in plaintext** — see the repeated note
+above: do not keep passwords, tokens, or other secrets in koda, and use a
+**private** repository for Git sync. koda also trusts the commands you choose
+to store and run; only `exec` entries you trust (or have reviewed).
 
 ## Development
 

--- a/src/koda/commands/exec.py
+++ b/src/koda/commands/exec.py
@@ -5,7 +5,7 @@ import sys
 
 import typer
 
-from ..cli_utils import exit_error
+from ..cli_utils import ExitCode, confirm, exit_error
 from ..cmd_helpers.display import print_memo as _print_memo
 from ..cmd_helpers.interactive import (
     pick_candidates,
@@ -61,10 +61,20 @@ def exec_memo(
             "Examples: -V 'localhost,5432' -V 'name=prod' -V '\"hello world\",\"foo,bar\"'"
         ),
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Skip the confirmation prompt for entries synced from a remote (source=remote).",
+    ),
 ):
     """Execute the memo body as a shell command. Alias: `koda x`.
 
     When no argument is given, this command also accepts one ref from stdin.
+
+    Entries brought in by `koda pull` are marked source=remote and prompt for
+    confirmation before running, since a compromised sync remote could rewrite
+    their body. Editing an entry locally clears the flag; -f skips the prompt.
     """
     if ref is None:
         stdin_refs = _read_stdin_refs()
@@ -75,6 +85,12 @@ def exec_memo(
 
     init_db()
     row = resolve_ref(ref)
+    if row.source == "remote" and not force:
+        label = ref if ref is not None else f"[{row.idx}]"
+        if not confirm(
+            f"Entry {label} was synced from a remote and not reviewed locally. Execute anyway?"
+        ):
+            exit_error("Aborted.", code=ExitCode.CANCELLED, style="yellow")
     content = _apply_vars(row.content.strip() if row.content else "", vars)
     shell = get_config().exec_shell
     try:

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -30,6 +30,40 @@ def _obtain_remote_payload(local_payload_path: Path | None) -> bytes:
     return payload_path.read_bytes()
 
 
+def _preview(content: str, width: int = 50) -> str:
+    """First line of ``content``, collapsed and truncated for one-line display."""
+    first = (content or "").splitlines()[0] if content else ""
+    return first if len(first) <= width else first[: width - 1] + "…"
+
+
+def _print_merge_plan(data: bytes) -> None:
+    """Show what a pull would insert/update without writing (`--dry-run`)."""
+    try:
+        rows = git_sync.GitSyncPayload.load(data)
+    except Exception as e:
+        exit_error(f"Invalid sync payload: {e}")
+
+    plan = git_sync.MemoMerger(get_db()).plan(rows)
+    inserts = [p for p in plan if p["action"] == "insert"]
+    updates = [p for p in plan if p["action"] == "update"]
+    skips = [p for p in plan if p["action"] == "skip"]
+
+    if not (inserts or updates):
+        console.print("[green]Nothing to merge — local is up to date with the payload.[/green]")
+    for p in inserts:
+        console.print(
+            f"[green]+ insert[/green] {p['uid'][:12]}  [{p['idx']}]  {_preview(p['content'])}"
+        )
+    for p in updates:
+        console.print(
+            f"[yellow]~ update[/yellow] {p['uid'][:12]}  [{p['idx']}]  {_preview(p['content'])}"
+        )
+    console.print(
+        f"[dim]{len(inserts)} insert, {len(updates)} update, {len(skips)} skip "
+        f"— dry run, no changes written.[/dim]"
+    )
+
+
 def _merge_payload(data: bytes) -> None:
     """Load a JSONL payload and merge it into the local DB, printing a summary."""
     try:
@@ -114,13 +148,23 @@ def pull(
     local_payload_path: Path | None = typer.Option(
         None, "--file", help="Import from this JSONL file (skip git pull in the clone)."
     ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show the insert/update diff without modifying the local database.",
+    ),
 ):
     """Pull memo JSONL from the Git clone (--file skips git); merge into local DB.
 
-    Merge key is uid + modified_at. Alias: `koda pull`.
+    Merge key is uid + modified_at. Merged entries are marked source=remote and
+    prompt before `koda x` runs them. Use --dry-run to preview the diff first.
+    Alias: `koda pull`.
     """
     init_db()
     data = _obtain_remote_payload(local_payload_path)
+    if dry_run:
+        _print_merge_plan(data)
+        return
     _merge_payload(data)
     console.print("[green]Pull complete.[/green]")
 

--- a/src/koda/db.py
+++ b/src/koda/db.py
@@ -98,12 +98,23 @@ def _migration_0002_widen_uid(conn) -> None:
         conn.execute("UPDATE memos SET uid = ? WHERE id = ?", (new_uid, memo_id))
 
 
+def _migration_0003_add_source(conn) -> None:
+    """Add the ``source`` column: 'local' for entries authored or reviewed on
+    this machine, 'remote' for entries brought in by a Git sync. Existing rows
+    are the user's own work, so they default to 'local'. The column is local
+    state only — it is never written to or read from the sync payload."""
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(memos)").fetchall()}
+    if "source" not in cols:
+        conn.execute("ALTER TABLE memos ADD COLUMN source TEXT NOT NULL DEFAULT 'local'")
+
+
 # Ordered list of schema migrations. Each entry N (0-based) advances the
 # database from PRAGMA user_version N to N+1. Append new migrations to the
 # end; never reorder or rewrite an existing one.
 _MIGRATIONS: list[Callable[[sqlite3.Connection], None]] = [
     _migration_0001_initial_schema,
     _migration_0002_widen_uid,
+    _migration_0003_add_source,
 ]
 
 SCHEMA_VERSION = len(_MIGRATIONS)
@@ -206,7 +217,7 @@ class MemoDatabase:
             sql += " AND shortcut IS NOT NULL AND shortcut != ''"
         return sql, tuple(params)
 
-    _MEMO_COLUMNS = "id, uid, idx, content, tags, shortcut, created_at, modified_at"
+    _MEMO_COLUMNS = "id, uid, idx, content, tags, shortcut, created_at, modified_at, source"
 
     def get_memos(
         self,
@@ -322,9 +333,11 @@ class MemoDatabase:
         modified_at: str,
     ) -> None:
         with self.connection() as conn:
+            # Editing an entry counts as reviewing it: reset source to 'local'
+            # so a previously remote-synced entry no longer warns on exec.
             conn.execute(
                 "UPDATE memos SET content = ?, tags = ?, shortcut = ?, "
-                "created_at = ?, modified_at = ? WHERE id = ?",
+                "created_at = ?, modified_at = ?, source = 'local' WHERE id = ?",
                 (content.strip(), tags, shortcut or None, created_at, modified_at, memo_id),
             )
 

--- a/src/koda/git_sync.py
+++ b/src/koda/git_sync.py
@@ -358,87 +358,160 @@ class MemoMerger:
                 (MemoDatabase.next_idx(conn), memo_id),
             )
 
+    @staticmethod
+    def _sort_key(m: dict):
+        return (
+            parse_memo_datetime(m.get("modified_at")) or parse_memo_datetime(m.get("created_at")),
+            str(m.get("uid") or ""),
+        )
+
+    @staticmethod
+    def _normalize(rm: dict) -> dict | None:
+        """Coerce a raw remote record into the fields merge/plan need, or return
+        None when uid/idx are missing or unparseable (the entry is skipped)."""
+        uid = rm.get("uid")
+        if not uid or not isinstance(uid, str):
+            return None
+        try:
+            want_idx = int(rm["idx"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        content = rm.get("content") if rm.get("content") is not None else ""
+        tags = rm.get("tags") if rm.get("tags") is not None else ""
+        created_at = str(rm.get("created_at") or "").strip() or datetime.now().strftime(
+            DATETIME_FMT
+        )
+        modified_at = str(rm.get("modified_at") or "").strip() or created_at
+        raw_sc = rm.get("shortcut")
+        sc = raw_sc if raw_sc is None or raw_sc == "" else str(raw_sc)
+        return {
+            "uid": uid,
+            "want_idx": want_idx,
+            "content": content,
+            "tags": tags,
+            "created_at": created_at,
+            "modified_at": modified_at,
+            "sc": sc,
+            "r_ts": parse_memo_datetime(modified_at) or parse_memo_datetime(created_at),
+        }
+
+    @staticmethod
+    def _find_local(conn, uid: str):
+        """Locate the local row for a remote uid: exact match, or—for a legacy
+        short uid—an unambiguous uid-prefix match against widened local uids."""
+        local_row = conn.execute(
+            "SELECT id, uid, idx, content, tags, shortcut, created_at, modified_at "
+            "FROM memos WHERE uid = ?",
+            (uid,),
+        ).fetchone()
+        if local_row is None and len(uid) < UID_LENGTH:
+            # Legacy payload: a pre-widening peer still emits 7-char uids. Match
+            # them to the widened local uid by prefix so the entry updates in
+            # place instead of duplicating. Only an unambiguous match is used.
+            candidates = conn.execute(
+                "SELECT id, uid, idx, content, tags, shortcut, created_at, modified_at "
+                "FROM memos WHERE uid LIKE ? ESCAPE '\\' LIMIT 2",
+                (MemoDatabase._uid_prefix_like(uid),),
+            ).fetchall()
+            if len(candidates) == 1:
+                local_row = candidates[0]
+        return local_row
+
     def merge(self, entries: list[dict]) -> tuple[int, int, int, int]:
-        """Return (inserted, updated, skipped, shortcut_dropped)."""
+        """Return (inserted, updated, skipped, shortcut_dropped). Inserted and
+        updated rows are marked source='remote' — untrusted until reviewed
+        locally, so `koda x` prompts before executing them."""
         inserted = updated = skipped = shortcut_dropped = 0
         with self.db.connection() as conn:
-            for rm in sorted(
-                entries,
-                key=lambda m: (
-                    parse_memo_datetime(m.get("modified_at"))
-                    or parse_memo_datetime(m.get("created_at")),
-                    str(m.get("uid") or ""),
-                ),
-            ):
-                uid = rm.get("uid")
-                if not uid or not isinstance(uid, str):
+            for rm in sorted(entries, key=self._sort_key):
+                rec = self._normalize(rm)
+                if rec is None:
                     skipped += 1
                     continue
-                try:
-                    want_idx = int(rm["idx"])
-                except (KeyError, TypeError, ValueError):
-                    skipped += 1
-                    continue
-                content = rm.get("content") if rm.get("content") is not None else ""
-                tags = rm.get("tags") if rm.get("tags") is not None else ""
-                created_at = str(rm.get("created_at") or "").strip() or datetime.now().strftime(
-                    DATETIME_FMT
-                )
-                modified_at = str(rm.get("modified_at") or "").strip() or created_at
-                raw_sc = rm.get("shortcut")
-                sc = raw_sc if raw_sc is None or raw_sc == "" else str(raw_sc)
-
-                r_ts = parse_memo_datetime(modified_at) or parse_memo_datetime(created_at)
-                local_row = conn.execute(
-                    "SELECT id, uid, idx, content, tags, shortcut, created_at, modified_at "
-                    "FROM memos WHERE uid = ?",
-                    (uid,),
-                ).fetchone()
-                if local_row is None and len(uid) < UID_LENGTH:
-                    # Legacy payload: a pre-widening peer still emits 7-char
-                    # uids. Match them to the widened local uid by prefix so the
-                    # entry updates in place instead of duplicating. Only an
-                    # unambiguous single match is accepted.
-                    candidates = conn.execute(
-                        "SELECT id, uid, idx, content, tags, shortcut, created_at, modified_at "
-                        "FROM memos WHERE uid LIKE ? ESCAPE '\\' LIMIT 2",
-                        (MemoDatabase._uid_prefix_like(uid),),
-                    ).fetchall()
-                    if len(candidates) == 1:
-                        local_row = candidates[0]
+                uid = rec["uid"]
+                local_row = self._find_local(conn, uid)
                 if local_row is None:
-                    # uid is absent (local_row is None), idx and shortcut are
-                    # pre-resolved to free values, so this INSERT cannot violate
-                    # any UNIQUE constraint — no retry needed.
-                    new_idx = pick_idx(conn, want_idx)
-                    use_sc = pick_shortcut(conn, uid, sc)
-                    if use_sc is None and sc:
+                    # uid is absent, idx and shortcut are pre-resolved to free
+                    # values, so this INSERT cannot violate any UNIQUE
+                    # constraint — no retry needed.
+                    new_idx = pick_idx(conn, rec["want_idx"])
+                    use_sc = pick_shortcut(conn, uid, rec["sc"])
+                    if use_sc is None and rec["sc"]:
                         shortcut_dropped += 1
                     conn.execute(
                         "INSERT INTO memos "
-                        "(uid, idx, shortcut, content, tags, created_at, modified_at) "
-                        "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                        (uid, new_idx, use_sc, content, tags, created_at, modified_at),
+                        "(uid, idx, shortcut, content, tags, created_at, modified_at, source) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, 'remote')",
+                        (
+                            uid,
+                            new_idx,
+                            use_sc,
+                            rec["content"],
+                            rec["tags"],
+                            rec["created_at"],
+                            rec["modified_at"],
+                        ),
                     )
                     inserted += 1
                     continue
 
                 memo_id = local_row[0]
-                l_created = local_row[6]
-                l_modified = local_row[7]
-                l_ts = parse_memo_datetime(l_modified) or parse_memo_datetime(l_created)
-                if r_ts <= l_ts:
+                l_ts = parse_memo_datetime(local_row[7]) or parse_memo_datetime(local_row[6])
+                if rec["r_ts"] <= l_ts:
                     skipped += 1
                     continue
 
-                use_sc = pick_shortcut(conn, uid, sc)
-                if use_sc is None and sc:
+                use_sc = pick_shortcut(conn, uid, rec["sc"])
+                if use_sc is None and rec["sc"]:
                     shortcut_dropped += 1
-                self._apply_idx_for_row(conn, memo_id, want_idx)
+                self._apply_idx_for_row(conn, memo_id, rec["want_idx"])
                 conn.execute(
                     "UPDATE memos SET shortcut = ?, content = ?, tags = ?, "
-                    "created_at = ?, modified_at = ? WHERE id = ?",
-                    (use_sc, content, tags, created_at, modified_at, memo_id),
+                    "created_at = ?, modified_at = ?, source = 'remote' WHERE id = ?",
+                    (
+                        use_sc,
+                        rec["content"],
+                        rec["tags"],
+                        rec["created_at"],
+                        rec["modified_at"],
+                        memo_id,
+                    ),
                 )
                 updated += 1
         return inserted, updated, skipped, shortcut_dropped
+
+    def plan(self, entries: list[dict]) -> list[dict]:
+        """Read-only classification of a payload for `pull --dry-run`: a list of
+        {action, uid, idx, content} where action is insert/update/skip, without
+        mutating the database. Mirrors merge's insert/update/skip rule; idx
+        shown is the remote's preferred value (conflict resolution is applied
+        only by the real merge)."""
+        out: list[dict] = []
+        with self.db.connection() as conn:
+            for rm in sorted(entries, key=self._sort_key):
+                rec = self._normalize(rm)
+                if rec is None:
+                    out.append(
+                        {
+                            "action": "skip",
+                            "uid": str(rm.get("uid") or "?"),
+                            "idx": None,
+                            "content": "",
+                        }
+                    )
+                    continue
+                local_row = self._find_local(conn, rec["uid"])
+                if local_row is None:
+                    action = "insert"
+                else:
+                    l_ts = parse_memo_datetime(local_row[7]) or parse_memo_datetime(local_row[6])
+                    action = "update" if rec["r_ts"] > l_ts else "skip"
+                out.append(
+                    {
+                        "action": action,
+                        "uid": rec["uid"],
+                        "idx": rec["want_idx"],
+                        "content": rec["content"] or "",
+                    }
+                )
+        return out

--- a/src/koda/models.py
+++ b/src/koda/models.py
@@ -12,7 +12,12 @@ class MemoRow:
 
     Field order matches the canonical SELECT projection used across the
     database layer: id, uid, idx, content, tags, shortcut, created_at,
-    modified_at.
+    modified_at, source.
+
+    ``source`` is a local trust annotation ('local' = authored or reviewed on
+    this machine; 'remote' = brought in by a Git sync and not yet reviewed). It
+    is intentionally NOT part of the sync payload, so a peer cannot label its
+    own entries 'local' to dodge the exec confirmation.
     """
 
     id: int
@@ -23,12 +28,13 @@ class MemoRow:
     shortcut: str | None
     created_at: str | None
     modified_at: str | None = ""
+    source: str = "local"
 
     @classmethod
     def from_row(cls, row) -> Optional["MemoRow"]:
         if row is None:
             return None
-        assert len(row) == 8, f"expected 8 columns, got {len(row)}"
+        assert len(row) == 9, f"expected 9 columns, got {len(row)}"
         return cls(*row)
 
     def to_dict(self) -> dict[str, Any]:
@@ -42,4 +48,5 @@ class MemoRow:
             "shortcut": self.shortcut,
             "created_at": self.created_at,
             "modified_at": self.modified_at,
+            "source": self.source,
         }

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -67,3 +67,46 @@ def test_heredoc_body(tmp_path):
     result = _run_x(tmp_path, "cat <<EOF\nline A\nline B\nEOF")
     assert result.returncode == 0, result.stderr
     assert result.stdout.splitlines() == ["line A", "line B"]
+
+
+def _seed_remote(tmp_path, body):
+    db_path = tmp_path / "exec.db"
+    seed = MemoDatabase(backend="local", path=db_path)
+    seed.init_db()
+    seed.add_memo("rem00001", 1, None, body, "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+    with seed.connection() as conn:
+        conn.execute("UPDATE memos SET source = 'remote' WHERE uid = ?", ("rem00001",))
+    return db_path
+
+
+def _run(tmp_path, db_path, *args):
+    return subprocess.run(
+        [sys.executable, "-c", "from koda.main import app; app()", "x", *args],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        env=_base_env(tmp_path, db_path),
+    )
+
+
+def test_remote_entry_refuses_without_confirmation(tmp_path):
+    """A source=remote entry must not execute unattended (no TTY to confirm)."""
+    db_path = _seed_remote(tmp_path, "echo SHOULD_NOT_RUN")
+    result = _run(tmp_path, db_path, "1")
+    assert result.returncode != 0
+    assert "SHOULD_NOT_RUN" not in result.stdout
+
+
+def test_remote_entry_runs_with_force(tmp_path):
+    """-f skips the confirmation prompt for remote entries."""
+    db_path = _seed_remote(tmp_path, "echo FORCED_RUN")
+    result = _run(tmp_path, db_path, "1", "-f")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "FORCED_RUN"
+
+
+def test_local_entry_runs_without_prompt(tmp_path):
+    """A normal (local) entry executes with no confirmation, even without a TTY."""
+    result = _run_x(tmp_path, "echo LOCAL_OK")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "LOCAL_OK"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -64,6 +64,36 @@ def test_up_migration_from_pre_versioning_schema(tmp_path):
     assert len(row.uid) == UID_LENGTH
 
 
+def test_source_column_added_and_defaults_local(tmp_path):
+    """Migration 0003 adds the source column; pre-existing rows default to
+    'local' (the user's own work)."""
+    old_path = tmp_path / "v2.db"
+    conn = sqlite3.connect(old_path)
+    conn.executescript(
+        """
+        CREATE TABLE memos (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, uid TEXT UNIQUE, idx INTEGER UNIQUE,
+            shortcut TEXT, content TEXT, tags TEXT, created_at TIMESTAMP, modified_at TIMESTAMP
+        );
+        PRAGMA user_version = 2;
+        """
+    )
+    full = compute_uid("body", "2026-01-01 00:00:00")
+    conn.execute(
+        "INSERT INTO memos (uid, idx, content, tags, created_at, modified_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (full, 0, "body", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    db = MemoDatabase(backend="local", path=old_path)
+    db.init_db()
+
+    assert "source" in _columns(db)
+    assert db.get_memo_by_uid(full).source == "local"
+
+
 def test_init_db_is_idempotent(tmp_path):
     db = MemoDatabase(backend="local", path=tmp_path / "idem.db")
     db.init_db()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,16 +4,26 @@ import pytest
 
 from koda.models import MemoRow
 
-# Canonical 8-column row matching _MEMO_COLUMNS in db.py:
-# id, uid, idx, content, tags, shortcut, created_at, modified_at
-_ROW = (1, "abc1234", 5, "hello", "work,home", "hi", "2026-01-01 00:00:00", "2026-01-02 00:00:00")
+# Canonical 9-column row matching _MEMO_COLUMNS in db.py:
+# id, uid, idx, content, tags, shortcut, created_at, modified_at, source
+_ROW = (
+    1,
+    "abc1234",
+    5,
+    "hello",
+    "work,home",
+    "hi",
+    "2026-01-01 00:00:00",
+    "2026-01-02 00:00:00",
+    "local",
+)
 
 
 class TestFromRow:
     def test_none_returns_none(self):
         assert MemoRow.from_row(None) is None
 
-    def test_eight_columns_materializes(self):
+    def test_nine_columns_materializes(self):
         memo = MemoRow.from_row(_ROW)
         assert memo is not None
         assert memo.id == 1
@@ -24,11 +34,12 @@ class TestFromRow:
         assert memo.shortcut == "hi"
         assert memo.created_at == "2026-01-01 00:00:00"
         assert memo.modified_at == "2026-01-02 00:00:00"
+        assert memo.source == "local"
 
-    def test_seven_columns_raises_assertion(self):
+    def test_eight_columns_raises_assertion(self):
         with pytest.raises(AssertionError):
-            MemoRow.from_row(_ROW[:7])
+            MemoRow.from_row(_ROW[:8])
 
-    def test_nine_columns_raises_assertion(self):
+    def test_ten_columns_raises_assertion(self):
         with pytest.raises(AssertionError):
             MemoRow.from_row((*_ROW, "extra"))

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,0 +1,123 @@
+"""Sync source tracking (#45): merged entries are 'remote' and untrusted,
+editing reviews them back to 'local', and the flag never crosses the wire.
+Also covers MemoMerger.plan (the read-only `pull --dry-run` engine)."""
+
+from koda.db import MemoDatabase
+from koda.git_sync import GitSyncPayload, MemoMerger
+
+
+def _entry(uid, idx, content="body", modified_at="2026-01-01 00:00:00", **extra):
+    rec = {
+        "uid": uid,
+        "idx": idx,
+        "shortcut": None,
+        "content": content,
+        "tags": "",
+        "created_at": "2026-01-01 00:00:00",
+        "modified_at": modified_at,
+    }
+    rec.update(extra)
+    return rec
+
+
+def test_add_memo_is_local(db: MemoDatabase):
+    db.add_memo("uid00001", 0, None, "x", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+    assert db.get_memo_by_uid("uid00001").source == "local"
+
+
+def test_merge_marks_inserted_remote(db: MemoDatabase):
+    MemoMerger(db).merge([_entry("aaaaaaaa11111111", 0)])
+    assert db.get_memo_by_uid("aaaaaaaa11111111").source == "remote"
+
+
+def test_merge_marks_updated_remote(db: MemoDatabase):
+    db.add_memo(
+        "aaaaaaaa11111111", 0, None, "old", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00"
+    )
+    MemoMerger(db).merge(
+        [_entry("aaaaaaaa11111111", 0, content="new", modified_at="2026-02-01 00:00:00")]
+    )
+    row = db.get_memo_by_uid("aaaaaaaa11111111")
+    assert row.content == "new" and row.source == "remote"
+
+
+def test_edit_resets_source_to_local(db: MemoDatabase):
+    MemoMerger(db).merge([_entry("aaaaaaaa11111111", 0)])
+    row = db.get_memo_by_uid("aaaaaaaa11111111")
+    assert row.source == "remote"
+    db.update_memo(row.id, "reviewed", "", None, row.created_at, "2026-03-01 00:00:00")
+    assert db.get_memo_by_uid("aaaaaaaa11111111").source == "local"
+
+
+def test_source_is_not_exported_in_payload(db: MemoDatabase):
+    MemoMerger(db).merge([_entry("aaaaaaaa11111111", 0)])
+    payload = GitSyncPayload.dump(db)
+    assert b'"source"' not in payload
+
+
+def test_payload_source_field_is_ignored(db: MemoDatabase):
+    """A malicious payload cannot self-label an entry 'local' to dodge the
+    exec confirmation — merged entries are always 'remote'."""
+    MemoMerger(db).merge([_entry("aaaaaaaa11111111", 0, source="local")])
+    assert db.get_memo_by_uid("aaaaaaaa11111111").source == "remote"
+
+
+def test_loaded_payload_record_has_no_source_key():
+    line = b'{"uid":"u1","idx":0,"content":"c","source":"local"}\n'
+    (rec,) = GitSyncPayload.load(line)
+    assert "source" not in rec
+
+
+# ── pull --dry-run (MemoMerger.plan) ────────────────────────────────────────
+
+
+def test_plan_classifies_insert_update_skip(db: MemoDatabase):
+    db.add_memo(
+        "existing0to0up00", 0, None, "old", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00"
+    )
+    db.add_memo(
+        "existing0to0skip", 1, None, "cur", "", "2026-03-01 00:00:00", "2026-03-01 00:00:00"
+    )
+
+    entries = [
+        _entry("brandnew00000000", 5, content="new entry"),
+        _entry("existing0to0up00", 0, content="newer", modified_at="2026-02-01 00:00:00"),
+        _entry("existing0to0skip", 1, content="older", modified_at="2026-01-01 00:00:00"),
+    ]
+    plan = MemoMerger(db).plan(entries)
+    by_uid = {p["uid"]: p["action"] for p in plan}
+    assert by_uid["brandnew00000000"] == "insert"
+    assert by_uid["existing0to0up00"] == "update"
+    assert by_uid["existing0to0skip"] == "skip"
+
+
+def test_plan_does_not_mutate_database(db: MemoDatabase):
+    db.add_memo(
+        "existing00000000", 0, None, "cur", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00"
+    )
+    before = [(r.uid, r.content, r.source) for r in db.get_memos(limit=None)]
+
+    MemoMerger(db).plan(
+        [
+            _entry("brandnew00000000", 5),
+            _entry("existing00000000", 0, content="changed", modified_at="2026-09-01 00:00:00"),
+        ]
+    )
+    after = [(r.uid, r.content, r.source) for r in db.get_memos(limit=None)]
+    assert before == after
+
+
+def test_plan_counts_match_merge(db: MemoDatabase):
+    db.add_memo(
+        "existing0to0up00", 0, None, "old", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00"
+    )
+    entries = [
+        _entry("brandnew00000000", 5),
+        _entry("existing0to0up00", 0, content="newer", modified_at="2026-02-01 00:00:00"),
+    ]
+    plan = MemoMerger(db).plan(entries)
+    inserts = sum(1 for p in plan if p["action"] == "insert")
+    updates = sum(1 for p in plan if p["action"] == "update")
+
+    ins, upd, _, _ = MemoMerger(db).merge(entries)
+    assert (ins, upd) == (inserts, updates)


### PR DESCRIPTION
## Summary
Closes #45 (sub-issue of epic #36). **High severity.**

A writable Git sync remote could rewrite the body of a synced shortcut and get arbitrary code executed on the victim's `koda x deploy`. This makes sync-origin entries visible and gates their execution.

## Changes
- **Schema migration 0003** adds `memos.source` (`'local'`/`'remote'`); existing rows default to `'local'`. `MemoRow` / `_MEMO_COLUMNS` carry the field.
- **`MemoMerger`** marks inserted/updated rows `source='remote'`. The flag is **local trust state and is never written to or read from the JSONL payload**, so a peer cannot self-label `'local'` to dodge the prompt. `edit` resets it to `'local'` (review = trust).
- **`koda exec`/`x`** prompts before running a `source=remote` entry; `-f/--force` skips it (non-TTY without `-f` refuses).
- **`koda pull --dry-run`** previews the insert/update diff without writing, via a new read-only `MemoMerger.plan()`. Merge field extraction was refactored into `_normalize`/`_find_local`, shared by `merge()` and `plan()` (no behavior change to merge).
- **README**: a "Remote trust boundary" subsection under Git sync plus a consolidated **"Security model"** (threat-model) section; `CLAUDE.md` updated.

## Testing
- Migration adds the column / defaults `local`; merge marks `remote`; `edit` resets to `local`; payload never carries `source` and a malicious `source` field is ignored.
- exec confirmation: local runs unprompted, remote refuses without `-f` on a non-TTY, remote runs with `-f` (verified end-to-end against the real CLI).
- `plan()`: insert/update/skip classification, no DB mutation, counts match `merge()`.
- `uv run pytest` (227 passed), `ruff check`, `ruff format --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)