### PR TITLE
feat(memo): add --title, edit footer title line, show display, and title-aware query

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Single-letter aliases are reserved and cannot be used as entry shortcuts.
 |---|---|
 | `-s` / `--shortcut` | Assign a memorable alias to an entry |
 | `-t` / `--tag` | Assign tags (on `add`) or filter by tag |
+| `--title` | Assign a human-readable display label (on `add`; editable via `edit`) |
 | `-V` / `--var` | Variable substitution at recall time |
 
 ## Installation
@@ -193,8 +194,11 @@ Save a new entry from arguments, heredoc, stdin, or `$EDITOR`.
 ```bash
 koda a "docker compose up --build" -t docker -s dc
 koda a "npm run dev" -t work
+koda a "psql -h localhost -U admin" --title "Local Postgres"
 koda a              # opens $EDITOR
 ```
+
+Use `--title` to attach a human-readable display label (single line). The title is shown by `koda show` and is also matched by `-q/--query` searches.
 
 Heredoc for multi-line content:
 
@@ -282,7 +286,7 @@ koda s 5    # → echo hello  # this is a comment
 
 ```bash
 koda l                          # all entries ordered by display index
-koda l -q "docker"              # substring search on body
+koda l -q "docker"              # substring search on body or title
 koda l -t linux                 # filter by tag substring
 koda l -T archive               # exclude entries tagged "archive"
 koda l -S                       # only entries that have a shortcut
@@ -395,12 +399,26 @@ koda x greet -V world   # → hi world
 
 ### Edit
 
-Open an entry in `$EDITOR`. The footer contains editable metadata (tags, shortcut).
+Open an entry in `$EDITOR`. The footer contains editable metadata (title, tags, shortcut).
 
 ```bash
 koda e web-srv        # by shortcut
 koda e 5              # by index
 ```
+
+The metadata footer template:
+
+```
+---
+# Metadata
+title: My Deploy Script
+tags: docker,work
+shortcut: dc
+created_at: 2026-01-01 00:00:00
+---
+```
+
+Edit the `title:` value to change it; leave the value blank to clear the title. If the entire footer is deleted, the existing title is preserved along with the other metadata.
 
 ---
 

--- a/src/koda/cmd_helpers/display.py
+++ b/src/koda/cmd_helpers/display.py
@@ -1,6 +1,7 @@
 """Rich-formatted memo display."""
 
 from rich.console import Console
+from rich.text import Text
 
 console = Console()
 
@@ -14,13 +15,19 @@ def print_memo(
     created_at: str | None,
     modified_at: str | None = None,
     source: str | None = None,
+    title: str | None = None,
 ) -> None:
     sc_str = f" | SC: [bold green]{shortcut}[/bold green]" if shortcut else ""
     ts = f"created: {created_at}"
     if modified_at and modified_at != created_at:
         ts += f" | modified: {modified_at}"
     src_str = " | [yellow]source: remote[/yellow]" if source == "remote" else ""
-    console.print(
-        f"\n[bold cyan]IDX: {idx}[/bold cyan] ({uid}){sc_str} | {ts}{src_str}\n"
-        f"Tags: [magenta]{tags}[/magenta]\n" + "-" * 20 + f"\n{content}"
-    )
+    console.print(f"\n[bold cyan]IDX: {idx}[/bold cyan] ({uid}){sc_str} | {ts}{src_str}")
+    if title:
+        # Build with Text so user-controlled content is never interpolated into
+        # Rich markup — a title containing "[bold]" must render literally.
+        title_line = Text()
+        title_line.append("Title: ", style="bold")
+        title_line.append(title)
+        console.print(title_line)
+    console.print(f"Tags: [magenta]{tags}[/magenta]\n" + "-" * 20 + f"\n{content}")

--- a/src/koda/cmd_helpers/metadata.py
+++ b/src/koda/cmd_helpers/metadata.py
@@ -25,7 +25,13 @@ def looks_like_koda_footer(segment: str) -> bool:
     if s.startswith("# Metadata"):
         return True
     lines = [ln for ln in s.splitlines() if ln.strip()]
-    return bool(lines and lines[0].strip().startswith("tags:"))
+    if not lines:
+        return False
+    first = lines[0].strip()
+    # Accept a footer whose first metadata line is either `tags:` or `title:`
+    # so a hand-trimmed footer (with the `# Metadata` header removed) still
+    # parses correctly.
+    return first.startswith("tags:") or first.startswith("title:")
 
 
 def first_footer_index(parts: list[str]) -> int | None:

--- a/src/koda/commands/exec.py
+++ b/src/koda/commands/exec.py
@@ -51,7 +51,15 @@ def _run_pick_action(action: str, ref: str) -> None:
     if action == "show":
         init_db()
         row = resolve_ref(ref)
-        _print_memo(row.uid, row.idx, row.shortcut, row.content, row.tags, row.created_at)
+        _print_memo(
+            row.uid,
+            row.idx,
+            row.shortcut,
+            row.content,
+            row.tags,
+            row.created_at,
+            title=row.title,
+        )
         return
     if action == "edit":
         memo.edit(ref)
@@ -186,7 +194,9 @@ def exec_memo(
 
 @app.command(rich_help_panel="Core")
 def pick(
-    query: str | None = typer.Option(None, "--query", "-q", help="Substring match on memo body."),
+    query: str | None = typer.Option(
+        None, "--query", "-q", help="Substring match on memo body or title."
+    ),
     tag: str | None = typer.Option(None, "--tag", "-t", help="Substring match on tags."),
     exclude_tag: str | None = typer.Option(
         None, "--exclude-tag", "-T", help="Exclude entries whose tags include this substring."

--- a/src/koda/commands/memo.py
+++ b/src/koda/commands/memo.py
@@ -44,6 +44,23 @@ def _validate_shortcut(shortcut: str | None) -> str | None:
     return shortcut
 
 
+def _validate_title(title: str | None) -> str | None:
+    """Strip and validate a title value.
+
+    Explicit empty/whitespace → error (user passed --title but gave nothing).
+    Newline in value → error (title must be a single line).
+    Otherwise return the stripped value, or None when the input is None.
+    """
+    if title is None:
+        return None
+    stripped = title.strip()
+    if not stripped:
+        exit_error("Title cannot be empty. Omit --title to save without one.")
+    if "\n" in title:
+        exit_error("Title must be a single line.")
+    return stripped
+
+
 def update_memo_full(
     memo_id: int,
     content: str,
@@ -63,8 +80,10 @@ def _add_impl(
     quiet: bool = False,
     print_uid: bool = False,
     print_idx: bool = False,
+    title: str | None = None,
 ) -> None:
     shortcut = _validate_shortcut(shortcut)
+    title = _validate_title(title)
     init_db()
     content = ""
 
@@ -98,7 +117,7 @@ def _add_impl(
     uid = _generate_uid(content, now)
     try:
         new_idx = get_db().add_memo_auto_idx(
-            uid, shortcut, content, formatted_tags, now, now, title=None
+            uid, shortcut, content, formatted_tags, now, now, title=title
         )
     except _IntegrityErrors:
         exit_error(f"Shortcut {shortcut!r} is already in use.")
@@ -110,6 +129,7 @@ def _add_impl(
     if not quiet:
         meta = f" | tags: {formatted_tags}" if formatted_tags else ""
         meta += f" | sc=[bold green]{shortcut}[/bold green]" if shortcut else ""
+        meta += f" | title: {title}" if title else ""
         console.print(f"[green]Saved [{new_idx}] ({uid}){meta}[/green]")
 
 
@@ -124,6 +144,9 @@ def add(
     shortcut: str | None = typer.Option(
         None, "--shortcut", "-s", help="Short alias for this entry (e.g. 'deploy')."
     ),
+    title: str | None = typer.Option(
+        None, "--title", help="Human-readable display label (single line, no alias)."
+    ),
     quiet: bool = typer.Option(
         False, "--quiet", help="Suppress the success message (for scripting)."
     ),
@@ -135,7 +158,9 @@ def add(
     ),
 ):
     """Create an entry from arguments, stdin, or your editor. Alias: `koda a`."""
-    _add_impl(text, tag, shortcut, quiet=quiet, print_uid=print_uid, print_idx=print_idx)
+    _add_impl(
+        text, tag, shortcut, quiet=quiet, print_uid=print_uid, print_idx=print_idx, title=title
+    )
 
 
 @app.command(name="remove", rich_help_panel="Core")
@@ -147,7 +172,7 @@ def rm(
         None, "--tag", "-t", help="Delete entries whose tags match this substring."
     ),
     query: str | None = typer.Option(
-        None, "--query", "-q", help="Delete entries whose body matches this substring."
+        None, "--query", "-q", help="Substring match on memo body or title."
     ),
     all_entries: bool = typer.Option(False, "--all", help="Delete ALL entries (requires -f)."),
     force: bool = typer.Option(False, "--force", "-f", help="Delete without prompting."),
@@ -203,7 +228,15 @@ def rm(
     else:
         ref = indices[0] if indices else None
         row = resolve_ref(ref)
-        _print_memo(row.uid, row.idx, row.shortcut, row.content, row.tags, row.created_at)
+        _print_memo(
+            row.uid,
+            row.idx,
+            row.shortcut,
+            row.content,
+            row.tags,
+            row.created_at,
+            title=row.title,
+        )
         console.print("\n[bold red]This entry will be deleted.[/bold red]")
 
         if not force and not confirm("Delete this entry?"):
@@ -252,8 +285,10 @@ def edit(
     )
 
     sc_line = f"shortcut: {shortcut}" if shortcut else "shortcut: "
+    title_line = f"title: {row.title}" if row.title else "title: "
     template = (
-        f"{content}\n\n---\n# Metadata\ntags: {tags}\n{sc_line}\ncreated_at: {created_at}\n---"
+        f"{content}\n\n---\n# Metadata\n{title_line}\ntags: {tags}\n"
+        f"{sc_line}\ncreated_at: {created_at}\n---"
     )
 
     with tempfile.NamedTemporaryFile(
@@ -276,32 +311,51 @@ def edit(
             new_content = "\n---\n".join(parts[:footer_at]).strip()
             meta_section = last_footer_segment(parts) or ""
             new_tags, new_shortcut, new_created_at = tags, shortcut, created_at
+            # If the footer is present, pick up the title from it; an empty
+            # value means "clear" (same contract as shortcut:). If the user
+            # deletes the footer entirely the no-footer branch preserves it.
+            new_title: str | None = row.title
+            footer_has_title_line = False
             for line in meta_section.splitlines():
-                if line.startswith("tags:"):
+                if line.startswith("title:"):
+                    footer_has_title_line = True
+                    val = line.removeprefix("title:").strip()
+                    # Empty value clears the title; non-empty goes through the
+                    # newline guard only (an empty value here means "clear").
+                    if not val:
+                        new_title = None
+                    elif "\n" in val:
+                        exit_error("Title must be a single line.")
+                    else:
+                        new_title = val
+                elif line.startswith("tags:"):
                     new_tags = line.removeprefix("tags:").strip()
                 elif line.startswith("shortcut:"):
                     val = line.removeprefix("shortcut:").strip()
                     new_shortcut = val if val else None
                 elif line.startswith("created_at:"):
                     new_created_at = line.removeprefix("created_at:").strip()
+            # If the footer existed but had no title: line at all (hand-edited
+            # footer without the title key), preserve the existing title.
+            if not footer_has_title_line:
+                new_title = row.title
             new_shortcut = _validate_shortcut(new_shortcut)
 
             try:
-                # title has no footer field yet (follow-up issue), so pass the
-                # existing value through unchanged — editing must not wipe it.
                 update_memo_full(
                     memo_id,
                     new_content,
                     new_tags,
                     new_shortcut,
                     new_created_at,
-                    title=row.title,
+                    title=new_title,
                 )
             except _IntegrityErrors:
                 exit_error(f"Shortcut {new_shortcut!r} is already in use.")
             if not quiet:
                 console.print(f"[green]Entry [{idx}] updated.[/green]")
         else:
+            # No footer detected: content-only update; all metadata preserved.
             new_content = "\n---\n".join(parts).strip() if parts else new_data.strip()
             update_memo_full(memo_id, new_content, tags, shortcut, created_at, title=row.title)
             if not quiet:
@@ -474,7 +528,9 @@ def list_memos(
         None,
         help="If given, show that single entry (index or shortcut) instead of the table.",
     ),
-    query: str | None = typer.Option(None, "--query", "-q", help="Substring match on memo body."),
+    query: str | None = typer.Option(
+        None, "--query", "-q", help="Substring match on memo body or title."
+    ),
     tag: str | None = typer.Option(None, "--tag", "-t", help="Substring match on tags."),
     exclude_tag: str | None = typer.Option(
         None,
@@ -588,6 +644,7 @@ def show(
         row.created_at,
         row.modified_at,
         row.source,
+        title=row.title,
     )
 
 

--- a/src/koda/db.py
+++ b/src/koda/db.py
@@ -217,8 +217,9 @@ class MemoDatabase:
         sql = " WHERE 1=1"
         params: list = []
         if query:
-            sql += " AND content LIKE ?"
-            params.append(f"%{query}%")
+            # Match against both body and title so `-q` finds title-only hits.
+            sql += " AND (content LIKE ? OR title LIKE ?)"
+            params.extend([f"%{query}%", f"%{query}%"])
         if tag:
             sql += " AND tags LIKE ?"
             params.append(f"%{tag}%")

--- a/tests/test_title_cli.py
+++ b/tests/test_title_cli.py
@@ -1,0 +1,295 @@
+"""Tests for title CLI: add --title, edit footer, show display, query matching (#141)."""
+
+import json
+
+import pytest
+import typer
+
+import koda.runtime as runtime
+from koda.commands import memo
+
+
+class FakeStdin:
+    def __init__(self, data="", tty=True):
+        self._data = data
+        self._tty = tty
+
+    def isatty(self):
+        return self._tty
+
+    def read(self):
+        return self._data
+
+
+@pytest.fixture
+def wired_db(db, monkeypatch):
+    """Point the lazy DB cache at a fresh temp database."""
+    monkeypatch.setattr(runtime, "_db", db)
+    return db
+
+
+# ── _validate_title ──────────────────────────────────────────────────────────
+
+
+def test_validate_title_none_returns_none():
+    assert memo._validate_title(None) is None
+
+
+def test_validate_title_strips_whitespace():
+    assert memo._validate_title("  My Title  ") == "My Title"
+
+
+def test_validate_title_empty_string_errors(capsys):
+    with pytest.raises(typer.Exit):
+        memo._validate_title("")
+    assert "Title cannot be empty" in capsys.readouterr().err
+
+
+def test_validate_title_whitespace_only_errors(capsys):
+    with pytest.raises(typer.Exit):
+        memo._validate_title("   ")
+    assert "Title cannot be empty" in capsys.readouterr().err
+
+
+def test_validate_title_newline_errors(capsys):
+    with pytest.raises(typer.Exit):
+        memo._validate_title("Line one\nLine two")
+    assert "Title must be a single line" in capsys.readouterr().err
+
+
+# ── add --title ──────────────────────────────────────────────────────────────
+
+
+def test_add_with_title_persists(wired_db, monkeypatch):
+    monkeypatch.setattr("sys.stdin", FakeStdin(tty=True))
+    memo._add_impl(text=["deploy body"], title="Deploy prod")
+    row = wired_db.get_latest_entry()
+    assert row.title == "Deploy prod"
+
+
+def test_add_with_title_visible_in_show_json(wired_db, monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", FakeStdin(tty=True))
+    memo._add_impl(text=["deploy body"], title="Deploy prod")
+    row = wired_db.get_latest_entry()
+    capsys.readouterr()  # discard the "Saved" success message
+    memo.show(ref=str(row.idx), json_output=True)
+    obj = json.loads(capsys.readouterr().out)
+    assert obj["title"] == "Deploy prod"
+
+
+def test_add_empty_title_rejected(wired_db, monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", FakeStdin(tty=True))
+    with pytest.raises(typer.Exit):
+        memo._add_impl(text=["body"], title="")
+    assert "Title cannot be empty" in capsys.readouterr().err
+    # Nothing saved.
+    assert wired_db.get_latest_entry() is None
+
+
+def test_add_multiline_title_rejected(wired_db, monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", FakeStdin(tty=True))
+    with pytest.raises(typer.Exit):
+        memo._add_impl(text=["body"], title="Line one\nLine two")
+    assert "Title must be a single line" in capsys.readouterr().err
+    assert wired_db.get_latest_entry() is None
+
+
+def test_add_success_message_includes_title(wired_db, monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin", FakeStdin(tty=True))
+    memo._add_impl(text=["body"], title="My Label")
+    out = capsys.readouterr().out
+    assert "title: My Label" in out
+
+
+# ── edit footer title line ────────────────────────────────────────────────────
+
+
+def _seed(db, content="body", title=None, shortcut=None):
+    db.add_memo(
+        "uid0001",
+        0,
+        shortcut,
+        content,
+        "work",
+        "2026-01-01 00:00:00",
+        "2026-01-01 00:00:00",
+        title=title,
+    )
+    return db.get_memo_by_idx(0)
+
+
+def test_edit_footer_sets_title(wired_db, monkeypatch):
+    _seed(wired_db)
+
+    def fake_editor(path):
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(
+                "body\n\n---\n# Metadata\ntitle: New Title\ntags: work\n"
+                "shortcut: \ncreated_at: 2026-01-01 00:00:00\n---"
+            )
+
+    monkeypatch.setattr(memo, "launch_editor", fake_editor)
+    memo.edit("0", quiet=True)
+    assert wired_db.get_memo_by_idx(0).title == "New Title"
+
+
+def test_edit_footer_clears_title_on_empty_value(wired_db, monkeypatch):
+    _seed(wired_db, title="Old Title")
+
+    def fake_editor(path):
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(
+                "body\n\n---\n# Metadata\ntitle: \ntags: work\n"
+                "shortcut: \ncreated_at: 2026-01-01 00:00:00\n---"
+            )
+
+    monkeypatch.setattr(memo, "launch_editor", fake_editor)
+    memo.edit("0", quiet=True)
+    assert wired_db.get_memo_by_idx(0).title is None
+
+
+def test_edit_footer_changes_title(wired_db, monkeypatch):
+    _seed(wired_db, title="Old Title")
+
+    def fake_editor(path):
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(
+                "body\n\n---\n# Metadata\ntitle: Updated Title\ntags: work\n"
+                "shortcut: \ncreated_at: 2026-01-01 00:00:00\n---"
+            )
+
+    monkeypatch.setattr(memo, "launch_editor", fake_editor)
+    memo.edit("0", quiet=True)
+    assert wired_db.get_memo_by_idx(0).title == "Updated Title"
+
+
+def test_edit_delete_footer_preserves_title(wired_db, monkeypatch):
+    """Deleting the whole footer must leave the title unchanged."""
+    _seed(wired_db, title="Keep Me")
+
+    def fake_editor(path):
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("body without footer")
+
+    monkeypatch.setattr(memo, "launch_editor", fake_editor)
+    memo.edit("0", quiet=True)
+    assert wired_db.get_memo_by_idx(0).title == "Keep Me"
+
+
+def test_edit_footer_without_title_key_preserves_title(wired_db, monkeypatch):
+    """A hand-trimmed footer that omits the title: line must not wipe the title."""
+    _seed(wired_db, title="Keep Me Too")
+
+    def fake_editor(path):
+        # Write a footer that has no title: line at all.
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(
+                "body\n\n---\n# Metadata\ntags: work\n"
+                "shortcut: \ncreated_at: 2026-01-01 00:00:00\n---"
+            )
+
+    monkeypatch.setattr(memo, "launch_editor", fake_editor)
+    memo.edit("0", quiet=True)
+    assert wired_db.get_memo_by_idx(0).title == "Keep Me Too"
+
+
+# ── looks_like_koda_footer: title: first line ─────────────────────────────────
+
+
+def test_looks_like_koda_footer_accepts_title_prefix():
+    from koda.cmd_helpers.metadata import looks_like_koda_footer
+
+    assert looks_like_koda_footer("title: My Title\ntags: work\n")
+
+
+def test_looks_like_koda_footer_still_accepts_tags_prefix():
+    from koda.cmd_helpers.metadata import looks_like_koda_footer
+
+    assert looks_like_koda_footer("tags: work\nshortcut: foo\n")
+
+
+# ── query matches title ──────────────────────────────────────────────────────
+
+
+def _seed_two(db):
+    """Insert two entries: one with a title hit, one with a body hit."""
+    db.add_memo(
+        "uid0001",
+        0,
+        None,
+        "unrelated body",
+        "work",
+        "2026-01-01 00:00:00",
+        "2026-01-01 00:00:00",
+        title="Deploy prod",
+    )
+    db.add_memo(
+        "uid0002",
+        1,
+        None,
+        "docker compose up",
+        "",
+        "2026-01-01 00:00:00",
+        "2026-01-01 00:00:00",
+        title=None,
+    )
+
+
+def test_query_matches_title_only_hit(wired_db):
+    _seed_two(wired_db)
+    # "Deploy" only appears in the title of entry 0, not in its body.
+    rows = wired_db.get_memos(query="Deploy")
+    assert len(rows) == 1
+    assert rows[0].uid == "uid0001"
+
+
+def test_query_matches_body_hit(wired_db):
+    _seed_two(wired_db)
+    rows = wired_db.get_memos(query="docker")
+    assert len(rows) == 1
+    assert rows[0].uid == "uid0002"
+
+
+def test_list_with_query_shows_title_hit(wired_db, monkeypatch, capsys):
+    _seed_two(wired_db)
+    memo._list_memos_impl(query="Deploy")
+    out = capsys.readouterr().out
+    # The body "unrelated body" should appear in the listed row.
+    assert "unrelated body" in out
+
+
+def test_remove_batch_query_matches_title(wired_db, monkeypatch, capsys):
+    _seed_two(wired_db)
+    # Force delete without prompt.
+    memo.rm(indices=None, tag=None, query="Deploy", all_entries=False, force=True)
+    assert wired_db.get_memo_by_idx(0) is None
+    # Body-match entry survives.
+    assert wired_db.get_memo_by_idx(1) is not None
+
+
+# ── copy preserves title ──────────────────────────────────────────────────────
+
+
+def test_copy_preserves_title(wired_db):
+    _seed(wired_db, title="Original Title")
+    memo.copy("0")
+    copied = wired_db.get_memo_by_idx(1)
+    assert copied is not None
+    assert copied.title == "Original Title"
+
+
+# ── show --json includes title ────────────────────────────────────────────────
+
+
+def test_show_json_includes_title(wired_db, capsys):
+    _seed(wired_db, title="JSON Title")
+    memo.show(ref="0", json_output=True)
+    obj = json.loads(capsys.readouterr().out)
+    assert obj["title"] == "JSON Title"
+
+
+def test_list_json_includes_title(wired_db, capsys):
+    _seed(wired_db, title="List JSON Title")
+    memo._emit_list_json(None, None, None, False, None, None)
+    data = json.loads(capsys.readouterr().out)
+    assert data[0]["title"] == "List JSON Title"


### PR DESCRIPTION
## Summary

- **`koda add --title TEXT`** (long-only, no `-T` alias): persists a human-readable display label. Validation rejects empty/whitespace and multi-line values with specific error messages. Success message appends `| title: <title>` when set.
- **`koda edit` footer** gains a `title:` line as the first metadata line. Empty value clears the title; deleting the whole footer preserves it along with other metadata. `looks_like_koda_footer` extended to also accept a first line starting with `title:`.
- **`koda show` / `print_memo`** gains a `title` keyword; renders a bold `Title: <value>` line between the IDX header and Tags, built via `rich.text.Text` (user content never interpolated into Rich markup). All call sites updated: `show`, single-delete preview in `remove`, and `_run_pick_action("show", ...)` in `exec.py`.
- **`-q/--query` now matches titles**: `MemoDatabase._filters` uses `(content LIKE ? OR title LIKE ?)`. Help strings updated on `list`, `pick`, and `remove`.
- **README** updated: `--title` on add, footer template with `title:` line, query semantics.
- **24 new tests** in `tests/test_title_cli.py` covering all spec requirements.

## Test plan

- [x] `uv run ruff format src tests` — clean
- [x] `uv run ruff check src tests` — clean
- [x] `uv run pytest` — 331 passed, 71% coverage (60% threshold)
- [x] `_validate_title` errors with exact messages for empty and multi-line input
- [x] `add --title` persists and shows in `show --json`
- [x] Edit round-trip: set, change, clear (empty value), delete footer → title preserved
- [x] `-q` matches title-only hit on `list`, batch `remove`
- [x] `copy` preserves title
- [x] `show --json` and `list --json` include `title` field

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)