### PR TITLE
chore(release): bump version to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-13
+
 ### Added
 - `-n` is now the short flag for `--dry-run` on `move`, `shift`, `compact`,
   `tag`, and `pull`, matching `exec`. Previously only `exec --dry-run` had a
@@ -140,7 +142,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`move` / `swap` / `shift` / `compact`), shortcuts, tags, variable
   substitution, and a `config` subcommand.
 
-[Unreleased]: https://github.com/ngt22/koda-cli/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/ngt22/koda-cli/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/ngt22/koda-cli/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/ngt22/koda-cli/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/ngt22/koda-cli/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/ngt22/koda-cli/compare/v1.1.0...v1.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koda-cli"
-version = "1.3.0"
+version = "1.4.0"
 description = "A fast CLI memo store and command launcher backed by SQLite or Turso."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -217,7 +217,7 @@ wheels = [
 
 [[package]]
 name = "koda-cli"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Release 1.4.0

Cuts the **1.4.0** release. Bumps `pyproject.toml` + `uv.lock` (1.3.0 → 1.4.0) and finalizes the CHANGELOG `[Unreleased]` section as `[1.4.0] - 2026-06-13`.

### What's in this release

A breaking CLI change making single-letter short flags consistent across commands (#149, #150, closing #135):

- **`-n` = `--dry-run` everywhere** it exists — `move` / `shift` / `compact` / `tag` / `pull` / `exec`.
- **Renamed colliding value flags:** `list --sort-by` `-s` → `-b`, `list --per-page` `-n` → `-l`, `shift --count` `-n` → `-c`.
- `-s` is now reserved for `--shortcut` (`add`). `pick`'s action flags (`-p`/`-e`/`-x`/`-r`/`-s`/`-m`) are kept as a documented exception.
- Fixes the footgun where `koda shift -n` silently shifted entries instead of previewing.

### Breaking change

`koda list -s`, `koda list -n`, and `koda shift -n` no longer work. Use `-b` / `-l` / `-c` (the long forms `--sort-by` / `--per-page` / `--count` are unchanged). Since users install from `main` via `uv tool`, this reaches anyone running `uv tool upgrade koda-cli` — flagged here so the version signal (`koda --version` → 1.4.0) lands with it.

### Verification

- `koda --version` reports `1.4.0`
- `ruff` + `pytest` already green on the merged #149/#150 changes

After merge, tag `v1.4.0` on the merge commit (consistent with `v1.3.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)