### PR TITLE
ci(release): add PyPI trusted-publishing workflow on tag push (#66)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,68 @@
+name: Publish to PyPI
+
+# Publishes koda-cli to PyPI when a version tag (v*) is pushed.
+#
+# Uses PyPI Trusted Publishing (OIDC) — no API token or secret is stored in the
+# repository. Before the first release, the maintainer must register this
+# workflow as a trusted publisher on PyPI:
+#   https://pypi.org/manage/account/publishing/
+#   Project: koda-cli | Owner: ngt22 | Repo: koda-cli
+#   Workflow: publish.yml | Environment: pypi
+#
+# Release flow: bump `version` in pyproject.toml, commit, then
+#   git tag vX.Y.Z && git push origin vX.Y.Z
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Check tag matches package version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(uv version --short)"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Tag v$tag does not match pyproject version $pkg"
+            exit 1
+          fi
+          echo "Releasing version $pkg"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/koda-cli
+    permissions:
+      id-token: write # required for trusted publishing (OIDC)
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -129,18 +129,26 @@ Single-letter aliases are reserved and cannot be used as entry shortcuts.
 
 ```bash
 # uv (recommended)
-uv tool install "koda-cli @ git+https://github.com/ngt22/koda-cli.git"
+uv tool install koda-cli
 
 # pipx
-pipx install "git+https://github.com/ngt22/koda-cli.git"
+pipx install koda-cli
 ```
 
 Turso remote backend (optional):
 
 ```bash
-uv tool install "koda-cli[turso] @ git+https://github.com/ngt22/koda-cli.git"
+uv tool install "koda-cli[turso]"
 # or
-pipx install "git+https://github.com/ngt22/koda-cli.git" --pip-args ".[turso]"
+pipx install koda-cli --pip-args ".[turso]"
+```
+
+Install the latest unreleased code straight from GitHub:
+
+```bash
+uv tool install "koda-cli @ git+https://github.com/ngt22/koda-cli.git"
+# or
+pipx install "git+https://github.com/ngt22/koda-cli.git"
 ```
 
 ## Update


### PR DESCRIPTION
Implements **E4-5 (#66)**, the last open sub-issue of the OSS-hygiene Epic #39. The other six (#62 LICENSE, #63 CONTRIBUTING, #64 templates, #65 CHANGELOG/release, #67 branch cleanup, #68 gitignore) are already merged.

## What this does
- **`.github/workflows/publish.yml`** — on a `v*` tag push:
  - `build` job: `uv build` (sdist + wheel), with a guard that fails if the tag (`vX.Y.Z`) does not match the `pyproject.toml` version.
  - `publish` job: uploads via **PyPI Trusted Publishing (OIDC)** using `pypa/gh-action-pypi-publish` with `id-token: write` and a `pypi` GitHub environment. **No API token is stored in the repo** (addresses the "OIDC trusted publishing to avoid token leakage" criterion).
- **README** — primary install is now `uv tool install koda-cli` / `pipx install koda-cli`; the `git+https` form is kept as a "latest unreleased code" fallback.

## Validation
- `actionlint` clean on `publish.yml`.
- `uv build` verified locally (`koda_cli-1.2.0.tar.gz` + wheel).
- `uv version --short` returns `1.2.0` (used by the tag-match guard).

## ⚠️ Manual maintainer steps (cannot be automated here)
The acceptance criteria include PyPI-side actions that require your PyPI account and cannot be done from this PR:
1. Create/sign in to a PyPI account and **reserve the `koda-cli` name**.
2. Register this workflow as a **trusted publisher** at https://pypi.org/manage/account/publishing/ — Project `koda-cli`, Owner `ngt22`, Repo `koda-cli`, Workflow `publish.yml`, Environment `pypi`.
3. Push a version tag (e.g. `git tag v1.2.1 && git push origin v1.2.1`) to trigger the first publish.

These prerequisites are documented in the workflow header comment.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)