### PR TITLE
refactor(cli)!: make single-letter short flags consistent across commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ koda l -q "docker"              # substring search on body or title
 koda l -t linux                 # filter by tag substring
 koda l -T archive               # exclude entries tagged "archive"
 koda l -S                       # only entries that have a shortcut
-koda l -n 50 -p 2              # 50 entries per page, page 2
-koda l -s created_at --desc     # sort by creation date descending
+koda l -l 50 -p 2              # 50 entries per page, page 2
+koda l -b created_at --desc     # sort by creation date descending
 koda l --columns idx,uid,sc,tags,content,created_at   # all columns
 koda l --columns idx,content    # minimal view
 koda l -d body                  # show body preview in content column
@@ -541,8 +541,8 @@ Each entry has a display index (`IDX`) you can freely rearrange — useful for k
 koda w 3 0        # swap display positions of entries 3 and 0
 koda m 7 1        # move entry 7 to empty position 1
 koda h 1          # shift entries at index 1+ up by 1 (makes room at 1)
-koda h 1 -n 3     # shift up by 3 positions
-koda h 5 -n -1    # shift entries from index 5 downward by 1
+koda h 1 -c 3     # shift up by 3 positions
+koda h 5 -c -1    # shift entries from index 5 downward by 1
 koda k            # reassign all indices to 0..n-1, fill gaps
 ```
 

--- a/src/koda/commands/index.py
+++ b/src/koda/commands/index.py
@@ -43,7 +43,7 @@ def move(
 def shift_cmd(
     start: int = typer.Argument(..., help="Shift entries at this index and above."),
     count: int = typer.Option(
-        1, "--count", "-n", help="Positions to shift (negative = shift down)."
+        1, "--count", "-c", help="Positions to shift (negative = shift down)."
     ),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Show what would change without modifying the database."

--- a/src/koda/commands/memo.py
+++ b/src/koda/commands/memo.py
@@ -588,13 +588,13 @@ def list_memos(
         False, "--shortcuts", "-S", help="Show only entries that have a shortcut."
     ),
     per_page: int | None = typer.Option(
-        None, "--per-page", "-n", help="Entries per page. [config: list.per_page]"
+        None, "--per-page", "-l", help="Entries per page. [config: list.per_page]"
     ),
     page: int = typer.Option(1, "--page", "-p", min=1, help="1-based page number to display."),
     sort_by: str | None = typer.Option(
         None,
         "--sort-by",
-        "-s",
+        "-b",
         case_sensitive=False,
         help=(
             "Sort column: id, idx, uid, tags, content, created_at, modified_at, shortcut. "


### PR DESCRIPTION
## Summary

Single-letter short flags previously mapped to different meanings across commands, which breaks muscle memory (e.g. typing `kl -s <shortcut>` hits `--sort-by` and errors). This pins each colliding letter to one global meaning.

- `-s` is reserved for **shortcut** (`add`)
- `-n` is reserved for **dry-run** (`exec`, idiomatic like `make -n`)

Renamed the colliding everyday value flags:

| Command | Old | New | Meaning |
|---|---|---|---|
| `list` | `-s` | `-b` | `--sort-by` |
| `list` | `-n` | `-l` | `--per-page` |
| `shift` | `-n` | `-c` | `--count` |

`pick`'s action flags (`-p/-e/-x/-r/-s/-m`) mirror subcommand names and form their own internally-consistent mini-language, so they are intentionally left as a documented exception.

Long forms (`--sort-by`, `--per-page`, `--count`) are unchanged.

## Breaking change

`koda list -s`, `koda list -n`, and `koda shift -n` no longer work. Update any aliases/scripts to `-b`/`-l`/`-c` respectively (or use the unchanged long forms).

## Verification

- `ruff check` / `ruff format --check`: pass
- `pytest`: 380 passed
- Confirmed new flags in `koda list --help` / `koda shift --help`; old `koda l -s …` now rejected as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)