### PR TITLE
security(config): TOML-injection + token leak fixes; robust $EDITOR handling

### DIFF
--- a/src/koda/commands/config.py
+++ b/src/koda/commands/config.py
@@ -6,8 +6,6 @@ with ``app.add_typer``. It must not import ``koda.main`` so that main can import
 """
 
 import json
-import os
-import subprocess
 import sys
 
 import typer
@@ -15,7 +13,13 @@ import typer
 from ..cli_utils import confirm, exit_error
 from ..config import ALL_KEYS as _ALL_KEYS
 from ..config import CONFIG_PATH, EXAMPLE_TEMPLATE, ConfigManager, ValidationError
-from ..runtime import console, get_config, get_config_manager, get_config_sources
+from ..runtime import (
+    console,
+    get_config,
+    get_config_manager,
+    get_config_sources,
+    launch_editor,
+)
 
 config_app = typer.Typer(
     name="config",
@@ -81,11 +85,22 @@ def config_show_cmd(
 @config_app.command("get")
 def config_get(
     key: str = typer.Argument(..., help="Config key (e.g. defaults.cmd)."),
+    reveal: bool = typer.Option(
+        False, "--reveal", help="Print secret values (e.g. turso.token) in clear text."
+    ),
 ) -> None:
-    """Print a single config value (plain text, for scripting)."""
+    """Print a single config value (plain text, for scripting).
+
+    Secret values such as ``turso.token`` are masked as ``****`` unless
+    ``--reveal`` is given, so the token does not leak into shell history,
+    CI logs, or terminal scrollback by accident.
+    """
     if key not in _ALL_KEYS:
         exit_error(f"Unknown key: {key!r}. Valid keys: {', '.join(sorted(_ALL_KEYS))}")
-    sys.stdout.write(str(ConfigManager.get(get_config(), key)) + "\n")
+    val = ConfigManager.get(get_config(), key)
+    if key == "turso.token" and val and not reveal:
+        val = "****"
+    sys.stdout.write(str(val) + "\n")
 
 
 @config_app.command("set")
@@ -157,8 +172,7 @@ def config_edit_cmd() -> None:
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     if not CONFIG_PATH.exists():
         CONFIG_PATH.write_text(EXAMPLE_TEMPLATE, encoding="utf-8")
-    editor = os.environ.get("EDITOR", "vim")
-    subprocess.call([editor, str(CONFIG_PATH)])
+    launch_editor(str(CONFIG_PATH))
 
 
 @config_app.command("path")

--- a/src/koda/commands/memo.py
+++ b/src/koda/commands/memo.py
@@ -1,9 +1,7 @@
 """Memo CRUD and display commands: add, remove, copy, edit, list, show, raw, tag."""
 
 import json
-import os
 import re
-import subprocess
 import sys
 import tempfile
 from datetime import datetime
@@ -29,6 +27,7 @@ from ..runtime import (
     get_config,
     get_db,
     init_db,
+    launch_editor,
     resolve_ref,
 )
 
@@ -70,11 +69,10 @@ def _add_impl(
     elif not sys.stdin.isatty():
         content = sys.stdin.read().strip()
     else:
-        editor = os.environ.get("EDITOR", "vim")
         with tempfile.NamedTemporaryFile(suffix=".tmp", mode="w+", delete=False) as tf:
             temp_path = tf.name
         try:
-            subprocess.call([editor, temp_path])
+            launch_editor(temp_path)
             with open(temp_path) as f:
                 content = f.read().strip()
         finally:
@@ -259,7 +257,6 @@ def edit(
         f"{content}\n\n---\n# Metadata\ntags: {tags}\n{sc_line}\ncreated_at: {created_at}\n---"
     )
 
-    editor = os.environ.get("EDITOR", "vim")
     with tempfile.NamedTemporaryFile(
         suffix=".tmp", mode="w+", delete=False, encoding="utf-8"
     ) as tf:
@@ -267,7 +264,7 @@ def edit(
         temp_path = tf.name
 
     try:
-        subprocess.call([editor, temp_path])
+        launch_editor(temp_path)
         with open(temp_path) as f:
             new_data = f.read()
 

--- a/src/koda/config.py
+++ b/src/koda/config.py
@@ -150,6 +150,36 @@ def valid_exec_shell(v: Any) -> bool:
     return bool(resolved) and Path(resolved).is_absolute()
 
 
+_TOML_STR_ESCAPES = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\b": "\\b",
+    "\t": "\\t",
+    "\n": "\\n",
+    "\f": "\\f",
+    "\r": "\\r",
+}
+
+
+def toml_basic_string(value: str) -> str:
+    """Quote ``value`` as a TOML basic string with proper escaping.
+
+    Without this, a value containing ``"`` or a newline could break out of its
+    string and inject arbitrary TOML keys/tables when written back to the config
+    file (e.g. forcing ``exec.confirm_remote = false``). Escaping ``\\`` and
+    ``"`` plus all control characters closes that injection vector and keeps the
+    value round-trippable by ``tomllib``."""
+    out = []
+    for ch in value:
+        if ch in _TOML_STR_ESCAPES:
+            out.append(_TOML_STR_ESCAPES[ch])
+        elif ord(ch) < 0x20 or ord(ch) == 0x7F:
+            out.append(f"\\u{ord(ch):04X}")
+        else:
+            out.append(ch)
+    return '"' + "".join(out) + '"'
+
+
 class DefaultCmd(str, Enum):
     RAW = "raw"
     LIST = "list"
@@ -331,10 +361,10 @@ class ConfigManager:
                 if isinstance(v, bool):
                     lines.append(f"{k} = {'true' if v else 'false'}")
                 elif isinstance(v, list):
-                    items = ", ".join(f'"{c}"' for c in v)
+                    items = ", ".join(toml_basic_string(str(c)) for c in v)
                     lines.append(f"{k} = [{items}]")
                 elif isinstance(v, str):
-                    lines.append(f'{k} = "{v}"')
+                    lines.append(f"{k} = {toml_basic_string(v)}")
                 else:
                     lines.append(f"{k} = {v}")
             lines.append("")

--- a/src/koda/runtime.py
+++ b/src/koda/runtime.py
@@ -7,7 +7,10 @@ config read, no DB handle. Config and the database are resolved lazily on first
 use.
 """
 
+import os
 import re
+import shlex
+import subprocess
 import sys
 from importlib.metadata import version
 from pathlib import Path
@@ -95,6 +98,32 @@ def version_callback(value: bool):
     if value:
         console.print(f"{__app_name__} version: [bold cyan]{__version__}[/bold cyan]")
         raise typer.Exit()
+
+
+def resolve_editor() -> list[str]:
+    """Resolve ``$EDITOR`` to a command vector, falling back to ``vim``.
+
+    Handles an empty/whitespace ``EDITOR`` (which would otherwise try to exec
+    ``""`` and crash) and multi-word editors such as ``code --wait``.
+    """
+    raw = os.environ.get("EDITOR", "").strip() or "vim"
+    try:
+        parts = shlex.split(raw)
+    except ValueError:
+        parts = [raw]
+    return parts or ["vim"]
+
+
+def launch_editor(path: str) -> None:
+    """Open ``path`` in the user's editor, exiting cleanly if it cannot run."""
+    editor = resolve_editor()
+    try:
+        subprocess.call([*editor, path])
+    except OSError as e:
+        exit_error(
+            f"Could not launch editor {editor[0]!r}: {e}. "
+            "Set $EDITOR to a valid editor, e.g. `export EDITOR=nano`."
+        )
 
 
 def init_db():

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -78,6 +78,6 @@ def test_no_arg_no_stdin_uses_editor(wired_db, monkeypatch):
         Path(cmd[1]).write_text("from editor")
         return 0
 
-    monkeypatch.setattr(memo.subprocess, "call", fake_call)
+    monkeypatch.setattr("koda.runtime.subprocess.call", fake_call)
     memo._add_impl(text=None)
     assert _latest_content(wired_db) == "from editor"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ import shutil
 
 import pytest
 
-from koda.config import ConfigManager, ValidationError
+from koda.config import ConfigManager, ValidationError, toml_basic_string
 
 
 class TestCoerce:
@@ -198,6 +198,61 @@ class TestExecShell:
     def test_empty_rejected(self):
         with pytest.raises(ValidationError):
             ConfigManager.validate("exec.shell", "")
+
+
+class TestTomlBasicString:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("plain", '"plain"'),
+            ('he said "hi"', '"he said \\"hi\\""'),
+            ("a\\b", '"a\\\\b"'),
+            ("line1\nline2", '"line1\\nline2"'),
+            ("tab\there", '"tab\\there"'),
+        ],
+    )
+    def test_escapes(self, value, expected):
+        assert toml_basic_string(value) == expected
+
+    def test_control_char_uses_unicode_escape(self):
+        assert toml_basic_string("\x00") == '"\\u0000"'
+
+
+class TestWriteRawInjection:
+    """write_raw must not let a value break out of its string and inject keys."""
+
+    def _roundtrip(self, tmp_path, data):
+        import sys
+
+        if sys.version_info >= (3, 11):
+            import tomllib
+        else:
+            import tomli as tomllib
+
+        mgr = ConfigManager(config_path=tmp_path / "config.toml")
+        mgr.write_raw(data)
+        with open(mgr.config_path, "rb") as f:
+            return tomllib.load(f)
+
+    def test_token_with_quotes_and_newlines_roundtrips(self, tmp_path):
+        # A token crafted to inject `[exec] confirm_remote = false`.
+        evil = 'foo"\n\n[exec]\nconfirm_remote = false\n'
+        parsed = self._roundtrip(tmp_path, {"turso": {"token": evil}})
+        # The value survives verbatim and no injected table appears.
+        assert parsed == {"turso": {"token": evil}}
+        assert "exec" not in parsed
+
+    def test_backslash_value_roundtrips(self, tmp_path):
+        parsed = self._roundtrip(tmp_path, {"git": {"sync_path": "C:\\Users\\me"}})
+        assert parsed["git"]["sync_path"] == "C:\\Users\\me"
+
+    def test_list_items_with_quotes_roundtrip(self, tmp_path):
+        parsed = self._roundtrip(tmp_path, {"list": {"columns": ['id"x', "content"]}})
+        assert parsed["list"]["columns"] == ['id"x', "content"]
+
+    def test_bool_and_int_still_written_unquoted(self, tmp_path):
+        parsed = self._roundtrip(tmp_path, {"list": {"desc": True, "per_page": 20}})
+        assert parsed["list"] == {"desc": True, "per_page": 20}
 
 
 class TestExecConfirmRemote:

--- a/tests/test_config_get_mask.py
+++ b/tests/test_config_get_mask.py
@@ -1,0 +1,44 @@
+"""`config get` must not leak turso.token in clear text unless --reveal.
+
+Keeps the secret out of shell history, CI logs, and terminal scrollback,
+matching the masking already applied by `config show`.
+"""
+
+import pytest
+
+from koda.commands import config as config_cmd
+from koda.config import Config
+
+
+@pytest.fixture
+def wired_config(monkeypatch):
+    cfg = Config()
+    cfg.turso_token = "super-secret-token"
+    cfg.defaults_cmd = "raw"
+    monkeypatch.setattr(config_cmd, "get_config", lambda: cfg)
+    return cfg
+
+
+def test_token_masked_by_default(wired_config, capsys):
+    config_cmd.config_get("turso.token", reveal=False)
+    out = capsys.readouterr().out
+    assert out.strip() == "****"
+    assert "super-secret-token" not in out
+
+
+def test_token_revealed_with_flag(wired_config, capsys):
+    config_cmd.config_get("turso.token", reveal=True)
+    assert capsys.readouterr().out.strip() == "super-secret-token"
+
+
+def test_empty_token_not_masked(monkeypatch, capsys):
+    cfg = Config()  # turso_token defaults to ""
+    monkeypatch.setattr(config_cmd, "get_config", lambda: cfg)
+    config_cmd.config_get("turso.token", reveal=False)
+    # An unset token prints as empty, not as "****".
+    assert capsys.readouterr().out.strip() == ""
+
+
+def test_non_secret_key_unaffected(wired_config, capsys):
+    config_cmd.config_get("defaults.cmd", reveal=False)
+    assert capsys.readouterr().out.strip() == "raw"

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -1,0 +1,64 @@
+"""Tests for the shared editor resolution/launch helpers in runtime.
+
+Covers the crash where an empty ``$EDITOR`` tried to exec ``""`` and raised a
+raw ``PermissionError`` traceback instead of falling back to vim.
+"""
+
+import pytest
+import typer
+
+import koda.runtime as runtime
+
+
+class TestResolveEditor:
+    def test_unset_falls_back_to_vim(self, monkeypatch):
+        monkeypatch.delenv("EDITOR", raising=False)
+        assert runtime.resolve_editor() == ["vim"]
+
+    @pytest.mark.parametrize("value", ["", "   ", "\t"])
+    def test_empty_or_whitespace_falls_back_to_vim(self, monkeypatch, value):
+        monkeypatch.setenv("EDITOR", value)
+        assert runtime.resolve_editor() == ["vim"]
+
+    def test_single_word(self, monkeypatch):
+        monkeypatch.setenv("EDITOR", "nano")
+        assert runtime.resolve_editor() == ["nano"]
+
+    def test_multi_word_is_split(self, monkeypatch):
+        monkeypatch.setenv("EDITOR", "code --wait")
+        assert runtime.resolve_editor() == ["code", "--wait"]
+
+    def test_unbalanced_quote_does_not_crash(self, monkeypatch):
+        monkeypatch.setenv("EDITOR", 'vim "')
+        # shlex.split raises on the unbalanced quote; we keep the raw string.
+        assert runtime.resolve_editor() == ['vim "']
+
+
+class TestLaunchEditor:
+    def test_empty_editor_launches_vim_without_crash(self, monkeypatch):
+        monkeypatch.setenv("EDITOR", "")
+        captured = {}
+        monkeypatch.setattr(
+            "koda.runtime.subprocess.call", lambda cmd: captured.setdefault("cmd", cmd)
+        )
+        runtime.launch_editor("/tmp/x")
+        assert captured["cmd"] == ["vim", "/tmp/x"]
+
+    def test_multi_word_editor_is_passed_through(self, monkeypatch):
+        monkeypatch.setenv("EDITOR", "code --wait")
+        captured = {}
+        monkeypatch.setattr(
+            "koda.runtime.subprocess.call", lambda cmd: captured.setdefault("cmd", cmd)
+        )
+        runtime.launch_editor("/tmp/x")
+        assert captured["cmd"] == ["code", "--wait", "/tmp/x"]
+
+    def test_missing_editor_binary_exits_cleanly(self, monkeypatch):
+        monkeypatch.setenv("EDITOR", "definitely-not-an-editor")
+
+        def boom(cmd):
+            raise FileNotFoundError(2, "No such file or directory")
+
+        monkeypatch.setattr("koda.runtime.subprocess.call", boom)
+        with pytest.raises(typer.Exit):
+            runtime.launch_editor("/tmp/x")


### PR DESCRIPTION
Three correctness/security fixes surfaced by an internal subagent review pass. No new dependencies; +24 tests (258 passing).

## 1. TOML injection in `config set` (High)
`ConfigManager.write_raw()` wrote string values as `"{v}"` with no escaping, so a value containing `"` or a newline could break out of the string and inject arbitrary TOML tables. Concretely:

```
koda config set turso.token $'foo"\n\n[exec]\nconfirm_remote = false\n[turso]\nx = "bar'
```

…would append `[exec] confirm_remote = false`, **silently disabling the remote-exec confirmation** (a pull'd `source=remote` snippet could then `koda x` without a prompt). Added `toml_basic_string()` which escapes `\`, `"`, and control characters; values now round-trip through `tomllib` verbatim and cannot inject keys.

## 2. `turso.token` leaked by `config get` (Medium)
`config show` masks the token as `****`, but `config get turso.token` printed it in clear text — into shell history, CI logs, and terminal scrollback. Now masked by default, with a `--reveal` opt-out for deliberate use.

## 3. Empty/invalid `$EDITOR` crash (UX/crash)
`EDITOR='' koda edit` tried to exec `""` and dumped a raw `PermissionError` traceback (a missing editor binary did the same). Added shared `resolve_editor()` / `launch_editor()` in `runtime`: falls back to `vim` on empty/whitespace `EDITOR`, splits multi-word values like `code --wait` via `shlex`, and turns a failed launch into a clean error pointing at `$EDITOR`. `add`, `edit`, and `config edit` all route through it.

## Verification
- `uv run pytest` → 258 passed (+24 new in `test_editor.py`, `test_config_get_mask.py`, `test_config.py`)
- `uv run ruff check` / `ruff format --check` clean
- Manual E2E: injection attempt leaves `exec.confirm_remote = True`; `config get turso.token` → `****` (real value with `--reveal`); `EDITOR=''` no longer crashes

Follow-ups from the same review (separate PRs): Git-sync timestamp-spoofing hardening (S2), exit-code taxonomy, UX quick-wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)