### PR TITLE
feat(cli): standardize -n as the --dry-run short flag across commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `-n` is now the short flag for `--dry-run` on `move`, `shift`, `compact`,
+  `tag`, and `pull`, matching `exec`. Previously only `exec --dry-run` had a
+  `-n` short form.
+
+### Changed
+- Single-letter short flags now map to one meaning per letter across commands.
+  `-s` is reserved for `--shortcut` (`add`) and `-n` for `--dry-run` (`exec`).
+  The colliding everyday value flags were renamed: `list --sort-by` `-s` → `-b`,
+  `list --per-page` `-n` → `-l`, and `shift --count` `-n` → `-c`. `pick`'s action
+  flags (`-p`/`-e`/`-x`/`-r`/`-s`/`-m`) mirror subcommand names and are kept.
+  **Breaking:** `koda list -s`, `koda list -n`, and `koda shift -n` no longer
+  work — use `-b`/`-l`/`-c` (long forms `--sort-by`/`--per-page`/`--count` are
+  unchanged). This also fixes the footgun where `koda shift -n` silently shifted
+  entries instead of previewing.
+
+## [1.3.0] - 2026-06-12
+
+### Added
 - `koda exec <ref> [args…]` now forwards trailing CLI arguments to the command.
   They become the shell's real positional parameters (`$1`, `$2`, `"$@"`); if the
   body doesn't reference them they are appended at the end (like a shell alias),
@@ -122,7 +140,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`move` / `swap` / `shift` / `compact`), shortcuts, tags, variable
   substitution, and a `config` subcommand.
 
-[Unreleased]: https://github.com/ngt22/koda-cli/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/ngt22/koda-cli/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/ngt22/koda-cli/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/ngt22/koda-cli/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/ngt22/koda-cli/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/ngt22/koda-cli/compare/v1.0.2...v1.1.0

--- a/README.md
+++ b/README.md
@@ -865,7 +865,7 @@ The sync remote is **outside your trust boundary**. Anyone who can write to it (
 - **The `source` flag never crosses the wire.** It is local-only state and is not written to (or read from) `koda-sync.jsonl`, so a remote cannot label its own entries `local` to dodge the prompt.
 
 ```bash
-koda pull --dry-run     # show what would change, write nothing
+koda pull --dry-run     # (or -n) show what would change, write nothing
 koda pull               # merge; new/updated entries become source=remote
 koda x deploy           # prompts because 'deploy' came from the remote
 koda edit deploy        # review it → trusted (source=local), no more prompts

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -151,6 +151,7 @@ def pull(
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
+        "-n",
         help="Show the insert/update diff without modifying the local database.",
     ),
 ):

--- a/src/koda/commands/index.py
+++ b/src/koda/commands/index.py
@@ -13,7 +13,7 @@ def move(
     from_idx: int = typer.Argument(..., help="Source display index."),
     to_idx: int = typer.Argument(..., help="Destination display index (must be empty)."),
     dry_run: bool = typer.Option(
-        False, "--dry-run", help="Show what would change without modifying the database."
+        False, "--dry-run", "-n", help="Show what would change without modifying the database."
     ),
     quiet: bool = typer.Option(False, "--quiet", help="Suppress the success message."),
 ):
@@ -46,7 +46,7 @@ def shift_cmd(
         1, "--count", "-c", help="Positions to shift (negative = shift down)."
     ),
     dry_run: bool = typer.Option(
-        False, "--dry-run", help="Show what would change without modifying the database."
+        False, "--dry-run", "-n", help="Show what would change without modifying the database."
     ),
 ):
     """Shift all entries at START and above by COUNT positions. Alias: `koda h`."""
@@ -123,7 +123,7 @@ def swap(
 @app.command(name="compact", rich_help_panel="Index")
 def compact_indices(
     dry_run: bool = typer.Option(
-        False, "--dry-run", help="Show what would change without modifying the database."
+        False, "--dry-run", "-n", help="Show what would change without modifying the database."
     ),
 ):
     """Fill index gaps by reassigning idx to contiguous values from 0. Alias: `koda k`."""

--- a/src/koda/commands/memo.py
+++ b/src/koda/commands/memo.py
@@ -749,7 +749,7 @@ def tag(
     tags: list[str] | None = typer.Option(None, "--tag", "-t", help="Tag(s) to add."),
     untag: list[str] | None = typer.Option(None, "--untag", "-T", help="Tag(s) to remove."),
     dry_run: bool = typer.Option(
-        False, "--dry-run", help="Show what would change without modifying the database."
+        False, "--dry-run", "-n", help="Show what would change without modifying the database."
     ),
     quiet: bool = typer.Option(False, "--quiet", help="Suppress the success message."),
 ):


### PR DESCRIPTION
Closes #135

## Summary

Completes the `-n` convention cleanup. After #149 freed `-n` from `list --per-page` and `shift --count` (and fixed the footgun where `koda shift -n` silently shifted entries), this PR makes `-n` consistently mean `--dry-run` everywhere it exists.

Added `-n` as the short flag for `--dry-run` on:

| Command | Before | After |
|---|---|---|
| `move` | `--dry-run` only | `--dry-run` / `-n` |
| `shift` | `--dry-run` only | `--dry-run` / `-n` |
| `compact` | `--dry-run` only | `--dry-run` / `-n` |
| `tag` | `--dry-run` only | `--dry-run` / `-n` |
| `pull` | `--dry-run` only | `--dry-run` / `-n` |
| `exec` | already had `-n` | unchanged |

So `-n` now means `--dry-run` on every command that supports it — no more three-way collision (#135).

## CHANGELOG catch-up

While here: #148 bumped the version to **1.3.0** (and tagged `v1.3.0`) but never updated `CHANGELOG.md`, so the accumulated `[Unreleased]` content — which matches #148's own release note (titles, list display modes, group exec) — was stranded under `[Unreleased]`. This PR retroactively labels it `[1.3.0] - 2026-06-12`, fixes the compare links, and opens a fresh `[Unreleased]` recording the #149 flag renames and this `-n` standardization.

## Verification

- `ruff check` / `ruff format --check`: pass
- `pytest`: 380 passed
- Manually confirmed in a throwaway DB that `shift -n` / `move -n` / `tag -n` / `compact -n` / `pull -n` preview without mutating (verified via `koda list --json` before/after); `koda <cmd> --help` shows `-n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)