### PR TITLE
docs(readme): revert install to git-based (not publishing to PyPI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,26 +129,18 @@ Single-letter aliases are reserved and cannot be used as entry shortcuts.
 
 ```bash
 # uv (recommended)
-uv tool install koda-cli
+uv tool install "koda-cli @ git+https://github.com/ngt22/koda-cli.git"
 
 # pipx
-pipx install koda-cli
+pipx install "git+https://github.com/ngt22/koda-cli.git"
 ```
 
 Turso remote backend (optional):
 
 ```bash
-uv tool install "koda-cli[turso]"
+uv tool install "koda-cli[turso] @ git+https://github.com/ngt22/koda-cli.git"
 # or
-pipx install koda-cli --pip-args ".[turso]"
-```
-
-Install the latest unreleased code straight from GitHub:
-
-```bash
-uv tool install "koda-cli @ git+https://github.com/ngt22/koda-cli.git"
-# or
-pipx install "git+https://github.com/ngt22/koda-cli.git"
+pipx install "git+https://github.com/ngt22/koda-cli.git" --pip-args ".[turso]"
 ```
 
 ## Update


### PR DESCRIPTION
PyPI distribution is not planned for now, so the `uv tool install koda-cli` / `pipx install koda-cli` instructions added in #128 would fail for users. This restores the `git+https` install (including the `[turso]` extra) as the primary path.

The `publish.yml` trusted-publishing workflow stays in place but dormant (it only triggers on `v*` tags), ready if PyPI distribution is revisited later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)