### PR TITLE
feat(exec): run reference-list (group) entries sequentially

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,30 @@ printf 'greet() {\n  echo "hi $1"\n}\ngreet "$1"\n' | koda a -s greet
 koda x greet -V world   # → hi world
 ```
 
-> **Security**: only store trusted commands. `exec` runs the body through the configured shell (`sh` by default).
+**Group entries — a playlist of other entries:**
+
+If a body is a list of `@<ref>` references (one per line, every line starting with `@`), `koda x` treats it as a **group**: it expands the references and runs each child sequentially, like a lightweight task runner. The `@<ref>` is an index or shortcut.
+
+```bash
+koda a "docker compose down" -s dcd
+koda a "docker compose up -d" -s dcu
+koda a "docker compose logs -f" -s dcl
+
+koda a -s restart        # opens $EDITOR; paste:
+#   @dcd
+#   @dcup        # comments and blank lines are ignored
+#   @dcl -f
+koda x restart           # runs dcd, then dcup, then `dcl -f`, in order
+```
+
+- **Per-line args.** Text after a ref on a line is passed to that child, with the same rules as call-time args: it fills `$1`/`"$@"` if the child body references them, otherwise it's appended (`@dcl -f` → `docker compose logs -f`).
+- **Nesting.** A child that is itself a group expands recursively. Cycles (`@a` → `@b` → `@a`) are detected and rejected, and nesting is capped at 10 levels deep.
+- **Parameterize with `-V`.** `-V` substitutes into the group body *before* it's parsed, so `@${SVC}` resolves to a different child per call (`koda x grp -V SVC=web`). Trailing args directly after a group ref are not supported in v1 — use `-V`.
+- **Fail fast.** The whole plan is resolved before anything runs, so an unknown ref aborts with nothing executed. The first child to exit non-zero stops the group, and `koda x` exits with that child's code. Progress lines (`→ [3] dcl (2/5)`) go to stderr, keeping stdout clean for the children's own output.
+- **Remote confirmation.** If the group itself or any expanded child is `source=remote`, `koda x` prompts once before running the whole group (listing the remote entries); `-f` skips it and `exec.confirm_remote=false` disables it, same as a single entry.
+- **Preview with `-n`.** `koda x <group> -n` prints one resolved command per child, in execution order, without running anything.
+
+> **Security**: only store trusted commands. `exec` runs the body through the configured shell (`sh` by default). A group runs each referenced entry, so the same caution applies to every child it pulls in.
 
 ---
 
@@ -837,7 +860,7 @@ koda pull   # git pull the clone, merge koda-sync.jsonl into local DB
 
 The sync remote is **outside your trust boundary**. Anyone who can write to it (a compromised account, a shared repo, a malicious collaborator) can change the body of any synced entry — including one bound to a shortcut you `exec`. To contain this:
 
-- **Entries arriving via `pull` are marked `source=remote`.** `koda exec`/`koda x` **prompts for confirmation before running a `source=remote` entry**, so a silently rewritten `deploy` snippet cannot execute unattended. The recommended way to trust an entry is to **review it with `koda edit <ref>`**, which clears the flag back to `local` permanently. `koda x -f/--force` runs it once without prompting — prefer `edit` over habitually reaching for `-f`, since an `-f` baked into an alias or script silently disables the check.
+- **Entries arriving via `pull` are marked `source=remote`.** `koda exec`/`koda x` **prompts for confirmation before running a `source=remote` entry**, so a silently rewritten `deploy` snippet cannot execute unattended. The recommended way to trust an entry is to **review it with `koda edit <ref>`**, which clears the flag back to `local` permanently. `koda x -f/--force` runs it once without prompting — prefer `edit` over habitually reaching for `-f`, since an `-f` baked into an alias or script silently disables the check. A [group entry](#execute-exec--run-a-saved-command) gates the same way: if the group or any expanded child is `source=remote`, `koda x` prompts once before running the whole group.
 - **Preview before you merge.** `koda pull --dry-run` shows the exact insert/update diff *without* touching the local database, so you can inspect incoming changes first.
 - **The `source` flag never crosses the wire.** It is local-only state and is not written to (or read from) `koda-sync.jsonl`, so a remote cannot label its own entries `local` to dodge the prompt.
 

--- a/src/koda/commands/exec.py
+++ b/src/koda/commands/exec.py
@@ -3,9 +3,12 @@
 import os
 import re
 import shlex
+import subprocess
 import sys
+from dataclasses import dataclass
 
 import typer
+from rich.console import Console
 
 from ..cli_utils import ExitCode, confirm, exit_error
 from ..cmd_helpers.display import print_memo as _print_memo
@@ -17,9 +20,11 @@ from ..cmd_helpers.interactive import (
 )
 from ..config import ConfigManager, ValidationError
 from ..main import app
+from ..models import MemoRow
 from ..runtime import (
     _apply_vars,
     _read_stdin_refs,
+    _strip_inline_comment,
     emit_raw,
     get_config,
     get_db,
@@ -27,6 +32,13 @@ from ..runtime import (
     resolve_ref,
 )
 from . import memo  # bound as a module to avoid a circular import at load time
+
+# A reference line in a group body: `@<ref> [args...]`. <ref> is an idx (digits)
+# or shortcut resolved via resolve_ref; the rest is shlex.split into per-child args.
+_GROUP_REF_RE = re.compile(r"^@\S+")
+# Guard against pathologically/maliciously deep nesting and indirect cycles even
+# before the uid stack catches a true loop.
+_MAX_GROUP_DEPTH = 10
 
 # Matches a shell positional-parameter reference: $1..$9, $0, $@, $*, $#, and the
 # braced forms ${1...}, ${@}, ${*}, ${#}. Deliberately does NOT match koda's own
@@ -42,6 +54,147 @@ def _references_positionals(body: str) -> bool:
     or left for the body to pick up itself (body uses $1/$@/${1:-default}/...).
     """
     return bool(_POSITIONAL_REF_RE.search(body))
+
+
+def _build_argv(shell: str, content: str, args: list[str]) -> list[str]:
+    """Build the `[shell, -c, content, shell, *args]` argv for one body.
+
+    Mirrors the single-entry construction: trailing args become the shell's real
+    positional params; if the body doesn't reference them, `"$@"` is appended so
+    they land at the end like extra words after an alias. With no args the tail is
+    omitted, keeping the invocation byte-for-byte identical to the no-args case.
+    """
+    if args and not _references_positionals(content):
+        content = f'{content} "$@"'
+    return [shell, "-c", content, shell, *args] if args else [shell, "-c", content]
+
+
+@dataclass(frozen=True)
+class _GroupChild:
+    """One resolved reference line in an expanded group plan."""
+
+    row: MemoRow
+    args: list[str]
+    argv: list[str]
+
+
+def _group_ref_lines(content: str) -> list[str] | None:
+    """Classify a body after _apply_vars: list of `@`-reference lines or None.
+
+    Strips inline comments and drops blank lines first. Returns the surviving
+    reference lines if EVERY remaining line is a `@<ref>` line (a group); None if
+    none are (a normal single-entry body). A mixed body (some but not all `@`
+    lines) is an error.
+    """
+    lines = []
+    for raw in content.splitlines():
+        line = _strip_inline_comment(raw).strip()
+        if line:
+            lines.append(line)
+    if not lines:
+        return None
+    ref_lines = [line for line in lines if _GROUP_REF_RE.match(line)]
+    if not ref_lines:
+        return None
+    if len(ref_lines) != len(lines):
+        exit_error("Mixed body: '@' reference lines cannot be combined with plain script lines.")
+    return ref_lines
+
+
+def _expand_group(
+    ref_lines: list[str], shell: str, uid_stack: list[str], depth: int
+) -> list[_GroupChild]:
+    """Resolve a group's reference lines into a flat, ordered child plan.
+
+    Resolves the FULL plan upfront so an unknown ref aborts before anything runs
+    (fail fast). Nested groups expand recursively; the uid_stack detects cycles
+    and _MAX_GROUP_DEPTH bounds runaway nesting.
+    """
+    if depth > _MAX_GROUP_DEPTH:
+        exit_error(f"Group nesting too deep (max {_MAX_GROUP_DEPTH}).")
+    plan: list[_GroupChild] = []
+    for line in ref_lines:
+        ref = line[1:]  # drop the leading '@'
+        try:
+            parts = shlex.split(ref)
+        except ValueError:
+            exit_error(f"Malformed reference line: {line!r}.")
+        # shlex.split never yields an empty list here: _GROUP_REF_RE guaranteed
+        # at least one non-space char after '@'.
+        child_ref, child_args = parts[0], parts[1:]
+        row = resolve_ref(child_ref)
+        child_content = row.content.strip() if row.content else ""
+        nested = _group_ref_lines(child_content)
+        if nested is not None:
+            if row.uid in uid_stack:
+                cycle = " -> ".join([*uid_stack, row.uid])
+                exit_error(f"Group cycle detected: {cycle}.")
+            plan.extend(_expand_group(nested, shell, [*uid_stack, row.uid], depth + 1))
+        else:
+            argv = _build_argv(shell, child_content, child_args)
+            plan.append(_GroupChild(row=row, args=child_args, argv=argv))
+    return plan
+
+
+def _first_line(content: str | None, limit: int = 60) -> str:
+    """First body line, truncated for confirmation/progress display."""
+    first = (content or "").strip().splitlines()
+    text = first[0] if first else ""
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _confirm_remote_children(involved: list[MemoRow], force: bool) -> None:
+    """Prompt once for the source=remote entries in a group plan, or refuse.
+
+    `involved` is the deduped group+children set. Mirrors the single-entry remote
+    gate: non-TTY refuses with the `koda edit` review hint; a TTY prompts once
+    listing each remote entry (children never re-prompt individually).
+    """
+    if not get_config().exec_confirm_remote or force:
+        return
+    remotes = [row for row in involved if row.source == "remote"]
+    if not remotes:
+        return
+    listing = []
+    for row in remotes[:10]:
+        listing.append(f"[{row.idx}] {_first_line(row.content)}")
+    if len(remotes) > 10:
+        listing.append(f"... and {len(remotes) - 10} more")
+    bullet = "\n".join(f"  {item}" for item in listing)
+    if not sys.stdin.isatty():
+        exit_error(
+            "Refusing to exec group: it involves entries synced from a remote "
+            "(source=remote) and not reviewed locally:\n"
+            f"{bullet}\n"
+            "Review them with `koda edit <ref>` to trust them (clears the flag), "
+            "or re-run with -f to execute now.",
+            style="yellow",
+        )
+    if not confirm(
+        "This group involves entries synced from a remote and not reviewed locally:\n"
+        f"{bullet}\n"
+        "Review with `koda edit <ref>` to trust them. Execute the group now anyway?"
+    ):
+        exit_error("Aborted.", code=ExitCode.CANCELLED, style="yellow")
+
+
+def _run_group(plan: list[_GroupChild], shell: str) -> None:
+    """Run each child sequentially; stop and exit on the first non-zero code.
+
+    Progress goes to STDERR so stdout stays clean for the children's own output.
+    """
+    err = Console(stderr=True)
+    total = len(plan)
+    for i, child in enumerate(plan, start=1):
+        label = child.row.shortcut or str(child.row.idx)
+        err.print(f"→ [{child.row.idx}] {label} ({i}/{total})", style="dim")
+        result = subprocess.run(child.argv)
+        if result.returncode != 0:
+            err.print(
+                f"Group stopped: [{child.row.idx}] {label} exited {result.returncode}.",
+                style="red",
+            )
+            raise typer.Exit(code=result.returncode)
 
 
 def _run_pick_action(action: str, ref: str) -> None:
@@ -145,6 +298,36 @@ def exec_memo(
     row = resolve_ref(ref)
     content = _apply_vars(row.content.strip() if row.content else "", vars)
     shell = get_config().exec_shell
+
+    # Group entry: a body whose lines are all `@<ref>` references. Detected after
+    # _apply_vars so `-V` can parameterize the group body (e.g. `@${SVC}`). Only
+    # the GROUP body goes through _apply_vars; children execute verbatim, so the
+    # backslash-escaped `\$(...)` storage contract is preserved (no second pass).
+    ref_lines = _group_ref_lines(content)
+    if ref_lines is not None:
+        if extra:
+            exit_error("Group entries do not take trailing args; parameterize with -V instead.")
+        plan = _expand_group(ref_lines, shell, [row.uid], depth=1)
+        if dry_run:
+            # Preview only: one shlex-quoted argv line per child, in execution
+            # order. No progress lines, confirmation, or shell validation — keep
+            # it pipeable, matching the single-entry preview rendering.
+            for child in plan:
+                sys.stdout.write(" ".join(shlex.quote(part) for part in child.argv) + "\n")
+            return
+        # Dedup the group + children by id so an entry referenced twice prompts
+        # once. The group entry itself can be source=remote and must also gate.
+        involved = list({r.id: r for r in [row, *(c.row for c in plan)]}.values())
+        _confirm_remote_children(involved, force)
+        try:
+            ConfigManager.validate("exec.shell", shell)
+        except ValidationError:
+            exit_error(
+                f"Refusing to exec: exec.shell {shell!r} is not allowed "
+                f"({ConfigManager.error_message('exec.shell')})."
+            )
+        _run_group(plan, shell)
+        return
 
     # Trailing CLI args become the shell's real positional parameters ($1, $@,
     # ...), so bodies can use `$1`, `"$@"`, and `${1:-default}` natively. If the

--- a/tests/test_exec_group.py
+++ b/tests/test_exec_group.py
@@ -1,0 +1,388 @@
+"""Group (reference-list) exec entries: `koda x <group>` expands `@ref` lines
+and runs each child sequentially (issue #143).
+
+Like ``test_exec.py`` these run the CLI as a real subprocess, since exec ends in
+``os.execvp`` / ``subprocess.run`` and replaces or spawns processes. Children
+write to files under tmp so order and execution are observable.
+"""
+
+import subprocess
+import sys
+
+from koda.db import MemoDatabase
+
+ENV_KEYS = ("PATH", "HOME")
+
+
+def _base_env(tmp_path, db_path):
+    import os
+
+    env = {k: os.environ[k] for k in ENV_KEYS if k in os.environ}
+    env["KODA_DB_PATH"] = str(db_path)
+    env["KODA_DB_PATH_OVERRIDE"] = "1"
+    env["KODA_CONFIG_PATH"] = str(tmp_path / "nonexistent.toml")
+    return env
+
+
+def _seed(db_path, entries):
+    """entries: list of (idx, shortcut, content). uid is derived from idx."""
+    seed = MemoDatabase(backend="local", path=db_path)
+    seed.init_db()
+    for idx, shortcut, content in entries:
+        seed.add_memo(
+            uid=f"uid{idx:05d}",
+            idx=idx,
+            shortcut=shortcut,
+            content=content,
+            tags="",
+            created_at="2026-01-01 00:00:00",
+            modified_at="2026-01-01 00:00:00",
+        )
+    return seed
+
+
+def _mark_remote(db_path, *uids):
+    seed = MemoDatabase(backend="local", path=db_path)
+    with seed.connection() as conn:
+        for uid in uids:
+            conn.execute("UPDATE memos SET source = 'remote' WHERE uid = ?", (uid,))
+
+
+def _run(tmp_path, db_path, *args, input=None):
+    return subprocess.run(
+        [sys.executable, "-c", "from koda.main import app; app()", "x", *args],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL if input is None else None,
+        input=input,
+        env=_base_env(tmp_path, db_path),
+    )
+
+
+# --- Detection ---
+
+
+def test_all_ref_lines_is_a_group(tmp_path):
+    """Every line starting with @ → group; children run in order."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(
+        db_path,
+        [
+            (1, "a", f"echo A >> {out}"),
+            (2, "b", f"echo B >> {out}"),
+            (10, "grp", "@1\n@2"),
+        ],
+    )
+    result = _run(tmp_path, db_path, "grp")
+    assert result.returncode == 0, result.stderr
+    assert out.read_text().split() == ["A", "B"]
+
+
+def test_plain_body_is_unchanged(tmp_path):
+    """A body with no @ lines runs as a normal single entry (execvp path)."""
+    db_path = tmp_path / "g.db"
+    _seed(db_path, [(1, "p", "echo PLAIN_OK")])
+    result = _run(tmp_path, db_path, "1")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "PLAIN_OK"
+
+
+def test_mixed_body_errors(tmp_path):
+    """Some-but-not-all @ lines is an error; nothing runs."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(db_path, [(1, "a", f"echo A >> {out}"), (10, "grp", "@1\necho plain")])
+    result = _run(tmp_path, db_path, "grp")
+    assert result.returncode != 0
+    assert "Mixed body" in result.stderr
+    assert not out.exists()
+
+
+def test_comment_and_blank_lines_ignored(tmp_path):
+    """Inline comments and blank lines don't break group detection."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(
+        db_path,
+        [
+            (1, "a", f"echo A >> {out}"),
+            (2, "b", f"echo B >> {out}"),
+            (10, "grp", "# header\n@1\n\n@2  # run b\n"),
+        ],
+    )
+    result = _run(tmp_path, db_path, "grp")
+    assert result.returncode == 0, result.stderr
+    assert out.read_text().split() == ["A", "B"]
+
+
+# --- Fail fast ---
+
+
+def test_unknown_ref_aborts_before_running_anything(tmp_path):
+    """An unknown ref on line 3 aborts expansion; no child runs (fail fast)."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(
+        db_path,
+        [
+            (1, "a", f"echo A >> {out}"),
+            (2, "b", f"echo B >> {out}"),
+            (10, "grp", "@1\n@2\n@nope"),
+        ],
+    )
+    result = _run(tmp_path, db_path, "grp")
+    assert result.returncode != 0
+    assert "nope" in result.stderr
+    assert not out.exists()
+
+
+# --- Order + stop on failure ---
+
+
+def test_stop_on_first_failure_with_exit_code(tmp_path):
+    """First non-zero exit stops the run and propagates that code; later
+    children do not run."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(
+        db_path,
+        [
+            (1, "a", f"echo A >> {out}"),
+            (2, "b", f"echo B >> {out}; exit 7"),
+            (3, "c", f"echo C >> {out}"),
+            (10, "grp", "@1\n@2\n@3"),
+        ],
+    )
+    result = _run(tmp_path, db_path, "grp")
+    assert result.returncode == 7
+    assert out.read_text().split() == ["A", "B"]  # C never ran
+
+
+# --- Per-line args (both branches of #138 semantics) ---
+
+
+def test_per_line_args_append_when_no_positional(tmp_path):
+    """A child body with no positional ref gets the line's args appended."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(
+        db_path,
+        [
+            (1, "a", f"echo >> {out}"),
+            (10, "grp", "@1 hello world"),
+        ],
+    )
+    result = _run(tmp_path, db_path, "grp")
+    assert result.returncode == 0, result.stderr
+    assert out.read_text().strip() == "hello world"
+
+
+def test_per_line_args_fill_positionals(tmp_path):
+    """A child body using $1 has the line's args fill it (no append)."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(
+        db_path,
+        [
+            (1, "a", f"echo logs-$1 >> {out}"),
+            (10, "grp", "@1 mypod"),
+        ],
+    )
+    result = _run(tmp_path, db_path, "grp")
+    assert result.returncode == 0, result.stderr
+    assert out.read_text().strip() == "logs-mypod"
+
+
+# --- Nesting + cycles + depth ---
+
+
+def test_nested_group_runs(tmp_path):
+    """A child that is itself a group expands recursively, in order."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(
+        db_path,
+        [
+            (1, "a", f"echo A >> {out}"),
+            (2, "b", f"echo B >> {out}"),
+            (3, "c", f"echo C >> {out}"),
+            (20, "inner", "@2\n@3"),
+            (10, "outer", "@1\n@inner"),
+        ],
+    )
+    result = _run(tmp_path, db_path, "outer")
+    assert result.returncode == 0, result.stderr
+    assert out.read_text().split() == ["A", "B", "C"]
+
+
+def test_direct_cycle_errors(tmp_path):
+    """A group that references itself errors with a cycle message."""
+    db_path = tmp_path / "g.db"
+    _seed(db_path, [(10, "grp", "@grp")])
+    result = _run(tmp_path, db_path, "grp")
+    assert result.returncode != 0
+    assert "cycle" in result.stderr.lower()
+
+
+def test_indirect_cycle_errors(tmp_path):
+    """A -> B -> A is detected as a cycle."""
+    db_path = tmp_path / "g.db"
+    _seed(db_path, [(10, "ga", "@gb"), (11, "gb", "@ga")])
+    result = _run(tmp_path, db_path, "ga")
+    assert result.returncode != 0
+    assert "cycle" in result.stderr.lower()
+
+
+def test_depth_limit_errors(tmp_path):
+    """Nesting deeper than the max errors (chain of groups, no cycle)."""
+    db_path = tmp_path / "g.db"
+    # 12 groups each pointing at the next, then a leaf — exceeds max depth 10.
+    entries = [(100 + i, f"g{i}", f"@g{i + 1}") for i in range(12)]
+    entries.append((200, "leaf", "echo LEAF"))
+    entries[-2] = (100 + 11, "g11", "@leaf")
+    _seed(db_path, entries)
+    result = _run(tmp_path, db_path, "g0")
+    assert result.returncode != 0
+    assert "deep" in result.stderr.lower()
+
+
+# --- Remote confirmation ---
+
+
+def test_remote_child_refuses_without_tty(tmp_path):
+    """A source=remote child makes the whole group refuse to run unattended."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(
+        db_path,
+        [
+            (1, "a", f"echo A >> {out}"),
+            (2, "b", f"echo B >> {out}"),
+            (10, "grp", "@1\n@2"),
+        ],
+    )
+    _mark_remote(db_path, "uid00002")
+    result = _run(tmp_path, db_path, "grp")
+    assert result.returncode != 0
+    assert "koda edit" in result.stderr
+    assert not out.exists()
+
+
+def test_remote_child_bypassed_with_force(tmp_path):
+    """-f skips the group remote prompt and runs everything."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(
+        db_path,
+        [
+            (1, "a", f"echo A >> {out}"),
+            (2, "b", f"echo B >> {out}"),
+            (10, "grp", "@1\n@2"),
+        ],
+    )
+    _mark_remote(db_path, "uid00002")
+    result = _run(tmp_path, db_path, "grp", "-f")
+    assert result.returncode == 0, result.stderr
+    assert out.read_text().split() == ["A", "B"]
+
+
+def test_remote_group_bypassed_when_confirm_disabled(tmp_path):
+    """exec.confirm_remote=false disables the group remote prompt."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(
+        db_path,
+        [
+            (1, "a", f"echo A >> {out}"),
+            (2, "b", f"echo B >> {out}"),
+            (10, "grp", "@1\n@2"),
+        ],
+    )
+    _mark_remote(db_path, "uid00002")
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("[exec]\nconfirm_remote = false\n", encoding="utf-8")
+    env = _base_env(tmp_path, db_path)
+    env["KODA_CONFIG_PATH"] = str(config_path)
+    result = subprocess.run(
+        [sys.executable, "-c", "from koda.main import app; app()", "x", "grp"],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert out.read_text().split() == ["A", "B"]
+
+
+def test_remote_group_entry_itself_triggers_refusal(tmp_path):
+    """A remote GROUP entry (all children local) still gates on confirmation."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(
+        db_path,
+        [
+            (1, "a", f"echo A >> {out}"),
+            (10, "grp", "@1"),
+        ],
+    )
+    _mark_remote(db_path, "uid00010")
+    result = _run(tmp_path, db_path, "grp")
+    assert result.returncode != 0
+    assert "koda edit" in result.stderr
+    assert not out.exists()
+
+
+# --- Dry run ---
+
+
+def test_dry_run_prints_one_line_per_child_runs_nothing(tmp_path):
+    """--dry-run prints a shlex-quoted argv per child, in order, and runs none."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(
+        db_path,
+        [
+            (1, "a", f"echo A >> {out}"),
+            (2, "b", f"echo B >> {out}"),
+            (10, "grp", "@1\n@2"),
+        ],
+    )
+    result = _run(tmp_path, db_path, "grp", "-n")
+    assert result.returncode == 0, result.stderr
+    lines = result.stdout.splitlines()
+    assert len(lines) == 2
+    assert "echo A" in lines[0]
+    assert "echo B" in lines[1]
+    assert not out.exists()  # nothing executed
+
+
+# --- Trailing args after a group ref ---
+
+
+def test_trailing_args_after_group_ref_error(tmp_path):
+    """v1 does not support trailing args on a group; point to -V instead."""
+    db_path = tmp_path / "g.db"
+    _seed(db_path, [(1, "a", "echo A"), (10, "grp", "@1")])
+    result = _run(tmp_path, db_path, "grp", "extra")
+    assert result.returncode != 0
+    assert "parameterize with -V" in result.stderr
+
+
+# --- -V into the group body ---
+
+
+def test_var_substitution_into_group_body(tmp_path):
+    """-V parameterizes the group body itself, e.g. `@${SVC}` resolves to a ref."""
+    db_path = tmp_path / "g.db"
+    out = tmp_path / "out.txt"
+    _seed(
+        db_path,
+        [
+            (1, "web", f"echo WEB >> {out}"),
+            (10, "grp", "@${SVC}"),
+        ],
+    )
+    result = _run(tmp_path, db_path, "grp", "-V", "SVC=web")
+    assert result.returncode == 0, result.stderr
+    assert out.read_text().strip() == "WEB"


### PR DESCRIPTION
## Summary

Adds **group entries** to `koda x` (issue #143). A group is a memo whose body is a list of `@<ref>` references, one per line. `koda x <group>` expands the references and runs each child sequentially — a lightweight playlist / task runner.

```
@dcd
@dcup        # comments and blank lines ignored
@dcl -f
```

- **Detection** happens after `_apply_vars` (so `-V` parameterizes the group body, e.g. `@${SVC}`): inline comments stripped and blanks dropped; all-`@` lines → group, some-but-not-all → error, none → existing single-entry path unchanged (still `os.execvp`).
- **Per-line `@<ref> [args...]`**: ref resolved via `resolve_ref`; args follow the #138 fill-positionals-or-append-`"$@"` semantics, per child.
- **Fail fast**: the full plan resolves upfront, so an unknown ref aborts with nothing run. Nested groups expand recursively with uid-stack cycle detection (error names the cycle) and a depth-10 cap.
- **Trailing CLI args after a group ref** error, pointing to `-V`.
- **Execution**: `subprocess.run` per child; dim progress line per child to stderr (`→ [3] dcl (2/5)`); first non-zero exit stops the run and propagates the code.
- **Remote confirmation**: group + children deduped by id; one prompt for any `source=remote` (non-TTY refuses with the review hint); `-f` / `exec.confirm_remote=false` bypass. Children never re-prompt individually.
- **`--dry-run`**: one shlex-quoted argv per child, stdout only, no progress / confirmation / shell validation.

Children execute verbatim — only the group body is substituted, preserving the backslash-escaped `\$(...)` storage contract (no second substitution pass). Single (non-group) entry behavior is byte-for-byte unchanged.

README gains a "Group entries" subsection under exec and a note in the remote trust-boundary section.

## Test plan

New `tests/test_exec_group.py` (19 tests, following the existing subprocess-based exec test patterns): detection (all-@ / plain / mixed / comments+blanks), fail-fast on unknown ref, sequential order + stop-on-failure with exit code, per-line args (append vs positional fill), nesting, direct + indirect cycles, depth limit, remote confirmation (non-TTY refusal, `-f` bypass, `confirm_remote=false` bypass, remote group entry itself), `--dry-run`, trailing-args error, `-V` into the group body.

`uv run ruff format --check src tests && uv run ruff check src tests && uv run pytest` → 380 passed.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)