### PR TITLE
feat(exec): forward trailing args to the command (positional params + defaults)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `koda exec <ref> [args…]` now forwards trailing CLI arguments to the command.
+  They become the shell's real positional parameters (`$1`, `$2`, `"$@"`); if the
+  body doesn't reference them they are appended at the end (like a shell alias),
+  so `koda x dcu llama-server` runs `docker compose up -d llama-server` while
+  `koda x dcu` runs the bare command — no `$1`/`${}` placeholder required.
+  Bodies can also use `${1:-default}` for fallbacks. Use `--` before option-like
+  args. (`-V` textual substitution is unchanged.)
 - `koda exec --dry-run` / `-n` prints the resolved command (variables already
   substituted) without executing it, skipping the remote-confirmation prompt and
   shell validation — a safe way to preview an unreviewed `source=remote` entry.

--- a/README.md
+++ b/README.md
@@ -316,6 +316,31 @@ koda x 12                      # run by index
 koda x klogs -V worker -n      # --dry-run: print the resolved command, don't run it
 ```
 
+**Append arguments at call time — `koda x <ref> [args…]`:**
+
+Anything after the ref is passed to the command. If the body doesn't use it, it's appended at the end — like extra words after a shell alias — so one snippet covers both the bare and the parameterized case, with no `$1`/`${}` needed:
+
+```bash
+koda a "docker compose up -d" -s dcu
+
+koda x dcu                 # → docker compose up -d
+koda x dcu llama-server    # → docker compose up -d llama-server
+koda x dcu web db          # → docker compose up -d web db
+```
+
+If the body *does* reference positional parameters, the args fill them instead, and `${1:-default}` supplies a fallback when none are passed:
+
+```bash
+koda a 'kubectl logs $1 --tail=100' -s klog
+koda x klog mypod          # → kubectl logs mypod --tail=100
+
+koda a 'echo Hello ${1:-world}' -s greet
+koda x greet               # → Hello world
+koda x greet Alice         # → Hello Alice
+```
+
+The args become the shell's real positional parameters (`$1`, `$2`, `"$@"`), so a value with spaces stays one word. Put `--` before anything that looks like an option (`koda x dcu -- --build`); koda's own flags (`-V`, `-f`, `-n`) are otherwise consumed by koda. This is distinct from `-V`, which does textual `$1`/`${KEY}` substitution *before* the shell runs — use `-V` when you need to drop a value into the middle of the body.
+
 **Preview before running — `--dry-run` / `-n`:**
 
 `koda x <ref> -n` prints the exact command that *would* run (variables already substituted) without executing it. It also skips the remote-confirmation prompt and shell validation, which makes it useful for checking an unreviewed `source=remote` entry before trusting it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,10 @@ koda stores arbitrary text entries and can execute them as shell commands
 - **Command execution** — `koda x` runs an entry's body through a shell. Entries
   brought in by `koda pull` are marked `source=remote` and require confirmation
   before they execute; reviewing an entry with `koda edit` clears that flag.
-  `exec.shell` is restricted to an allowlist of known shells. `koda x --dry-run`
+  `exec.shell` is restricted to an allowlist of known shells. Trailing CLI args
+  after the ref are passed as the shell's positional parameters (`$1`, `"$@"`),
+  individually quoted, so a caller's arguments cannot break out of the resolved
+  command. `koda x --dry-run`
   previews the resolved command without running it (and so skips the confirmation
   prompt — nothing executes), but it prints the body verbatim and does not strip
   terminal escape sequences; redirect its output to a file when inspecting a

--- a/src/koda/commands/exec.py
+++ b/src/koda/commands/exec.py
@@ -1,6 +1,7 @@
 """Execution and interactive-selection commands: exec, pick."""
 
 import os
+import re
 import shlex
 import sys
 
@@ -27,6 +28,21 @@ from ..runtime import (
 )
 from . import memo  # bound as a module to avoid a circular import at load time
 
+# Matches a shell positional-parameter reference: $1..$9, $0, $@, $*, $#, and the
+# braced forms ${1...}, ${@}, ${*}, ${#}. Deliberately does NOT match koda's own
+# ${KEY} named placeholders (a letter after the brace), so a body that only uses
+# ${KEY} still gets trailing args appended rather than swallowed.
+_POSITIONAL_REF_RE = re.compile(r"\$(?:\d|[@*#]|\{\s*[\d@*#])")
+
+
+def _references_positionals(body: str) -> bool:
+    """True if the shell body already consumes positional params ($1, $@, ...).
+
+    Decides whether trailing CLI args are appended as `"$@"` (body ignores them)
+    or left for the body to pick up itself (body uses $1/$@/${1:-default}/...).
+    """
+    return bool(_POSITIONAL_REF_RE.search(body))
+
 
 def _run_pick_action(action: str, ref: str) -> None:
     if action == "raw":
@@ -46,10 +62,22 @@ def _run_pick_action(action: str, ref: str) -> None:
     exit_error(f"Unsupported pick action: {action}")
 
 
-@app.command(name="exec", rich_help_panel="Core")
+@app.command(
+    name="exec",
+    rich_help_panel="Core",
+    context_settings={"ignore_unknown_options": True, "help_option_names": ["-h", "--help"]},
+)
 def exec_memo(
     ref: str | None = typer.Argument(
         None, help="Entry index or shortcut to execute (default: latest)."
+    ),
+    extra: list[str] | None = typer.Argument(
+        None,
+        help=(
+            "Extra args passed to the command: appended at the end (like a shell "
+            'alias) or used to fill $1, $2, "$@" if the body references them. '
+            "Put -- before args that look like options."
+        ),
     ),
     vars: list[str] | None = typer.Option(
         None,
@@ -79,6 +107,12 @@ def exec_memo(
 
     When no argument is given, this command also accepts one ref from stdin.
 
+    Extra arguments after the ref are passed to the command. If the body does not
+    use them they are appended at the end (e.g. `koda x dcu llama-server` runs
+    `docker compose up -d llama-server`); if the body references `$1`/`"$@"` they
+    fill those, and `${1:-default}` supplies a fallback when none are passed. Put
+    `--` before args that look like options (`koda x dcu -- --build`).
+
     Entries brought in by `koda pull` are marked source=remote and prompt for
     confirmation before running, since a compromised sync remote could rewrite
     their body. Review with `koda edit <ref>` to trust an entry permanently
@@ -103,13 +137,26 @@ def exec_memo(
     row = resolve_ref(ref)
     content = _apply_vars(row.content.strip() if row.content else "", vars)
     shell = get_config().exec_shell
+
+    # Trailing CLI args become the shell's real positional parameters ($1, $@,
+    # ...), so bodies can use `$1`, `"$@"`, and `${1:-default}` natively. If the
+    # body doesn't reference them, append `"$@"` so they land at the end of the
+    # command, like extra words typed after a shell alias. With no extra args the
+    # invocation is byte-for-byte what it was before (full backward compatibility).
+    positionals = list(extra or [])
+    if positionals and not _references_positionals(content):
+        content = f'{content} "$@"'
+    # argv[3] becomes $0 for the spawned shell; positionals[*] become $1, $2, ...
+    argv = [shell, "-c", content, shell, *positionals] if positionals else [shell, "-c", content]
+
     if dry_run:
         # Preview only: skip remote confirmation and shell validation since
-        # nothing is executed. Quote both the shell and the body so the output
-        # is a faithful, copy-pasteable rendering of the real `<shell> -c <body>`
-        # invocation even when the shell name (validation skipped here) or the
-        # body contains characters the shell would otherwise re-interpret.
-        sys.stdout.write(f"{shlex.quote(shell)} -c {shlex.quote(content)}\n")
+        # nothing is executed. shlex.quote every part so the output is a
+        # faithful, copy-pasteable rendering of the real argv — including the
+        # `<shell> ... <args>` tail when trailing args are passed as positional
+        # parameters. The shell still does the final `$@`/`${1:-...}` expansion,
+        # so the preview shows the invocation, not the post-expansion string.
+        sys.stdout.write(" ".join(shlex.quote(part) for part in argv) + "\n")
         return
     if row.source == "remote" and not force and get_config().exec_confirm_remote:
         label = ref if ref is not None else f"[{row.idx}]"
@@ -134,7 +181,7 @@ def exec_memo(
             f"Refusing to exec: exec.shell {shell!r} is not allowed "
             f"({ConfigManager.error_message('exec.shell')})."
         )
-    os.execvp(shell, [shell, "-c", content])
+    os.execvp(shell, argv)
 
 
 @app.command(rich_help_panel="Core")

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -195,3 +195,74 @@ def test_dry_run_reads_ref_from_stdin(tmp_path):
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.rstrip().endswith("'echo FROM_STDIN'")
+
+
+# --- Trailing args: appended when the body has no placeholder, or used to fill
+# --- $1/"$@"/${1:-default} when it does (the seeded entry is at idx 1). ---
+
+
+def test_no_trailing_args_runs_base_command(tmp_path):
+    """With no extra args the body runs exactly as written (back-compat)."""
+    result = _run_x(tmp_path, "echo BASE", extra=("1",))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "BASE"
+
+
+def test_trailing_arg_appended_when_body_has_no_placeholder(tmp_path):
+    """`koda x dcu a b` appends the args at the end, like a shell alias."""
+    result = _run_x(tmp_path, "echo BASE", extra=("1", "x1", "x2"))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "BASE x1 x2"
+
+
+def test_trailing_arg_fills_positional_reference(tmp_path):
+    """When the body uses $1, the trailing arg fills it (no append)."""
+    result = _run_x(tmp_path, "echo logs-$1", extra=("1", "mypod"))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "logs-mypod"
+
+
+def test_shell_default_value_used_when_no_arg(tmp_path):
+    """`${1:-default}` yields the default when no trailing arg is given."""
+    result = _run_x(tmp_path, "echo Hello ${1:-world}", extra=("1",))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "Hello world"
+
+
+def test_shell_default_value_overridden_by_arg(tmp_path):
+    """A trailing arg overrides the `${1:-default}` fallback."""
+    result = _run_x(tmp_path, "echo Hello ${1:-world}", extra=("1", "Alice"))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "Hello Alice"
+
+
+def test_trailing_args_preserve_word_boundaries(tmp_path):
+    """Args are real shell positionals, so spaces in a value stay one word."""
+    result = _run_x(tmp_path, 'printf "[%s]\\n" "$@"', extra=("1", "a b", "c"))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["[a b]", "[c]"]
+
+
+def test_dry_run_shows_appended_positional_args(tmp_path):
+    """--dry-run renders the real argv, including the appended `"$@"` tail."""
+    result = _run_x(tmp_path, "docker compose up -d", extra=("1", "-n", "svc"))
+    assert result.returncode == 0, result.stderr
+    out = result.stdout.strip()
+    assert " -c 'docker compose up -d \"$@\"' " in out
+    assert out.endswith(" svc")
+
+
+def test_trailing_option_like_args_via_double_dash(tmp_path):
+    """`--` lets args that look like options pass through to the command."""
+    result = _run_x(tmp_path, "docker compose up -d", extra=("1", "-n", "--", "--build"))
+    assert result.returncode == 0, result.stderr
+    out = result.stdout.strip()
+    assert '"$@"' in out
+    assert out.endswith(" --build")
+
+
+def test_trailing_unknown_option_passes_through(tmp_path):
+    """Unknown options are forwarded to the command, not rejected by koda."""
+    result = _run_x(tmp_path, "docker compose up -d", extra=("1", "--build", "-n"))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith(" --build")


### PR DESCRIPTION
## Summary

`koda exec <ref> [args…]` now forwards trailing CLI arguments to the executed command, so a single snippet covers both the bare and the parameterized case without writing a `$1`/`${}` placeholder.

- Trailing args become the shell's **real positional parameters** (`$1`, `$2`, `"$@"`).
- If the body **doesn't reference** them, they're **appended at the end**, like extra words after a shell alias.
- If the body **does reference** them, they fill those, and `${1:-default}` provides a fallback.

```bash
koda a "docker compose up -d" -s dcu
koda x dcu                 # → docker compose up -d
koda x dcu llama-server    # → docker compose up -d llama-server

koda a 'echo Hello ${1:-world}' -s greet
koda x greet               # → Hello world
koda x greet Alice         # → Hello Alice
```

## Behavior notes

- Args are passed as real positionals (each `shlex.quote`d), so a value with spaces stays one word and cannot break out of the resolved command.
- `--dry-run`/`-n` renders the faithful argv, e.g. `sh -c 'docker compose up -d "$@"' sh llama-server` (the shell does the final `$@`/`${1:-…}` expansion, so the preview shows the invocation, not the post-expansion string).
- `ignore_unknown_options` is enabled so option-like args pass through (`koda x dcu --build`). koda's own flags (`-V`/`-f`/`-n`) are consumed by koda; use `--` to forward them (`koda x dcu -- -f`).
- **Backward compatible**: with no trailing args the invocation is byte-for-byte identical to before; the existing `-V` textual `$1`/`${KEY}` substitution path is unchanged.

## Tests / docs

- 9 new tests in `tests/test_exec.py` (append / `$1` fill / `${1:-default}` / quoting / dry-run / `--` / unknown-option passthrough).
- Full suite: **291 passed**, coverage **65.66%** (≥60% floor). ruff format/check + mypy clean.
- README (Execute section), SECURITY.md (command-execution bullet), CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
