### PR TITLE
feat(db): add nullable title column (migration 0004), model field, and sync payload support

### DIFF
--- a/src/koda/commands/memo.py
+++ b/src/koda/commands/memo.py
@@ -44,9 +44,16 @@ def _validate_shortcut(shortcut: str | None) -> str | None:
     return shortcut
 
 
-def update_memo_full(memo_id: int, content: str, tags: str, shortcut: str | None, created_at: str):
+def update_memo_full(
+    memo_id: int,
+    content: str,
+    tags: str,
+    shortcut: str | None,
+    created_at: str,
+    title: str | None = None,
+):
     now = datetime.now().strftime(DATETIME_FMT)
-    get_db().update_memo(memo_id, content, tags, shortcut, created_at, now)
+    get_db().update_memo(memo_id, content, tags, shortcut, created_at, now, title=title)
 
 
 def _add_impl(
@@ -90,7 +97,9 @@ def _add_impl(
     now = datetime.now().strftime(DATETIME_FMT)
     uid = _generate_uid(content, now)
     try:
-        new_idx = get_db().add_memo_auto_idx(uid, shortcut, content, formatted_tags, now, now)
+        new_idx = get_db().add_memo_auto_idx(
+            uid, shortcut, content, formatted_tags, now, now, title=None
+        )
     except _IntegrityErrors:
         exit_error(f"Shortcut {shortcut!r} is already in use.")
 
@@ -216,7 +225,10 @@ def copy(
     row = resolve_ref(ref)
     now = datetime.now().strftime(DATETIME_FMT)
     new_uid = _generate_uid(row.content or "", now)
-    new_idx = get_db().add_memo_auto_idx(new_uid, None, row.content, row.tags, now, now)
+    # A copy keeps the source title (display label travels with the body).
+    new_idx = get_db().add_memo_auto_idx(
+        new_uid, None, row.content, row.tags, now, now, title=row.title
+    )
     console.print(f"[green]Copied [{row.idx}] → [{new_idx}] ({new_uid}).[/green]")
 
 
@@ -275,14 +287,23 @@ def edit(
             new_shortcut = _validate_shortcut(new_shortcut)
 
             try:
-                update_memo_full(memo_id, new_content, new_tags, new_shortcut, new_created_at)
+                # title has no footer field yet (follow-up issue), so pass the
+                # existing value through unchanged — editing must not wipe it.
+                update_memo_full(
+                    memo_id,
+                    new_content,
+                    new_tags,
+                    new_shortcut,
+                    new_created_at,
+                    title=row.title,
+                )
             except _IntegrityErrors:
                 exit_error(f"Shortcut {new_shortcut!r} is already in use.")
             if not quiet:
                 console.print(f"[green]Entry [{idx}] updated.[/green]")
         else:
             new_content = "\n---\n".join(parts).strip() if parts else new_data.strip()
-            update_memo_full(memo_id, new_content, tags, shortcut, created_at)
+            update_memo_full(memo_id, new_content, tags, shortcut, created_at, title=row.title)
             if not quiet:
                 console.print(
                     "[yellow]No metadata footer found; "

--- a/src/koda/db.py
+++ b/src/koda/db.py
@@ -47,6 +47,7 @@ VALID_SORT_COLUMNS = {
     "created_at",
     "modified_at",
     "shortcut",
+    "title",
 }
 
 
@@ -108,6 +109,16 @@ def _migration_0003_add_source(conn) -> None:
         conn.execute("ALTER TABLE memos ADD COLUMN source TEXT NOT NULL DEFAULT 'local'")
 
 
+def _migration_0004_add_title(conn) -> None:
+    """Add the nullable ``title`` column: a display-only, human-readable label.
+    Existing rows have no title, so the column stays NULL until set. It is
+    content (synced, unlike ``source``) but is never used to resolve a ref —
+    ``shortcut`` remains the only callable name."""
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(memos)").fetchall()}
+    if "title" not in cols:
+        conn.execute("ALTER TABLE memos ADD COLUMN title TEXT")
+
+
 # Ordered list of schema migrations. Each entry N (0-based) advances the
 # database from PRAGMA user_version N to N+1. Append new migrations to the
 # end; never reorder or rewrite an existing one.
@@ -115,6 +126,7 @@ _MIGRATIONS: list[Callable[[sqlite3.Connection], None]] = [
     _migration_0001_initial_schema,
     _migration_0002_widen_uid,
     _migration_0003_add_source,
+    _migration_0004_add_title,
 ]
 
 SCHEMA_VERSION = len(_MIGRATIONS)
@@ -217,7 +229,7 @@ class MemoDatabase:
             sql += " AND shortcut IS NOT NULL AND shortcut != ''"
         return sql, tuple(params)
 
-    _MEMO_COLUMNS = "id, uid, idx, content, tags, shortcut, created_at, modified_at, source"
+    _MEMO_COLUMNS = "id, uid, idx, content, tags, shortcut, created_at, modified_at, source, title"
 
     def get_memos(
         self,
@@ -315,12 +327,14 @@ class MemoDatabase:
         tags: str,
         created_at: str,
         modified_at: str,
+        title: str | None = None,
     ) -> None:
         with self.connection() as conn:
             conn.execute(
-                "INSERT INTO memos (uid, idx, shortcut, content, tags, created_at, modified_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (uid, idx, shortcut or None, content, tags, created_at, modified_at),
+                "INSERT INTO memos "
+                "(uid, idx, shortcut, content, tags, created_at, modified_at, title) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (uid, idx, shortcut or None, content, tags, created_at, modified_at, title),
             )
 
     def add_memo_auto_idx(
@@ -331,6 +345,7 @@ class MemoDatabase:
         tags: str,
         created_at: str,
         modified_at: str,
+        title: str | None = None,
     ) -> int:
         """Insert a memo at the next free display index, allocated atomically in
         the same transaction, and return that idx. Raises ``IntegrityErrors`` on
@@ -340,9 +355,9 @@ class MemoDatabase:
             new_idx = self.next_idx(conn)
             conn.execute(
                 "INSERT INTO memos "
-                "(uid, idx, shortcut, content, tags, created_at, modified_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (uid, new_idx, shortcut or None, content, tags, created_at, modified_at),
+                "(uid, idx, shortcut, content, tags, created_at, modified_at, title) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (uid, new_idx, shortcut or None, content, tags, created_at, modified_at, title),
             )
         return new_idx
 
@@ -354,14 +369,15 @@ class MemoDatabase:
         shortcut: str | None,
         created_at: str,
         modified_at: str,
+        title: str | None = None,
     ) -> None:
         with self.connection() as conn:
             # Editing an entry counts as reviewing it: reset source to 'local'
             # so a previously remote-synced entry no longer warns on exec.
             conn.execute(
                 "UPDATE memos SET content = ?, tags = ?, shortcut = ?, "
-                "created_at = ?, modified_at = ?, source = 'local' WHERE id = ?",
-                (content.strip(), tags, shortcut or None, created_at, modified_at, memo_id),
+                "created_at = ?, modified_at = ?, title = ?, source = 'local' WHERE id = ?",
+                (content.strip(), tags, shortcut or None, created_at, modified_at, title, memo_id),
             )
 
     def delete_memo(self, memo_id: int) -> None:

--- a/src/koda/git_sync.py
+++ b/src/koda/git_sync.py
@@ -141,6 +141,14 @@ class GitSyncPayload:
             sc = str(sc)
         else:
             sc = None
+        # title is content (synced). Missing/None/"" → None; non-str coerced.
+        # Old peers omit the field entirely, so a default of None gives backward
+        # compatibility.
+        title = raw.get("title", None)
+        if title is not None and title != "":
+            title = str(title)
+        else:
+            title = None
         return {
             "uid": uid,
             "idx": idx,
@@ -149,6 +157,7 @@ class GitSyncPayload:
             "tags": tags,
             "created_at": created_at,
             "modified_at": modified_at,
+            "title": title,
         }
 
     @staticmethod
@@ -177,11 +186,11 @@ class GitSyncPayload:
         """Export memos as UTF-8 JSON Lines, one object per line, sorted by uid."""
         with db.connection() as conn:
             rows = conn.execute(
-                "SELECT uid, idx, shortcut, content, tags, created_at, modified_at "
+                "SELECT uid, idx, shortcut, content, tags, created_at, modified_at, title "
                 "FROM memos ORDER BY uid ASC, id ASC"
             ).fetchall()
         memos: list[dict] = []
-        for uid, idx, shortcut, content, tags, created_at, modified_at in rows:
+        for uid, idx, shortcut, content, tags, created_at, modified_at, title in rows:
             ca = created_at or ""
             ma = modified_at if modified_at else (ca or "")
             memos.append(
@@ -193,6 +202,8 @@ class GitSyncPayload:
                     "tags": tags if tags is not None else "",
                     "created_at": ca,
                     "modified_at": ma,
+                    # title is content; emit JSON null when unset.
+                    "title": title,
                 }
             )
         memos.sort(key=lambda m: m["uid"])
@@ -409,6 +420,13 @@ class MemoMerger:
         modified_at = str(rm.get("modified_at") or "").strip() or created_at
         raw_sc = rm.get("shortcut")
         sc = raw_sc if raw_sc is None or raw_sc == "" else str(raw_sc)
+        # title is synced content. Missing (old peer) / None / "" → None. Since
+        # the merge is last-writer-wins over the whole record, a newer remote
+        # record that omits title will clear a local title — this is intentional
+        # (the remote is the authoritative latest version of the entry).
+        raw_title = rm.get("title")
+        title = raw_title if raw_title is None or raw_title == "" else str(raw_title)
+        title = title or None
         return {
             "uid": uid,
             "want_idx": want_idx,
@@ -417,6 +435,7 @@ class MemoMerger:
             "created_at": created_at,
             "modified_at": modified_at,
             "sc": sc,
+            "title": title,
             "r_ts": parse_memo_datetime(modified_at) or parse_memo_datetime(created_at),
         }
 
@@ -465,8 +484,9 @@ class MemoMerger:
                         shortcut_dropped += 1
                     conn.execute(
                         "INSERT INTO memos "
-                        "(uid, idx, shortcut, content, tags, created_at, modified_at, source) "
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, 'remote')",
+                        "(uid, idx, shortcut, content, tags, created_at, modified_at, "
+                        "title, source) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'remote')",
                         (
                             uid,
                             new_idx,
@@ -475,6 +495,7 @@ class MemoMerger:
                             rec["tags"],
                             rec["created_at"],
                             rec["modified_at"],
+                            rec["title"],
                         ),
                     )
                     inserted += 1
@@ -492,13 +513,14 @@ class MemoMerger:
                 self._apply_idx_for_row(conn, memo_id, rec["want_idx"])
                 conn.execute(
                     "UPDATE memos SET shortcut = ?, content = ?, tags = ?, "
-                    "created_at = ?, modified_at = ?, source = 'remote' WHERE id = ?",
+                    "created_at = ?, modified_at = ?, title = ?, source = 'remote' WHERE id = ?",
                     (
                         use_sc,
                         rec["content"],
                         rec["tags"],
                         rec["created_at"],
                         rec["modified_at"],
+                        rec["title"],
                         memo_id,
                     ),
                 )

--- a/src/koda/models.py
+++ b/src/koda/models.py
@@ -12,12 +12,16 @@ class MemoRow:
 
     Field order matches the canonical SELECT projection used across the
     database layer: id, uid, idx, content, tags, shortcut, created_at,
-    modified_at, source.
+    modified_at, source, title.
 
     ``source`` is a local trust annotation ('local' = authored or reviewed on
     this machine; 'remote' = brought in by a Git sync and not yet reviewed). It
     is intentionally NOT part of the sync payload, so a peer cannot label its
     own entries 'local' to dodge the exec confirmation.
+
+    ``title`` is a display-only, human-readable label (nullable). It is synced
+    content but is never used to resolve a ref — ``shortcut`` stays the only
+    callable name.
     """
 
     id: int
@@ -29,12 +33,13 @@ class MemoRow:
     created_at: str | None
     modified_at: str | None = ""
     source: str = "local"
+    title: str | None = None
 
     @classmethod
     def from_row(cls, row) -> Optional["MemoRow"]:
         if row is None:
             return None
-        assert len(row) == 9, f"expected 9 columns, got {len(row)}"
+        assert len(row) == 10, f"expected 10 columns, got {len(row)}"
         return cls(*row)
 
     @classmethod
@@ -56,4 +61,5 @@ class MemoRow:
             "created_at": self.created_at,
             "modified_at": self.modified_at,
             "source": self.source,
+            "title": self.title,
         }

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -51,6 +51,7 @@ def test_dump_load_round_trip(db):
             "tags": "",
             "created_at": "2026-01-01 00:00:00",
             "modified_at": "2026-01-01 00:00:00",
+            "title": None,
         },
         {
             "uid": "uid0002",
@@ -60,6 +61,7 @@ def test_dump_load_round_trip(db):
             "tags": "work",
             "created_at": "2026-01-02 00:00:00",
             "modified_at": "2026-01-02 00:00:00",
+            "title": None,
         },
     ]
 
@@ -130,3 +132,52 @@ class TestParseRecordDefaults:
     def test_idx_coerced_from_numeric_string(self):
         rec = GitSyncPayload.parse_record({"uid": "uid0001", "idx": "5"}, 1)
         assert rec["idx"] == 5
+
+    def test_missing_title_becomes_none(self):
+        # Legacy payload from an old peer: no 'title' field → None (backward compat).
+        rec = GitSyncPayload.parse_record({"uid": "uid0001", "idx": 0}, 1)
+        assert rec["title"] is None
+
+    def test_empty_title_becomes_none(self):
+        rec = GitSyncPayload.parse_record({"uid": "uid0001", "idx": 0, "title": ""}, 1)
+        assert rec["title"] is None
+
+    def test_title_preserved(self):
+        rec = GitSyncPayload.parse_record({"uid": "uid0001", "idx": 0, "title": "Deploy"}, 1)
+        assert rec["title"] == "Deploy"
+
+
+def test_dump_emits_title(db):
+    db.add_memo(
+        "uid0001", 0, None, "first", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00", title="Hello"
+    )
+    line = GitSyncPayload.dump(db).decode().strip()
+    assert json.loads(line)["title"] == "Hello"
+
+
+def test_dump_emits_null_title_when_unset(db):
+    db.add_memo("uid0001", 0, None, "first", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+    line = GitSyncPayload.dump(db).decode().strip()
+    assert json.loads(line)["title"] is None
+
+
+def test_dump_load_round_trip_with_title(db):
+    db.add_memo(
+        "uid0001",
+        0,
+        None,
+        "first",
+        "",
+        "2026-01-01 00:00:00",
+        "2026-01-01 00:00:00",
+        title="My Title",
+    )
+    loaded = GitSyncPayload.load(GitSyncPayload.dump(db))
+    assert loaded[0]["title"] == "My Title"
+
+
+def test_legacy_payload_line_without_title_parses():
+    # A line emitted by a pre-title peer has no 'title' key at all.
+    data = b'{"uid":"uid0001","idx":0,"content":"x"}\n'
+    loaded = GitSyncPayload.load(data)
+    assert loaded[0]["title"] is None

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -11,6 +11,7 @@ def entry(
     shortcut=None,
     created_at="2026-01-01 00:00:00",
     modified_at=None,
+    title=None,
 ):
     return {
         "uid": uid,
@@ -20,6 +21,7 @@ def entry(
         "tags": tags,
         "created_at": created_at,
         "modified_at": modified_at if modified_at is not None else created_at,
+        "title": title,
     }
 
 
@@ -133,6 +135,32 @@ def test_batch_mixed_outcomes(db):
     assert inserted == 2
     assert updated == 1
     assert skipped == 0
+
+
+def test_insert_carries_title(db):
+    MemoMerger(db).merge([entry("uid0001", 0, title="Deploy prod")])
+    assert db.get_memo_by_uid("uid0001").title == "Deploy prod"
+
+
+def test_update_carries_title(db):
+    db.add_memo("uid0001", 0, None, "old", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+    MemoMerger(db).merge(
+        [entry("uid0001", 0, content="new", modified_at="2026-02-01 00:00:00", title="Renamed")]
+    )
+    assert db.get_memo_by_uid("uid0001").title == "Renamed"
+
+
+def test_newer_remote_without_title_clears_local_title(db):
+    """Last-writer-wins is whole-record: a newer remote that omits the title
+    clears the local one (intentional — remote is the latest version)."""
+    db.add_memo(
+        "uid0001", 0, None, "old", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00", title="Keep?"
+    )
+    assert db.get_memo_by_uid("uid0001").title == "Keep?"
+    MemoMerger(db).merge(
+        [entry("uid0001", 0, content="new", modified_at="2026-02-01 00:00:00", title=None)]
+    )
+    assert db.get_memo_by_uid("uid0001").title is None
 
 
 def test_two_new_entries_claim_same_idx(db):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -94,6 +94,53 @@ def test_source_column_added_and_defaults_local(tmp_path):
     assert db.get_memo_by_uid(full).source == "local"
 
 
+def test_title_column_added_and_nullable(tmp_path):
+    """Migration 0004 adds the nullable title column to a v3 DB, preserving the
+    existing row (title NULL) and reaching user_version 4."""
+    old_path = tmp_path / "v3.db"
+    conn = sqlite3.connect(old_path)
+    conn.executescript(
+        """
+        CREATE TABLE memos (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, uid TEXT UNIQUE, idx INTEGER UNIQUE,
+            shortcut TEXT, content TEXT, tags TEXT, created_at TIMESTAMP, modified_at TIMESTAMP,
+            source TEXT NOT NULL DEFAULT 'local'
+        );
+        PRAGMA user_version = 3;
+        """
+    )
+    full = compute_uid("body", "2026-01-01 00:00:00")
+    conn.execute(
+        "INSERT INTO memos (uid, idx, content, tags, created_at, modified_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (full, 0, "body", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    db = MemoDatabase(backend="local", path=old_path)
+    db.init_db()
+
+    assert _user_version(db) == 4
+    assert "title" in _columns(db)
+    row = db.get_memo_by_uid(full)
+    assert row is not None and row.content == "body"
+    assert row.title is None
+
+
+def test_title_migration_is_idempotent_on_fresh_db(tmp_path):
+    """A fresh DB carries the title column and re-running init_db is a no-op."""
+    db = MemoDatabase(backend="local", path=tmp_path / "fresh_title.db")
+    db.init_db()
+    assert "title" in _columns(db)
+    assert _user_version(db) == SCHEMA_VERSION
+
+    # Re-run: must not error, drop the column, or re-apply the migration.
+    db.init_db()
+    assert "title" in _columns(db)
+    assert _user_version(db) == SCHEMA_VERSION
+
+
 def test_init_db_is_idempotent(tmp_path):
     db = MemoDatabase(backend="local", path=tmp_path / "idem.db")
     db.init_db()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,8 +4,8 @@ import pytest
 
 from koda.models import MemoRow
 
-# Canonical 9-column row matching _MEMO_COLUMNS in db.py:
-# id, uid, idx, content, tags, shortcut, created_at, modified_at, source
+# Canonical 10-column row matching _MEMO_COLUMNS in db.py:
+# id, uid, idx, content, tags, shortcut, created_at, modified_at, source, title
 _ROW = (
     1,
     "abc1234",
@@ -16,6 +16,7 @@ _ROW = (
     "2026-01-01 00:00:00",
     "2026-01-02 00:00:00",
     "local",
+    "My Title",
 )
 
 
@@ -23,7 +24,7 @@ class TestFromRow:
     def test_none_returns_none(self):
         assert MemoRow.from_row(None) is None
 
-    def test_nine_columns_materializes(self):
+    def test_ten_columns_materializes(self):
         memo = MemoRow.from_row(_ROW)
         assert memo is not None
         assert memo.id == 1
@@ -35,11 +36,18 @@ class TestFromRow:
         assert memo.created_at == "2026-01-01 00:00:00"
         assert memo.modified_at == "2026-01-02 00:00:00"
         assert memo.source == "local"
+        assert memo.title == "My Title"
 
-    def test_eight_columns_raises_assertion(self):
+    def test_to_dict_includes_title(self):
+        memo = MemoRow.from_row(_ROW)
+        assert memo is not None
+        d = memo.to_dict()
+        assert d["title"] == "My Title"
+
+    def test_nine_columns_raises_assertion(self):
         with pytest.raises(AssertionError):
-            MemoRow.from_row(_ROW[:8])
+            MemoRow.from_row(_ROW[:9])
 
-    def test_ten_columns_raises_assertion(self):
+    def test_eleven_columns_raises_assertion(self):
         with pytest.raises(AssertionError):
             MemoRow.from_row((*_ROW, "extra"))

--- a/tests/test_title.py
+++ b/tests/test_title.py
@@ -1,0 +1,73 @@
+"""Title column threading: edit/copy must never wipe an existing title."""
+
+import pytest
+
+import koda.runtime as runtime
+from koda.commands import memo
+
+
+@pytest.fixture
+def wired_db(db, monkeypatch):
+    """Point the lazy DB cache at a fresh temp database."""
+    monkeypatch.setattr(runtime, "_db", db)
+    return db
+
+
+def _seed_titled(db, title="Deploy prod"):
+    """Insert one entry that carries a title and return its row."""
+    db.add_memo(
+        "uid0001",
+        0,
+        "dp",
+        "deploy body",
+        "work",
+        "2026-01-01 00:00:00",
+        "2026-01-01 00:00:00",
+        title=title,
+    )
+    return db.get_memo_by_idx(0)
+
+
+def test_copy_preserves_source_title(wired_db):
+    _seed_titled(wired_db)
+    memo.copy("0")
+    copied = wired_db.get_memo_by_idx(1)
+    assert copied is not None
+    assert copied.title == "Deploy prod"
+
+
+def test_edit_with_footer_preserves_title(wired_db, monkeypatch):
+    """The footer has no title field yet, so a footer edit must pass the
+    existing title through unchanged."""
+    _seed_titled(wired_db)
+
+    def fake_editor(path):
+        # Rewrite body but keep the metadata footer intact.
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(
+                "new body\n\n---\n# Metadata\ntags: work\n"
+                "shortcut: dp\ncreated_at: 2026-01-01 00:00:00\n---"
+            )
+
+    monkeypatch.setattr(memo, "launch_editor", fake_editor)
+    memo.edit("0", quiet=True)
+
+    row = wired_db.get_memo_by_idx(0)
+    assert row.content == "new body"
+    assert row.title == "Deploy prod"
+
+
+def test_edit_without_footer_preserves_title(wired_db, monkeypatch):
+    _seed_titled(wired_db)
+
+    def fake_editor(path):
+        # Drop the footer entirely: content-only update branch.
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("body without footer")
+
+    monkeypatch.setattr(memo, "launch_editor", fake_editor)
+    memo.edit("0", quiet=True)
+
+    row = wired_db.get_memo_by_idx(0)
+    assert row.content == "body without footer"
+    assert row.title == "Deploy prod"


### PR DESCRIPTION
## Summary

Adds the storage/model/sync plumbing for a per-entry **title**: a display-only, human-readable label. No CLI surface is added here (follow-ups cover `add --title`, the edit footer, and list display). Titles are content (synced) but are NEVER used to resolve a ref — `shortcut` stays the only callable name; `KodaGroup.resolve_command` and `resolve_ref` are untouched.

- **Schema (`db.py`)**: migration `_migration_0004_add_title` adds a nullable `title TEXT`, guarded by a `PRAGMA table_info` check and appended to `_MIGRATIONS` (never reordered). `title` is appended LAST to `_MEMO_COLUMNS`; `VALID_SORT_COLUMNS` gains `title` (propagates to `list --sort-by`). `add_memo`/`add_memo_auto_idx`/`update_memo` accept a keyword `title: str | None = None`; `update_memo` keeps resetting `source='local'`.
- **Model (`models.py`)**: `MemoRow.title` appended after `source`; `from_row` asserts 10 columns; `to_dict()` includes `title`.
- **Callers (`commands/memo.py`)**: `update_memo_full` threads `title`; `edit` (footer and no-footer branches) and `copy` pass the existing/source title so it is never wiped; `_add_impl` passes `title=None`.
- **Sync (`git_sync.py`)**: `dump` emits `title` (JSON `null` when unset); `parse_record`/`_normalize` accept optional `title` (missing/None/`""` → `None`) for backward compat with pre-title peers; `merge` INSERT/UPDATE write `title`. Last-writer-wins is whole-record, so a newer remote record without a title clears the local title — flagged intentional in a code comment.

## Test plan

Added tests: migration 0004 (fresh / existing v3 DB / idempotent / `user_version` reaches 4 / nullable, preserves rows), 10-column model materialization + `to_dict` title, dump/parse round-trip with and without title, legacy payload line lacking the field, merge insert/update carrying title and clearing-on-newer-remote, and edit/copy preserving title.

Gate results (`uv run ruff format src tests && uv run ruff check src tests && uv run pytest`):

- `ruff format`: 49 files unchanged
- `ruff check`: all checks passed
- `pytest`: **307 passed**

No behavior change for any existing CLI command output.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)