### PR TITLE
feat(cli): group commands into labeled --help sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `list`, `remove`, and `pick`. The `--quiet` flag on `add`/`copy`/`tag`/`move`/
   `swap` no longer has a `-q` short alias — spell out `--quiet`. This removes the
   ambiguity of `-q` meaning different things on different commands.
+- `koda --help` now groups commands into labeled sections (Core, Git sync, Data,
+  Index, Config) instead of one flat list, making the `push`/`pull` sync
+  commands and the data/index commands easier to discover.
 
 ### Fixed
 - `swap` no longer fails with a UNIQUE-constraint error when one of the entries

--- a/src/koda/commands/exec.py
+++ b/src/koda/commands/exec.py
@@ -45,7 +45,7 @@ def _run_pick_action(action: str, ref: str) -> None:
     exit_error(f"Unsupported pick action: {action}")
 
 
-@app.command(name="exec")
+@app.command(name="exec", rich_help_panel="Core")
 def exec_memo(
     ref: str | None = typer.Argument(
         None, help="Entry index or shortcut to execute (default: latest)."
@@ -115,7 +115,7 @@ def exec_memo(
     os.execvp(shell, [shell, "-c", content])
 
 
-@app.command()
+@app.command(rich_help_panel="Core")
 def pick(
     query: str | None = typer.Option(None, "--query", "-q", help="Substring match on memo body."),
     tag: str | None = typer.Option(None, "--tag", "-t", help="Substring match on tags."),

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -83,7 +83,7 @@ def _merge_payload(data: bytes) -> None:
     )
 
 
-@app.command()
+@app.command(rich_help_panel="Git sync")
 def push(
     payload_file: Path | None = typer.Option(
         None, "--file", help="Use this JSONL file instead of exporting the local database."
@@ -143,7 +143,7 @@ def push(
     console.print(f"[green]Synced payload to Git: {payload_path}[/green]")
 
 
-@app.command()
+@app.command(rich_help_panel="Git sync")
 def pull(
     local_payload_path: Path | None = typer.Option(
         None, "--file", help="Import from this JSONL file (skip git pull in the clone)."
@@ -169,7 +169,7 @@ def pull(
     console.print("[green]Pull complete.[/green]")
 
 
-@app.command()
+@app.command(rich_help_panel="Data")
 def export(
     out: Path | None = typer.Option(
         None, "--out", "-o", help="Write JSONL to this file instead of stdout."
@@ -188,7 +188,7 @@ def export(
         sys.stdout.buffer.write(data)
 
 
-@app.command(name="import")
+@app.command(name="import", rich_help_panel="Data")
 def import_memos(
     file: Path = typer.Argument(..., help="JSONL file to import (merged by uid + modified_at)."),
 ):
@@ -204,7 +204,7 @@ def import_memos(
     console.print("[green]Import complete.[/green]")
 
 
-@app.command()
+@app.command(rich_help_panel="Data")
 def diff(
     local_payload_path: Path | None = typer.Option(
         None, "--file", help="Diff against this JSONL file instead of the Git clone."
@@ -255,7 +255,7 @@ def diff(
     )
 
 
-@app.command()
+@app.command(rich_help_panel="Data")
 def backup(
     out: Path = typer.Option(
         ..., "--out", "-o", help="Destination file for the SQLite snapshot (must not exist)."

--- a/src/koda/commands/index.py
+++ b/src/koda/commands/index.py
@@ -8,7 +8,7 @@ from ..main import app
 from ..runtime import console, get_db, init_db
 
 
-@app.command(name="move")
+@app.command(name="move", rich_help_panel="Index")
 def move(
     from_idx: int = typer.Argument(..., help="Source display index."),
     to_idx: int = typer.Argument(..., help="Destination display index (must be empty)."),
@@ -39,7 +39,7 @@ def move(
         console.print(f"[green]Moved {from_idx} → {to_idx}.[/green]")
 
 
-@app.command(name="shift")
+@app.command(name="shift", rich_help_panel="Index")
 def shift_cmd(
     start: int = typer.Argument(..., help="Shift entries at this index and above."),
     count: int = typer.Option(
@@ -90,7 +90,7 @@ def shift_cmd(
     console.print(f"[green]Shifted entries from index {start} by {count:+d}.[/green]")
 
 
-@app.command(name="swap")
+@app.command(name="swap", rich_help_panel="Index")
 def swap(
     idx1: int = typer.Argument(..., help="First display index."),
     idx2: int = typer.Argument(..., help="Second display index."),
@@ -120,7 +120,7 @@ def swap(
         console.print(f"[green]Swapped {idx1} ↔ {idx2}.[/green]")
 
 
-@app.command(name="compact")
+@app.command(name="compact", rich_help_panel="Index")
 def compact_indices(
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Show what would change without modifying the database."

--- a/src/koda/commands/memo.py
+++ b/src/koda/commands/memo.py
@@ -104,7 +104,7 @@ def _add_impl(
         console.print(f"[green]Saved [{new_idx}] ({uid}){meta}[/green]")
 
 
-@app.command()
+@app.command(rich_help_panel="Core")
 def add(
     text: list[str] | None = typer.Argument(
         None, help="Text to save (optional if using stdin or $EDITOR)."
@@ -129,7 +129,7 @@ def add(
     _add_impl(text, tag, shortcut, quiet=quiet, print_uid=print_uid, print_idx=print_idx)
 
 
-@app.command(name="remove")
+@app.command(name="remove", rich_help_panel="Core")
 def rm(
     indices: list[str] | None = typer.Argument(
         None, help="Entry indices, ranges (e.g. 1 3 5-8), or a single shortcut. Default: latest."
@@ -205,7 +205,7 @@ def rm(
         console.print(f"[red]Deleted [{row.idx}]: {preview}...[/red]")
 
 
-@app.command(name="copy")
+@app.command(name="copy", rich_help_panel="Core")
 def copy(
     ref: str | None = typer.Argument(
         None, help="Source entry index or shortcut (default: latest)."
@@ -220,7 +220,7 @@ def copy(
     console.print(f"[green]Copied [{row.idx}] → [{new_idx}] ({new_uid}).[/green]")
 
 
-@app.command()
+@app.command(rich_help_panel="Core")
 def edit(
     ref: str | None = typer.Argument(
         None, help="Entry index or shortcut to edit (default: latest)."
@@ -447,7 +447,7 @@ def _list_memos_impl(
         console.print(f"[dim]Page {page}/{total_pages} — next: koda l -p {page + 1}[/dim]")
 
 
-@app.command(name="list")
+@app.command(name="list", rich_help_panel="Core")
 def list_memos(
     ref: str | None = typer.Argument(
         None,
@@ -535,7 +535,7 @@ def list_memos(
     )
 
 
-@app.command()
+@app.command(rich_help_panel="Core")
 def show(
     ref: str | None = typer.Argument(None, help="Entry index or shortcut (default: latest)."),
     json_output: bool = typer.Option(
@@ -570,7 +570,7 @@ def show(
     )
 
 
-@app.command()
+@app.command(rich_help_panel="Core")
 def raw(
     entry_refs: list[str] | None = typer.Argument(
         None,
@@ -607,7 +607,7 @@ def raw(
             emit_raw(ref, vars)
 
 
-@app.command()
+@app.command(rich_help_panel="Core")
 def tag(
     indices: list[str] = typer.Argument(..., help="Entry indices or ranges (e.g. 1 3 5-8)."),
     tags: list[str] | None = typer.Option(None, "--tag", "-t", help="Tag(s) to add."),

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -68,7 +68,7 @@ app = typer.Typer(
     invoke_without_command=True,
     no_args_is_help=False,
 )
-app.add_typer(config_app, name="config")
+app.add_typer(config_app, name="config", rich_help_panel="Config")
 
 
 @app.callback(invoke_without_command=True)


### PR DESCRIPTION
## Summary

`koda --help` listed all 21 commands in a single flat **Commands** panel, so the alias-less Git sync commands (`push`/`pull`) and the data/index commands were easy to overlook — they look "missing" at a glance even though they were always registered.

This assigns a `rich_help_panel` to every command so the help splits into labeled sections:

```
╭─ Core ────────────────────────────────────────────╮
│ add  remove  copy  edit  list  show  raw  tag      │
│ exec  pick                                         │
╰────────────────────────────────────────────────────╯
╭─ Git sync ────────────────────────────────────────╮
│ push   Write memo export ... into the Git clone... │
│ pull   Pull memo JSONL from the Git clone ...      │
╰────────────────────────────────────────────────────╯
╭─ Data ────────────────────────────────────────────╮
│ export  import  diff  backup                       │
╰────────────────────────────────────────────────────╯
╭─ Index ───────────────────────────────────────────╮
│ move  shift  swap  compact                         │
╰────────────────────────────────────────────────────╯
╭─ Config ──────────────────────────────────────────╮
│ config                                             │
╰────────────────────────────────────────────────────╯
```

Panels render in registration order, and the Core commands register first (`exec.py` imports `memo` at load time), so **Core appears at the top**.

## Changes

- `commands/{memo,exec,git,index}.py`: `rich_help_panel="..."` on each `@app.command`.
- `main.py`: `rich_help_panel="Config"` on the `config` sub-app.
- `CHANGELOG.md`: documented under Changed.

No behavior change — help presentation only.

## Verification

`ruff check`, `ruff format --check`, `mypy`, and `pytest` all green (277 passed, coverage 65.88%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)