### PR TITLE
feat(list): display modes title/body/full/both via --display/-d and config list.display

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,10 +294,23 @@ koda l -n 50 -p 2              # 50 entries per page, page 2
 koda l -s created_at --desc     # sort by creation date descending
 koda l --columns idx,uid,sc,tags,content,created_at   # all columns
 koda l --columns idx,content    # minimal view
+koda l -d body                  # show body preview in content column
+koda l -d title                 # show title (falls back to body preview if unset)
+koda l -d full                  # show entire body, ignoring rows/truncate
+koda l -d both                  # bold title line + body preview below
 ```
 
-Default columns: `IDX`, `SC`, `Tags`, `Content`. Available columns: `idx`, `uid`, `sc`, `tags`, `content`, `created_at` (`idx` is required).
+Default columns: `IDX`, `SC`, `Tags`, `Content`. Available columns: `idx`, `uid`, `sc`, `tags`, `title`, `content`, `created_at` (`idx` is required).
 Sort columns: `id`, `idx`, `uid`, `tags`, `content`, `created_at`, `modified_at`, `shortcut`.
+
+**Display modes (`--display` / `-d`):** Control what the Content column cell shows.
+
+| Mode | Content cell |
+|---|---|
+| `title` | Entry title; falls back to body preview when title is unset (default) |
+| `body` | Body preview, respecting `--rows` and `--truncate` (original behaviour) |
+| `full` | Full body — all lines, no truncation |
+| `both` | Bold title line followed by body preview; without a title, just the body preview |
 
 ---
 
@@ -687,7 +700,8 @@ rows = 1          # content preview lines (0 = all)
 truncate = 80     # max chars per line (0 = no truncation)
 sort_by = "idx"   # default sort column
 desc = false      # sort direction
-columns = ["idx", "sc", "tags", "content"]   # idx is required; available: idx, uid, sc, tags, content, created_at
+columns = ["idx", "sc", "tags", "content"]   # idx is required; available: idx, uid, sc, tags, title, content, created_at
+display = "title" # content column mode: title | body | full | both
 
 [db]
 path = "~/.local/share/koda/koda.db"

--- a/src/koda/cmd_helpers/interactive.py
+++ b/src/koda/cmd_helpers/interactive.py
@@ -41,6 +41,23 @@ def pick_candidates(
     )
 
 
+def _fzf_line(row: MemoRow) -> str:
+    """Build the tab-delimited fzf input line for a single memo row.
+
+    Fields: idx \\t uid \\t sc \\t tags \\t created_at \\t label \\t first_line
+    where label = title if set, else first body line, and first_line is always
+    the first body line.  Tab characters inside label/first_line are replaced
+    with a space so they don't shift the field layout.
+    """
+    first_line = (row.content or "").splitlines()[0] if row.content else ""
+    first_line = first_line.replace("\t", " ")
+    label = (row.title or first_line).replace("\t", " ")
+    return (
+        f"{row.idx}\t{row.uid}\t{row.shortcut or '-'}\t"
+        f"{row.tags or '-'}\t{row.created_at}\t{label}\t{first_line}"
+    )
+
+
 def _run_fzf(candidates: list[MemoRow], multi: bool) -> list[str]:
     """Run fzf over the candidates and return the selected entry refs (idx strings).
 
@@ -52,14 +69,7 @@ def _run_fzf(candidates: list[MemoRow], multi: bool) -> list[str]:
     if not sys.stdin.isatty():
         exit_error("`koda pick` requires an interactive TTY.")
 
-    lines: list[str] = []
-    for row in candidates:
-        first_line = (row.content or "").splitlines()[0] if row.content else ""
-        display = (
-            f"{row.idx}\t{row.uid}\t{row.shortcut or '-'}\t"
-            f"{row.tags or '-'}\t{row.created_at}\t{first_line}"
-        )
-        lines.append(display)
+    lines = [_fzf_line(row) for row in candidates]
 
     term_cols = shutil.get_terminal_size(fallback=(120, 40)).columns
     # Keep list area readable on narrower terminals by switching to bottom preview.
@@ -75,8 +85,8 @@ def _run_fzf(candidates: list[MemoRow], multi: bool) -> list[str]:
         "koda> ",
         "--preview",
         (
-            "printf 'IDX: %s\\nUID: %s\\nSC: %s\\nTags: %s\\nCreated: %s\\n\\n%s\\n' "
-            "{1} {2} {3} {4} {5} {6}"
+            "printf 'IDX: %s\\nUID: %s\\nSC: %s\\nTags: %s\\nCreated: %s\\nTitle: %s\\n\\n%s\\n' "
+            "{1} {2} {3} {4} {5} {6} {7}"
         ),
         "--preview-window",
         preview_window,

--- a/src/koda/commands/memo.py
+++ b/src/koda/commands/memo.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import typer
 from rich.table import Table
+from rich.text import Text
 
 from ..cli_utils import ExitCode, confirm, exit_error
 from ..cmd_helpers.display import print_memo as _print_memo
@@ -397,6 +398,62 @@ def _emit_list_json(
     sys.stdout.write(json.dumps([r.to_dict() for r in rows], ensure_ascii=False, indent=2) + "\n")
 
 
+_DISPLAY_MODES = ("title", "body", "full", "both")
+
+
+def _build_content_cell(
+    memo,
+    display_mode: str,
+    rows_value: int | None,
+    truncate: int,
+) -> Text | str:
+    """Build the Rich renderable for the content column based on display_mode."""
+    content_lines = (memo.content or "").splitlines()
+
+    def _preview_lines() -> list[str]:
+        if rows_value is None:
+            lines = content_lines if content_lines else [""]
+        else:
+            lines = content_lines[:rows_value] if content_lines else [""]
+            if content_lines and len(content_lines) > rows_value:
+                lines = lines + ["..."]
+        if truncate > 0:
+            ellipsis = "..."
+            if truncate <= len(ellipsis):
+                lines = [line[:truncate] for line in lines]
+            else:
+                lines = [
+                    line if len(line) <= truncate else line[: truncate - len(ellipsis)] + ellipsis
+                    for line in lines
+                ]
+        return lines
+
+    if display_mode == "body":
+        return "\n".join(_preview_lines())
+
+    if display_mode == "title":
+        if memo.title:
+            cell = Text()
+            cell.append(memo.title, style="bold")
+            return cell
+        # Fallback: body preview (same as body mode)
+        return "\n".join(_preview_lines())
+
+    if display_mode == "full":
+        return "\n".join(content_lines) if content_lines else ""
+
+    # both
+    cell = Text()
+    if memo.title:
+        cell.append(memo.title, style="bold")
+        preview = "\n".join(_preview_lines())
+        if preview:
+            cell.append("\n" + preview)
+    else:
+        cell.append("\n".join(_preview_lines()))
+    return cell
+
+
 def _list_memos_impl(
     query: str | None = None,
     tag: str | None = None,
@@ -409,6 +466,7 @@ def _list_memos_impl(
     rows: str | None = None,
     truncate: int | None = None,
     columns: list[str] | None = None,
+    display: str | None = None,
 ) -> None:
     init_db()
 
@@ -429,6 +487,8 @@ def _list_memos_impl(
         truncate = get_config().list_truncate
     elif truncate < 0:
         exit_error("--truncate must be 0 or greater.")
+    if display is None:
+        display = get_config().list_display
 
     normalized_sort = sort_by.lower()
     if normalized_sort not in VALID_SORT_COLUMNS:
@@ -481,42 +541,28 @@ def _list_memos_impl(
         label, kwargs = COLUMN_DEFS[col]
         table.add_column(label, **kwargs)
 
-    row_values: dict = {}
     for memo in memos:
-        content_lines = (memo.content or "").splitlines()
-        if rows_value is None:
-            preview_lines = content_lines if content_lines else [""]
-        else:
-            preview_lines = content_lines[:rows_value] if content_lines else [""]
-            if content_lines and len(content_lines) > rows_value:
-                preview_lines = preview_lines + ["..."]
-
-        if truncate > 0:
-            ellipsis = "..."
-            if truncate <= len(ellipsis):
-                preview_lines = [line[:truncate] for line in preview_lines]
-            else:
-                preview_lines = [
-                    line if len(line) <= truncate else line[: truncate - len(ellipsis)] + ellipsis
-                    for line in preview_lines
-                ]
-
-        preview = "\n".join(preview_lines)
+        content_cell = _build_content_cell(memo, display, rows_value, truncate)
         row_values = {
             "idx": str(memo.idx),
             "uid": memo.uid or "",
             "sc": memo.shortcut or "",
             "tags": memo.tags or "",
-            "content": preview,
+            "title": memo.title or "",
+            "content": content_cell,
             "created_at": memo.created_at,
         }
         table.add_row(*[row_values[col] for col in columns])
     console.print(table)
-    rows_text = "0" if rows_value is None else str(rows_value)
-    truncate_text = "off" if truncate == 0 else str(truncate)
+    if display == "full":
+        rows_text = "all"
+        truncate_text = "off"
+    else:
+        rows_text = "0" if rows_value is None else str(rows_value)
+        truncate_text = "off" if truncate == 0 else str(truncate)
     console.print(
         f"[dim]Total: {total_count} | Pages: {total_pages} | Max IDX: {max_idx} | "
-        f"Rows: {rows_text} | Truncate: {truncate_text}[/dim]"
+        f"Rows: {rows_text} | Truncate: {truncate_text} | Display: {display}[/dim]"
     )
     if total_pages > 1 and page < total_pages:
         console.print(f"[dim]Page {page}/{total_pages} — next: koda l -p {page + 1}[/dim]")
@@ -579,6 +625,12 @@ def list_memos(
             f"Available: {', '.join(VALID_LIST_COLUMNS)}. [config: list.columns]"
         ),
     ),
+    display: str | None = typer.Option(
+        None,
+        "--display",
+        "-d",
+        help=("Content column display mode: title, body, full, or both. [config: list.display]"),
+    ),
     json_output: bool = typer.Option(
         False, "--json", help="Output all matching entries as a JSON array (ignores paging)."
     ),
@@ -597,6 +649,11 @@ def list_memos(
     if columns is not None:
         parsed_columns = [c.strip() for c in columns.split(",") if c.strip()]
         _validate_list_columns(parsed_columns, "--columns")
+    parsed_display: str | None = None
+    if display is not None:
+        parsed_display = display.strip().lower()
+        if parsed_display not in _DISPLAY_MODES:
+            exit_error(f"Invalid --display {display!r}. Use one of: title, body, full, both.")
     _list_memos_impl(
         query,
         tag,
@@ -609,6 +666,7 @@ def list_memos(
         rows,
         truncate,
         parsed_columns,
+        parsed_display,
     )
 
 

--- a/src/koda/config.py
+++ b/src/koda/config.py
@@ -33,7 +33,7 @@ CONFIG_PATH = Path(os.getenv("KODA_CONFIG_PATH", DEFAULT_CONFIG_PATH))
 # VALID_SORT_COLUMNS is owned by db.py (it lists the DB columns that may appear
 # in an ORDER BY); re-exported here so config validators and callers that import
 # from koda.config keep working without reaching into the db layer.
-VALID_LIST_COLUMNS = ["idx", "uid", "sc", "tags", "content", "created_at"]
+VALID_LIST_COLUMNS = ["idx", "uid", "sc", "tags", "title", "content", "created_at"]
 REQUIRED_LIST_COLUMNS = {"idx"}
 
 COLUMN_DEFS: dict = {
@@ -41,6 +41,7 @@ COLUMN_DEFS: dict = {
     "uid": ("UID", {"width": 16, "style": "dim"}),
     "sc": ("SC", {"width": 10, "style": "bold green"}),
     "tags": ("Tags", {"style": "magenta", "width": 15}),
+    "title": ("Title", {"style": "bold", "ratio": 1}),
     "content": ("Content", {"ratio": 1}),
     "created_at": ("Created At", {"width": 19}),
 }
@@ -62,7 +63,8 @@ EXAMPLE_TEMPLATE = (
     "# rows = 1         # 0 = all lines\n"
     "# truncate = 80    # 0 = no truncation\n"
     '# sort_by = "idx"\n'
-    "# desc = false\n\n"
+    "# desc = false\n"
+    '# display = "title"   # title | body | full | both\n\n'
     "# [db]\n"
     f'# path = "{DEFAULT_DB_PATH}"\n'
     '# backend = "local"   # "local" or "turso"\n\n'
@@ -198,6 +200,7 @@ class Config:
     list_sort_by: str = "idx"
     list_desc: bool = False
     list_columns: list[str] = field(default_factory=lambda: ["idx", "sc", "tags", "content"])
+    list_display: str = "title"
     db_path: str = str(DEFAULT_DB_PATH)
     db_backend: str = "local"
     turso_url: str = ""
@@ -249,6 +252,11 @@ _FIELD_SPECS: dict[str, FieldSpec] = {
             and REQUIRED_LIST_COLUMNS.issubset(v)
         ),
         f'must include "idx"; available: {", ".join(VALID_LIST_COLUMNS)}',
+    ),
+    "list.display": FieldSpec(
+        str,
+        lambda v: v in ("title", "body", "full", "both"),
+        "must be one of: title, body, full, both",
     ),
     "db.path": FieldSpec(
         str,

--- a/tests/test_display_modes.py
+++ b/tests/test_display_modes.py
@@ -1,0 +1,320 @@
+"""Tests for list display modes (--display/-d) and list.display config (#142)."""
+
+import pytest
+import typer
+
+import koda.runtime as runtime
+from koda.cmd_helpers.interactive import _fzf_line
+from koda.commands import memo
+from koda.config import ALL_KEYS, ConfigManager, ValidationError
+from koda.models import MemoRow
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def wired_db(db, monkeypatch):
+    """Point the lazy DB cache at a fresh temp database."""
+    monkeypatch.setattr(runtime, "_db", db)
+    return db
+
+
+def _seed(db, content="body text", title=None, shortcut=None, idx=0):
+    db.add_memo(
+        f"uid{idx:04d}",
+        idx,
+        shortcut,
+        content,
+        "",
+        "2026-01-01 00:00:00",
+        "2026-01-01 00:00:00",
+        title=title,
+    )
+    return db.get_memo_by_idx(idx)
+
+
+# ── display mode: body ────────────────────────────────────────────────────────
+
+
+def test_body_mode_shows_preview(wired_db, capsys):
+    _seed(wired_db, content="line one\nline two", title="My Title")
+    memo._list_memos_impl(display="body")
+    out = capsys.readouterr().out
+    assert "line one" in out
+
+
+def test_body_mode_respects_rows(wired_db, capsys):
+    _seed(wired_db, content="line one\nline two\nline three", title="My Title")
+    memo._list_memos_impl(display="body", rows="1")
+    out = capsys.readouterr().out
+    # Should show first line and ellipsis, not second line
+    assert "line one" in out
+    assert "line three" not in out
+
+
+def test_body_mode_footer_shows_display(wired_db, capsys):
+    _seed(wired_db, content="hello")
+    memo._list_memos_impl(display="body")
+    out = capsys.readouterr().out
+    assert "Display: body" in out
+
+
+# ── display mode: title ───────────────────────────────────────────────────────
+
+
+def test_title_mode_shows_title_when_set(wired_db, capsys):
+    _seed(wired_db, content="actual body", title="Deploy prod")
+    memo._list_memos_impl(display="title")
+    out = capsys.readouterr().out
+    assert "Deploy prod" in out
+
+
+def test_title_mode_falls_back_to_body_when_unset(wired_db, capsys):
+    _seed(wired_db, content="body preview text", title=None)
+    memo._list_memos_impl(display="title")
+    out = capsys.readouterr().out
+    assert "body preview text" in out
+
+
+def test_title_mode_footer_shows_display(wired_db, capsys):
+    _seed(wired_db, content="hello")
+    memo._list_memos_impl(display="title")
+    out = capsys.readouterr().out
+    assert "Display: title" in out
+
+
+# ── display mode: full ────────────────────────────────────────────────────────
+
+
+def test_full_mode_shows_all_lines(wired_db, capsys):
+    _seed(wired_db, content="line one\nline two\nline three", title=None)
+    # Even with rows=1 and truncate=10, full mode should show all lines
+    memo._list_memos_impl(display="full", rows="1", truncate=10)
+    out = capsys.readouterr().out
+    assert "line one" in out
+    assert "line two" in out
+    assert "line three" in out
+
+
+def test_full_mode_footer_shows_rows_all_truncate_off(wired_db, capsys):
+    _seed(wired_db, content="hello")
+    memo._list_memos_impl(display="full")
+    out = capsys.readouterr().out
+    assert "Rows: all" in out
+    assert "Truncate: off" in out
+    assert "Display: full" in out
+
+
+# ── display mode: both ────────────────────────────────────────────────────────
+
+
+def test_both_mode_shows_title_and_body(wired_db, capsys):
+    _seed(wired_db, content="body line", title="My Title")
+    memo._list_memos_impl(display="both")
+    out = capsys.readouterr().out
+    assert "My Title" in out
+    assert "body line" in out
+
+
+def test_both_mode_without_title_shows_body_preview(wired_db, capsys):
+    _seed(wired_db, content="just body", title=None)
+    memo._list_memos_impl(display="both")
+    out = capsys.readouterr().out
+    assert "just body" in out
+
+
+def test_both_mode_footer_shows_display(wired_db, capsys):
+    _seed(wired_db, content="hello")
+    memo._list_memos_impl(display="both")
+    out = capsys.readouterr().out
+    assert "Display: both" in out
+
+
+# ── default display mode from config ─────────────────────────────────────────
+
+
+def test_default_display_is_title_from_config(wired_db, monkeypatch, capsys):
+    """Default config list_display="title" should apply when --display not passed."""
+    # Default Config().list_display is "title", no need to override
+    _seed(wired_db, content="body text", title="Config Title")
+    memo._list_memos_impl()  # no display= argument
+    out = capsys.readouterr().out
+    assert "Display: title" in out
+    assert "Config Title" in out
+
+
+def test_cli_flag_overrides_config_default(wired_db, monkeypatch, capsys):
+    """Passing --display body should override the config default of title."""
+    _seed(wired_db, content="body only", title="Some Title")
+    # Explicitly call with body mode — title should not appear as Display marker
+    memo._list_memos_impl(display="body")
+    out = capsys.readouterr().out
+    assert "Display: body" in out
+
+
+def test_invalid_display_flag_exits(wired_db, capsys):
+    """Passing an invalid --display value should call exit_error."""
+    with pytest.raises(typer.Exit):
+        memo.list_memos(
+            ref=None,
+            query=None,
+            tag=None,
+            exclude_tag=None,
+            shortcuts_only=False,
+            per_page=None,
+            page=1,
+            sort_by=None,
+            desc=None,
+            rows=None,
+            truncate=None,
+            columns=None,
+            display="nonsense",
+            json_output=False,
+        )
+    assert "Invalid --display" in capsys.readouterr().err
+
+
+def test_invalid_display_case_insensitive_accepted(wired_db, capsys):
+    """Mixed-case display mode should be normalised and accepted."""
+    _seed(wired_db, content="hello")
+    memo.list_memos(
+        ref=None,
+        query=None,
+        tag=None,
+        exclude_tag=None,
+        shortcuts_only=False,
+        per_page=None,
+        page=1,
+        sort_by=None,
+        desc=None,
+        rows=None,
+        truncate=None,
+        columns=None,
+        display="BODY",
+        json_output=False,
+    )
+    out = capsys.readouterr().out
+    assert "Display: body" in out
+
+
+# ── config: list.display in ALL_KEYS / validate / coerce ─────────────────────
+
+
+def test_list_display_in_all_keys():
+    assert "list.display" in ALL_KEYS
+
+
+def test_list_display_valid_values():
+    for mode in ("title", "body", "full", "both"):
+        assert ConfigManager.validate("list.display", mode) == mode
+
+
+def test_list_display_invalid_value():
+    with pytest.raises(ValidationError):
+        ConfigManager.validate("list.display", "fancy")
+
+
+def test_list_display_coerce():
+    assert ConfigManager.coerce("list.display", "full") == "full"
+
+
+def test_list_display_default_is_title():
+    from koda.config import Config
+
+    assert Config().list_display == "title"
+
+
+def test_list_display_in_example_template():
+    from koda.config import EXAMPLE_TEMPLATE
+
+    assert "display" in EXAMPLE_TEMPLATE
+    assert "title" in EXAMPLE_TEMPLATE
+
+
+# ── --columns: title column ───────────────────────────────────────────────────
+
+
+def test_title_in_valid_list_columns():
+    from koda.config import VALID_LIST_COLUMNS
+
+    assert "title" in VALID_LIST_COLUMNS
+
+
+def test_columns_with_title_renders(wired_db, capsys):
+    _seed(wired_db, content="body text", title="Col Title")
+    # Use display="body" so the content column shows the body,
+    # while the separate title column shows the title.
+    memo._list_memos_impl(columns=["idx", "title", "content"], display="body")
+    out = capsys.readouterr().out
+    assert "Col Title" in out
+    assert "body text" in out
+
+
+def test_list_columns_config_accepts_title():
+    assert ConfigManager.validate("list.columns", ["idx", "title"]) == ["idx", "title"]
+
+
+# ── _fzf_line helper ─────────────────────────────────────────────────────────
+
+
+def _make_row(idx=0, content="", title=None, shortcut=None, tags=""):
+    return MemoRow(
+        id=1,
+        uid=f"uid{idx:04d}",
+        idx=idx,
+        shortcut=shortcut,
+        content=content,
+        tags=tags,
+        created_at="2026-01-01 00:00:00",
+        modified_at="2026-01-01 00:00:00",
+        source="local",
+        title=title,
+    )
+
+
+def test_fzf_line_titled_entry_uses_title_as_label():
+    row = _make_row(content="first body line", title="My Label")
+    line = _fzf_line(row)
+    fields = line.split("\t")
+    # field 6 (index 5) is label
+    assert fields[5] == "My Label"
+    # field 7 (index 6) is first body line
+    assert fields[6] == "first body line"
+
+
+def test_fzf_line_untitled_entry_uses_first_line_as_label():
+    row = _make_row(content="first body line\nsecond line", title=None)
+    line = _fzf_line(row)
+    fields = line.split("\t")
+    assert fields[5] == "first body line"
+    assert fields[6] == "first body line"
+
+
+def test_fzf_line_tab_in_content_sanitized():
+    row = _make_row(content="col1\tcol2", title=None)
+    line = _fzf_line(row)
+    fields = line.split("\t")
+    # first_line and label should have tab replaced by space
+    assert fields[5] == "col1 col2"
+    assert fields[6] == "col1 col2"
+
+
+def test_fzf_line_tab_in_title_sanitized():
+    row = _make_row(content="body", title="title\twith tab")
+    line = _fzf_line(row)
+    fields = line.split("\t")
+    assert fields[5] == "title with tab"
+
+
+def test_fzf_line_field_count():
+    row = _make_row(content="body", title="t")
+    line = _fzf_line(row)
+    assert len(line.split("\t")) == 7
+
+
+def test_fzf_line_empty_content_no_title():
+    row = _make_row(content="", title=None)
+    line = _fzf_line(row)
+    fields = line.split("\t")
+    assert fields[5] == ""
+    assert fields[6] == ""

--- a/tests/test_title_cli.py
+++ b/tests/test_title_cli.py
@@ -254,8 +254,9 @@ def test_list_with_query_shows_title_hit(wired_db, monkeypatch, capsys):
     _seed_two(wired_db)
     memo._list_memos_impl(query="Deploy")
     out = capsys.readouterr().out
-    # The body "unrelated body" should appear in the listed row.
-    assert "unrelated body" in out
+    # In title display mode (default), the content cell shows the title "Deploy prod"
+    # for the matched entry (uid0001 has title="Deploy prod", body="unrelated body").
+    assert "Deploy prod" in out
 
 
 def test_remove_batch_query_matches_title(wired_db, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

- Adds `--display`/`-d` option to `koda list` (case-insensitive: `title | body | full | both`), defaulting to new config key `list.display` (built-in default: `"title"`).
- **Mode semantics** for the Content column cell:
  - `body` — current preview behaviour (rows/truncate), byte-for-byte unchanged
  - `title` — shows the entry title; falls back to body preview when unset, so existing untitled DBs render identically
  - `full` — entire body, ignoring rows/truncate; footer shows `Rows: all | Truncate: off`
  - `both` — bold title line + body preview; without a title, just the body preview
- Cells built with `rich.text.Text` (no user data interpolated into markup strings).
- Footer gains `Display: <mode>` suffix.
- **Config**: `Config.list_display = "title"`, `_FIELD_SPECS["list.display"]` with validator, `EXAMPLE_TEMPLATE` comment; surfaced automatically via `ALL_KEYS`.
- **`--columns`**: `"title"` added to `VALID_LIST_COLUMNS` and `COLUMN_DEFS` (style bold, ratio 1); `row_values["title"] = memo.title or ""`.
- **pick** (`cmd_helpers/interactive.py`): line construction factored into `_fzf_line(row)` helper; fields become `idx\tuid\tsc\ttags\tcreated_at\tlabel\tfirst_line` where `label = title or first body line`; tabs in label/first_line sanitized; preview gains a `Title:` row (field 6) with body first line from field 7.
- **README**: documents `--display/-d`, all four modes, and `list.display` config.
- 30 new tests in `tests/test_display_modes.py`; one test in `test_title_cli.py` updated to reflect the new title-mode default.

## Test plan

- [x] All 361 tests pass: `uv run pytest` (72% coverage, above 60% threshold)
- [x] `uv run ruff format src tests` — no changes
- [x] `uv run ruff check src tests` — no errors
- [x] Each display mode rendering verified (body/title/full/both)
- [x] Title fallback for untitled entries
- [x] `full` mode ignores rows/truncate, footer shows `Rows: all | Truncate: off`
- [x] `both` mode shows title line + preview; without title, just body preview
- [x] Config default applies; CLI flag overrides config; invalid flag and invalid config value produce expected errors
- [x] `--columns idx,title,content` renders correctly
- [x] `list.columns` config accepts `"title"`
- [x] `_fzf_line`: titled entry uses title as label; untitled uses first line; embedded tabs sanitized; 7 fields
- [x] With no titles in DB and default config, `koda list` output unchanged except footer `Display: title` suffix

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)