### PR TITLE
chore(release): bump version to 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koda-cli"
-version = "1.2.0"
+version = "1.3.0"
 description = "A fast CLI memo store and command launcher backed by SQLite or Turso."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -217,7 +217,7 @@ wheels = [
 
 [[package]]
 name = "koda-cli"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary
Bump version 1.2.0 → 1.3.0 for the minor release containing:
- Entry titles: `add --title`, `edit` footer line, `show` display, title-aware `-q` (#140, #141)
- `list` display modes `title|body|full|both` via `--display/-d` + `list.display` config (#142)
- Group (reference-list) exec entries with cycle detection and remote confirmation (#143)

## Test plan
- [x] `uv run pytest` (380 passed)
- [x] `uv run koda --version` reports 1.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)