### PR TITLE
security(exec): guide remote warning to `koda edit`; add exec.confirm_remote opt-out (#125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,16 +735,23 @@ koda pull   # git pull the clone, merge koda-sync.jsonl into local DB
 
 The sync remote is **outside your trust boundary**. Anyone who can write to it (a compromised account, a shared repo, a malicious collaborator) can change the body of any synced entry — including one bound to a shortcut you `exec`. To contain this:
 
-- **Entries arriving via `pull` are marked `source=remote`.** `koda exec`/`koda x` **prompts for confirmation before running a `source=remote` entry**, so a silently rewritten `deploy` snippet cannot execute unattended. Reviewing the entry with `koda edit` clears the flag back to `local`; `koda x -f/--force` skips the prompt (e.g. in trusted scripts).
+- **Entries arriving via `pull` are marked `source=remote`.** `koda exec`/`koda x` **prompts for confirmation before running a `source=remote` entry**, so a silently rewritten `deploy` snippet cannot execute unattended. The recommended way to trust an entry is to **review it with `koda edit <ref>`**, which clears the flag back to `local` permanently. `koda x -f/--force` runs it once without prompting — prefer `edit` over habitually reaching for `-f`, since an `-f` baked into an alias or script silently disables the check.
 - **Preview before you merge.** `koda pull --dry-run` shows the exact insert/update diff *without* touching the local database, so you can inspect incoming changes first.
 - **The `source` flag never crosses the wire.** It is local-only state and is not written to (or read from) `koda-sync.jsonl`, so a remote cannot label its own entries `local` to dodge the prompt.
 
 ```bash
-koda pull --dry-run   # show what would change, write nothing
-koda pull             # merge; new/updated entries become source=remote
-koda x deploy         # prompts because 'deploy' came from the remote
-koda x deploy -f      # run without prompting
+koda pull --dry-run     # show what would change, write nothing
+koda pull               # merge; new/updated entries become source=remote
+koda x deploy           # prompts because 'deploy' came from the remote
+koda edit deploy        # review it → trusted (source=local), no more prompts
+koda x deploy -f        # run once without prompting (does NOT clear the flag)
 ```
+
+> **Disabling the prompt** — if you fully trust your sync remote, set
+> `exec.confirm_remote = false` (or `koda config set exec.confirm_remote false`)
+> to turn the confirmation off. **This is a security downgrade**: a compromised
+> remote could then run arbitrary code via `koda x` with no confirmation. Leave
+> it `true` (the default) unless you control the remote end to end.
 
 ### Setting up a second machine
 
@@ -850,7 +857,7 @@ sync remote, the `KODA_*` environment variables, a hand-edited
 | Area | Risk | Mitigation |
 |---|---|---|
 | `exec` shell | A tampered `exec.shell` could redirect `koda x` to an arbitrary binary | `exec.shell` is restricted to an allowlist (`sh`, `bash`, `zsh`, `fish`) that must resolve to an absolute executable |
-| Git sync poisoning | A writable remote could rewrite the body of an `exec` entry | `pull`-merged entries are marked `source=remote` and **`koda x` prompts before running them**; `pull --dry-run` previews changes; the `source` flag is local-only and never synced. See [Remote trust boundary](#remote-trust-boundary) |
+| Git sync poisoning | A writable remote could rewrite the body of an `exec` entry | `pull`-merged entries are marked `source=remote` and **`koda x` prompts before running them** (review with `koda edit` to trust; `exec.confirm_remote=false` opts out, at the cost of the check); `pull --dry-run` previews changes; the `source` flag is local-only and never synced. See [Remote trust boundary](#remote-trust-boundary) |
 | uid collision | The old 7-char (28-bit) `uid` was collidable (~16k entries) / preimage-attackable, enabling sync poisoning | `uid` is 16 hex chars (64-bit); legacy short uids still resolve via prefix match |
 | `git.payload_file` | A relative path like `.git/hooks/post-merge` could overwrite a git hook that then executes | The validator and `push` reject any path with `..` or a `.git` component, or an absolute path |
 | `db.path` | `KODA_DB_PATH=~/.ssh/authorized_keys` could create files at an attacker-chosen location | A local `db.path` is restricted to `~/.local/share/koda` / `$XDG_DATA_HOME/koda`; `KODA_DB_PATH_OVERRIDE=1` is the explicit escape hatch for CI/tests |

--- a/src/koda/commands/exec.py
+++ b/src/koda/commands/exec.py
@@ -74,7 +74,9 @@ def exec_memo(
 
     Entries brought in by `koda pull` are marked source=remote and prompt for
     confirmation before running, since a compromised sync remote could rewrite
-    their body. Editing an entry locally clears the flag; -f skips the prompt.
+    their body. Review with `koda edit <ref>` to trust an entry permanently
+    (this clears the flag); -f runs it once without prompting. Set
+    exec.confirm_remote=false to disable the prompt entirely (not recommended).
     """
     if ref is None:
         stdin_refs = _read_stdin_refs()
@@ -85,10 +87,20 @@ def exec_memo(
 
     init_db()
     row = resolve_ref(ref)
-    if row.source == "remote" and not force:
+    if row.source == "remote" and not force and get_config().exec_confirm_remote:
         label = ref if ref is not None else f"[{row.idx}]"
+        review_hint = f"Review it with `koda edit {label}` to trust it (clears the flag)"
+        if not sys.stdin.isatty():
+            # No TTY to prompt on (cron, pipes, scripts). Steer toward review
+            # rather than habitual -f, which would defeat the safety check.
+            exit_error(
+                f"Refusing to exec {label}: synced from a remote (source=remote) and not "
+                f"reviewed locally. {review_hint}, or re-run with -f to execute now.",
+                style="yellow",
+            )
         if not confirm(
-            f"Entry {label} was synced from a remote and not reviewed locally. Execute anyway?"
+            f"Entry {label} was synced from a remote and not reviewed locally. "
+            f"{review_hint}. Execute now anyway?"
         ):
             exit_error("Aborted.", code=ExitCode.CANCELLED, style="yellow")
     content = _apply_vars(row.content.strip() if row.content else "", vars)

--- a/src/koda/config.py
+++ b/src/koda/config.py
@@ -80,6 +80,11 @@ EXAMPLE_TEMPLATE = (
     '# sync_format = "jsonl"                     # or KODA_GIT_SYNC_FORMAT\n\n'
     "# [exec]\n"
     '# shell = "sh"\n'
+    "# Prompt before running entries pulled from a remote (source=remote).\n"
+    "# Setting this false DISABLES that safety check — a compromised sync\n"
+    "# remote could then run code via `koda x` with no confirmation. Leave\n"
+    "# true unless you fully trust your sync remote.\n"
+    "# confirm_remote = true\n"
 )
 
 
@@ -176,6 +181,7 @@ class Config:
     git_payload_file: str = "koda-sync.jsonl"
     git_sync_format: str = GIT_SYNC_FORMAT_JSONL
     exec_shell: str = "sh"
+    exec_confirm_remote: bool = True
 
 
 def _dotkey(field_name: str) -> str:
@@ -249,6 +255,7 @@ _FIELD_SPECS: dict[str, FieldSpec] = {
         f"must be an installed shell ({', '.join(EXEC_SHELL_ALLOWLIST)}) "
         "resolvable to an absolute path",
     ),
+    "exec.confirm_remote": FieldSpec(bool),
 }
 
 ALL_KEYS: list[str] = list(_FIELD_SPECS.keys())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -198,3 +198,25 @@ class TestExecShell:
     def test_empty_rejected(self):
         with pytest.raises(ValidationError):
             ConfigManager.validate("exec.shell", "")
+
+
+class TestExecConfirmRemote:
+    def test_default_is_true(self):
+        from koda.config import Config
+
+        assert Config().exec_confirm_remote is True
+
+    @pytest.mark.parametrize("raw,expected", [("false", False), ("0", False), ("true", True)])
+    def test_coerce_bool(self, raw, expected):
+        assert ConfigManager.coerce("exec.confirm_remote", raw) is expected
+
+    def test_coerce_invalid(self):
+        with pytest.raises(ValidationError):
+            ConfigManager.coerce("exec.confirm_remote", "maybe")
+
+    def test_present_in_config_example_template(self):
+        from koda.config import EXAMPLE_TEMPLATE
+
+        assert "confirm_remote" in EXAMPLE_TEMPLATE
+        # The security caveat is spelled out for users about to flip it.
+        assert "DISABLES" in EXAMPLE_TEMPLATE

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -90,11 +90,13 @@ def _run(tmp_path, db_path, *args):
 
 
 def test_remote_entry_refuses_without_confirmation(tmp_path):
-    """A source=remote entry must not execute unattended (no TTY to confirm)."""
+    """A source=remote entry must not execute unattended (no TTY to confirm),
+    and the message steers toward `koda edit` rather than habitual -f."""
     db_path = _seed_remote(tmp_path, "echo SHOULD_NOT_RUN")
     result = _run(tmp_path, db_path, "1")
     assert result.returncode != 0
     assert "SHOULD_NOT_RUN" not in result.stdout
+    assert "koda edit" in result.stderr
 
 
 def test_remote_entry_runs_with_force(tmp_path):
@@ -110,3 +112,21 @@ def test_local_entry_runs_without_prompt(tmp_path):
     result = _run_x(tmp_path, "echo LOCAL_OK")
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "LOCAL_OK"
+
+
+def test_remote_entry_runs_when_confirm_disabled(tmp_path):
+    """With exec.confirm_remote=false, a remote entry runs without prompting."""
+    db_path = _seed_remote(tmp_path, "echo OPTED_OUT")
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("[exec]\nconfirm_remote = false\n", encoding="utf-8")
+    env = _base_env(tmp_path, db_path)
+    env["KODA_CONFIG_PATH"] = str(config_path)
+    result = subprocess.run(
+        [sys.executable, "-c", "from koda.main import app; app()", "x", "1"],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "OPTED_OUT"


### PR DESCRIPTION
## Summary
Closes #125. Follow-up to #45 (epic #36). Two refinements to the `source=remote` exec confirmation.

### 1. Message guidance (alarm-fatigue mitigation)
The non-TTY refusal and the interactive prompt now recommend **`koda edit <ref>`** first — reviewing an entry clears `source` to `local` permanently. `-f` remains the one-shot escape but is no longer the primary suggestion, so users don't habitually bake `-f` into aliases/scripts and silently disable the check.

```
$ koda x deploy        # remote, no TTY
Refusing to exec deploy: synced from a remote (source=remote) and not reviewed
locally. Review it with `koda edit deploy` to trust it (clears the flag), or
re-run with -f to execute now.
```

### 2. `exec.confirm_remote` opt-out (bool, default `true`)
For users who fully trust their sync remote. When `false`, `koda x` does not prompt for `source=remote` entries.

**Disabling is a documented security downgrade** — a compromised remote could then run code via `koda x` with no confirmation. The caveat is spelled out in:
- README → *Remote trust boundary* (a callout) and the *Security model* table row.
- The `koda config edit` example template (`# confirm_remote = true` with a "Setting this false DISABLES that safety check …" comment).

## Testing
- Config: default `True`; `coerce` bool incl. invalid; example template contains the caveat.
- exec (subprocess): remote entry runs without prompt when `confirm_remote=false`; non-TTY refusal message mentions `koda edit`; `-f` and local paths unchanged.
- Verified end-to-end against the real CLI (`config get`/`set`, refusal text, opted-out run).
- `uv run pytest` (234 passed), `ruff check`, `ruff format --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)