### PR TITLE
feat!: byte-exact raw, Python 3.13 support, README overhaul — beta version 0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         include:
           # Verify the CLI works on macOS too (single representative version).
           - os: macos-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `koda raw` now prints the stored body byte-for-byte. The previous automatic
+  transforms — stripping shell-style inline comments and appending a trailing
+  newline when missing — are removed. **Breaking:** consumers that relied on
+  the old shell-safe output must handle comments and newlines themselves.
+
 ## [1.4.0] - 2026-06-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,31 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-10
+
+### Added
+- Python 3.13 support: the CI matrix, classifiers, and badge now include 3.13.
+
 ### Changed
 - `koda raw` now prints the stored body byte-for-byte. The previous automatic
   transforms — stripping shell-style inline comments and appending a trailing
   newline when missing — are removed. **Breaking:** consumers that relied on
   the old shell-safe output must handle comments and newlines themselves.
 
-## [1.4.0] - 2026-06-13
+### Docs
+- README overhaul: fixed example errors (group shortcut, progress line),
+  documented sync deletion/conflict caveats and uid collision, documented CSV
+  escaping for `-V`, merged the standalone Options section into the Command
+  reference, removed the eval example, added Uninstall and
+  `KODA_DB_PATH_OVERRIDE` docs, and clarified the `exec.shell` threat model.
 
-### Added
-- `-n` is now the short flag for `--dry-run` on `move`, `shift`, `compact`,
-  `tag`, and `pull`, matching `exec`. Previously only `exec --dry-run` had a
-  `-n` short form.
-
-### Changed
-- Single-letter short flags now map to one meaning per letter across commands.
-  `-s` is reserved for `--shortcut` (`add`) and `-n` for `--dry-run` (`exec`).
-  The colliding everyday value flags were renamed: `list --sort-by` `-s` → `-b`,
-  `list --per-page` `-n` → `-l`, and `shift --count` `-n` → `-c`. `pick`'s action
-  flags (`-p`/`-e`/`-x`/`-r`/`-s`/`-m`) mirror subcommand names and are kept.
-  **Breaking:** `koda list -s`, `koda list -n`, and `koda shift -n` no longer
-  work — use `-b`/`-l`/`-c` (long forms `--sort-by`/`--per-page`/`--count` are
-  unchanged). This also fixes the footgun where `koda shift -n` silently shifted
-  entries instead of previewing.
-
-## [1.3.0] - 2026-06-12
+## [0.3.0] - 2026-06-12
 
 ### Added
 - `koda exec <ref> [args…]` now forwards trailing CLI arguments to the command.
@@ -83,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sits at display index `-1` (the temporary index is now derived from the table
   rather than a hardcoded `-1` sentinel).
 
-## [1.2.0] - 2026-06-06
+## [0.2.0] - 2026-06-06
 
 ### Added
 - Git sync over JSON Lines: `push` / `pull` commands plus `git.*` configuration,
@@ -114,12 +108,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restricted `exec.shell` to an allowlisted, absolute-path executable.
 - Hardened on-disk permissions for the config file and database.
 
-## [1.1.1] - 2026-04-24
+## [0.1.1] - 2026-04-24
 
 ### Fixed
 - Convert query parameters to tuples for Turso libsql compatibility.
 
-## [1.1.0] - 2026-04-24
+## [0.1.0] - 2026-04-24
 
 ### Added
 - Turso remote database backend.
@@ -129,18 +123,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use CSV (comma + quotes) as the positional-variable delimiter and stop
   escaping positional values with `re.escape()`.
 
-## [1.0.2] - 2026-04-22
+## [0.0.2] - 2026-04-22
 
 ### Added
 - Interactive `pick` command backed by fzf.
 
-## [1.0.1] - 2026-04-22
+## [0.0.1] - 2026-04-22
 
 ### Fixed
 - Expand `~` in the database path from config.
 - Use the correct package name for version lookup.
 
-## [1.0.0] - 2026-04-22
+## [0.0.0] - 2026-04-22
 
 ### Added
 - Initial public release: SQLite-backed memo store with `add`, `list`, `show`,
@@ -149,11 +143,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   substitution, and a `config` subcommand.
 
 [Unreleased]: https://github.com/ngt22/koda-cli/compare/v1.4.0...HEAD
-[1.4.0]: https://github.com/ngt22/koda-cli/compare/v1.3.0...v1.4.0
-[1.3.0]: https://github.com/ngt22/koda-cli/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/ngt22/koda-cli/compare/v1.1.1...v1.2.0
-[1.1.1]: https://github.com/ngt22/koda-cli/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/ngt22/koda-cli/compare/v1.0.2...v1.1.0
-[1.0.2]: https://github.com/ngt22/koda-cli/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/ngt22/koda-cli/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/ngt22/koda-cli/releases/tag/v1.0.0
+[0.4.0]: https://github.com/ngt22/koda-cli/compare/v1.3.0...v1.4.0
+[0.3.0]: https://github.com/ngt22/koda-cli/compare/v1.2.0...v1.3.0
+[0.2.0]: https://github.com/ngt22/koda-cli/compare/v1.1.1...v1.2.0
+[0.1.1]: https://github.com/ngt22/koda-cli/compare/v1.1.0...v1.1.1
+[0.1.0]: https://github.com/ngt22/koda-cli/compare/v1.0.2...v1.1.0
+[0.0.2]: https://github.com/ngt22/koda-cli/compare/v1.0.1...v1.0.2
+[0.0.1]: https://github.com/ngt22/koda-cli/compare/v1.0.0...v1.0.1
+[0.0.0]: https://github.com/ngt22/koda-cli/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # koda-cli
 
 [![CI](https://github.com/ngt22/koda-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/ngt22/koda-cli/actions/workflows/ci.yml)
-[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue)](https://github.com/ngt22/koda-cli/blob/main/pyproject.toml)
+[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://github.com/ngt22/koda-cli/blob/main/pyproject.toml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](https://github.com/ngt22/koda-cli/blob/main/LICENSE)
 
 A **text store** for the terminal. Save any text — commands, paths, templates, notes — to SQLite and recall it instantly by index, shortcut, or fuzzy search. Saved entries can be executed as shell commands, making koda a **terminal launcher**. Sync via a private Git repository to share the same store across machines, giving you a **cross-machine clipboard** that works from any terminal. Built with Python, Typer, and Rich.
@@ -14,8 +14,8 @@ A **text store** for the terminal. Save any text — commands, paths, templates,
 - [Quick reference](#quick-reference)
 - [Installation](#installation)
 - [Update](#update)
+- [Uninstall](#uninstall)
 - [Command reference](#command-reference)
-- [Options](#options)
 - [Recommended aliases](#recommended-aliases)
 - [Configuration](#configuration)
 - [Environment variables](#environment-variables)
@@ -38,16 +38,16 @@ koda sits between a snippet manager and a note tool: it keeps arbitrary text the
 
 **What koda gives you, at a glance:**
 
-| Capability | koda |
-|---|:---|
-| Store arbitrary text | ✓ |
-| Run any entry as a command | ✓ (`exec` / `pick`) |
-| Fuzzy interactive pick | ✓ (fzf) |
-| Variable substitution | ✓ (`${KEY}` / `$1`) |
-| Shortcut & index recall | ✓ |
-| Cross-machine sync | ✓ (your own Git repo) |
-| Storage | SQLite (or Turso) |
-| Shell-friendly output | ✓ (`raw`, `--json`) |
+| Capability | How (koda) |
+|---|---|
+| Store arbitrary text | `add` — arguments, stdin, or `$EDITOR` |
+| Run any entry as a command | `exec` / `pick -x` |
+| Fuzzy interactive pick | `pick` (fzf) |
+| Variable substitution | `-V` — `${KEY}` / `$1` |
+| Shortcut & index recall | numeric `idx` or `-s` shortcut |
+| Cross-machine sync | `push` / `pull` via your own Git repo |
+| Storage | local SQLite (or Turso remote) |
+| Shell-friendly output | `raw`, `--json` |
 
 ## Features
 
@@ -68,7 +68,8 @@ koda sits between a snippet manager and a note tool: it keeps arbitrary text the
 **Other**
 
 - **Cross-machine sync**: Push and pull via a private Git repository — the same store is available from every terminal, on every machine.
-- **Display index**: Stable `uid` (SHA1 short hash) plus user-controlled `idx`. Reorder with `move`/`swap`; close gaps with `compact`.
+- **Display index**: Stable `uid` (first 16 hex chars of SHA1 over content + creation timestamp) plus user-controlled `idx`. Reorder with `move`/`swap`; close gaps with `compact`.
+- **uid collision caveat**: The `uid` is derived from content + creation time (second granularity), so two entries created in the same second with identical content share a `uid` and merge into one entry during Git sync. Avoid creating identical entries within the same second if you rely on sync.
 - **XDG-friendly**: Data under `~/.local/share/koda/`, config under `~/.config/koda/`.
 - **Configurable defaults**: Persist preferences in `~/.config/koda/config.toml`.
 
@@ -183,6 +184,20 @@ uv tool upgrade koda-cli
 pipx upgrade koda-cli
 ```
 
+---
+
+## Uninstall
+
+```bash
+# uv
+uv tool uninstall koda-cli
+
+# pipx
+pipx uninstall koda-cli
+```
+
+Data (`~/.local/share/koda/`) and config (`~/.config/koda/`) are not removed by the tool manager. Delete them manually if you want a full cleanup.
+
 ## Command reference
 
 Most commands take an **entry reference** as their first argument — either a **numeric index** (e.g. `5`, shown by `koda l`) or a **shortcut** (a string alias you assign with `-s` at save time, e.g. `koda a "..." -s glog`). In the examples below, names like `glog` and `web-srv` are shortcuts.
@@ -221,6 +236,32 @@ Content source precedence: **text arguments > piped stdin > `$EDITOR`**. When
 arguments are given, piped stdin is ignored (with a warning on stderr). This
 keeps `koda a "text"` working in non-interactive shells (cron, IDE tasks,
 sandboxes) where stdin is not a TTY.
+
+---
+
+### Shortcuts (`-s` / `--shortcut`)
+
+Assign a memorable string alias to any entry and use it instead of a numeric index.
+
+```bash
+# Save with a shortcut (-s is short for --shortcut)
+koda a "kubectl rollout restart deploy/api" -t k8s -s restart
+
+# Use the shortcut anywhere an index is accepted
+koda r restart
+koda x restart
+koda s restart
+koda d restart
+
+# Default command — no subcommand needed (when defaults.cmd = raw)
+koda restart          # → koda raw restart
+
+# List all entries that have shortcuts
+koda l -S
+koda l -S --sort-by shortcut
+```
+
+To change or remove a shortcut, open the entry with `edit` — the `shortcut:` field appears in the metadata footer.
 
 ---
 
@@ -272,12 +313,12 @@ curl http://$(koda r web-ip):3000/healthz
 koda e web-ip   # opens $EDITOR
 ```
 
-`raw` strips shell-style inline comments (`#` at line start or after whitespace). Use `show` to see the original stored text.
+`raw` prints the body exactly as stored, byte-for-byte — comments, whitespace, and trailing newlines are preserved. Use `show` to see the entry with its metadata.
 
 ```bash
 koda a 'echo hello  # this is a comment'
-koda r 5    # → echo hello
-koda s 5    # → echo hello  # this is a comment
+koda r 5    # → echo hello  # this is a comment
+koda s 5    # → echo hello  # this is a comment (with metadata)
 ```
 
 ---
@@ -417,19 +458,60 @@ koda a "docker compose logs -f" -s dcl
 
 koda a -s restart        # opens $EDITOR; paste:
 #   @dcd
-#   @dcup        # comments and blank lines are ignored
+#   @dcu         # comments and blank lines are ignored
 #   @dcl -f
-koda x restart           # runs dcd, then dcup, then `dcl -f`, in order
+koda x restart           # runs dcd, then dcu, then `dcl -f`, in order
 ```
 
 - **Per-line args.** Text after a ref on a line is passed to that child, with the same rules as call-time args: it fills `$1`/`"$@"` if the child body references them, otherwise it's appended (`@dcl -f` → `docker compose logs -f`).
 - **Nesting.** A child that is itself a group expands recursively. Cycles (`@a` → `@b` → `@a`) are detected and rejected, and nesting is capped at 10 levels deep.
-- **Parameterize with `-V`.** `-V` substitutes into the group body *before* it's parsed, so `@${SVC}` resolves to a different child per call (`koda x grp -V SVC=web`). Trailing args directly after a group ref are not supported in v1 — use `-V`.
-- **Fail fast.** The whole plan is resolved before anything runs, so an unknown ref aborts with nothing executed. The first child to exit non-zero stops the group, and `koda x` exits with that child's code. Progress lines (`→ [3] dcl (2/5)`) go to stderr, keeping stdout clean for the children's own output.
+- **Parameterize with `-V`.** `-V` substitutes into the group body *before* it's parsed, so `@${SVC}` resolves to a different child per call (`koda x grp -V SVC=web`). Trailing args directly after a group ref are not supported yet — use `-V`.
+- **Fail fast.** The whole plan is resolved before anything runs, so an unknown ref aborts with nothing executed. The first child to exit non-zero stops the group, and `koda x` exits with that child's code. Progress lines (`→ [2] dcl (3/3)`) go to stderr, keeping stdout clean for the children's own output.
 - **Remote confirmation.** If the group itself or any expanded child is `source=remote`, `koda x` prompts once before running the whole group (listing the remote entries); `-f` skips it and `exec.confirm_remote=false` disables it, same as a single entry.
 - **Preview with `-n`.** `koda x <group> -n` prints one resolved command per child, in execution order, without running anything.
 
 > **Security**: only store trusted commands. `exec` runs the body through the configured shell (`sh` by default). A group runs each referenced entry, so the same caution applies to every child it pulls in.
+
+---
+
+### Variable substitution (`-V` / `--var`)
+
+Embed placeholders in a saved entry; fill them in at recall time with `-V`.
+
+| Style | Placeholder | How to pass |
+|---|---|---|
+| Named | `${host}` | `-V KEY=VALUE` |
+| Positional | `$1`, `$2`, ... | `-V value` or `-V val1,val2` (comma-separated, left-to-right) |
+
+```bash
+# Save a template with a positional placeholder
+koda a "gcloud storage cp \$1 gs://my-company-analytics-prod/uploads/" -t gcloud -s upload
+
+# Run with different values — no need to retype the bucket path
+koda x upload -V ./report.csv
+koda x upload -V ./summary.csv
+
+# Named substitution — swap one variable by name
+koda a "aws s3 sync ./dist s3://acme-frontend-\${env}-us-east-1/app/" -t aws -s deploy
+koda x deploy -V env=prod
+koda x deploy -V env=staging
+
+# Multiple positional values
+koda a "rsync -avz \$1 \$2" -t rsync
+koda r 8 -V /src/path -V user@host:/dest
+koda r 8 -V '/src/path,user@host:/dest'    # same result, comma-separated
+
+# Mix named and positional
+koda r 9 -V 'admin,5432' -V host=db.example.com -V name="new york"
+# → connect admin@db.example.com:5432 as new york
+```
+
+Positional values are comma-separated within a single `-V` flag. Use `"..."` inside the flag to include spaces or commas in a value: `-V '"hello world","foo,bar"'`.
+
+Values follow CSV quoting rules: `"..."` preserves spaces and commas, a literal
+double quote inside a value is written as `""` (doubled), and backslashes are
+literal characters, not escapes. Example: `-V '"say ""hi""","a\b"'` passes the
+values `say "hi"` and `a\b`.
 
 ---
 
@@ -473,8 +555,6 @@ koda p -x -q docker -t dev     # pre-filter by query and tag, then pick
 koda x "$(koda p -p)"          # pick IDX, pass to exec
 kd x "$(kd p -p)"              # kd prefix
 kx "$(kp -p)"                  # two-letter alias
-
-eval $(koda p -p | xargs koda r)   # pick IDX, eval the body
 ```
 
 Other action flags: `-e` edit, `-r` raw, `-s` show.
@@ -533,6 +613,22 @@ Re-tagging with an already-present tag is idempotent (no-op).
 
 ---
 
+### Tags (`-t` / `--tag`)
+
+Assign one or more tags to an entry at save time; use them to filter across commands.
+
+```bash
+koda a "docker compose up" -t docker,dev     # assign multiple tags at add time
+koda l -t docker                             # filter list by tag substring
+koda l -T archive                            # exclude entries tagged "archive"
+koda d -t tmp                                # delete all entries tagged "tmp"
+koda p -x -t dev                             # pick + exec, pre-filtered by tag
+```
+
+Use `tag` (subcommand) to add or remove tags on existing entries in bulk — see [Tag](#tag).
+
+---
+
 ### Reorder entries (`move`, `swap`, `shift`, `compact`)
 
 Each entry has a display index (`IDX`) you can freely rearrange — useful for keeping frequently used snippets at low numbers.
@@ -561,90 +657,6 @@ koda g reset -f                  # delete config file without prompt
 koda g edit                      # open config in $EDITOR
 koda g path                      # print config file path
 ```
-
----
-
-## Options
-
-The following are flags that work across multiple commands, not standalone subcommands.
-
----
-
-### Shortcuts (`-s` / `--shortcut`)
-
-Assign a memorable string alias to any entry and use it instead of a numeric index.
-
-```bash
-# Save with a shortcut (-s is short for --shortcut)
-koda a "kubectl rollout restart deploy/api" -t k8s -s restart
-
-# Use the shortcut anywhere an index is accepted
-koda r restart
-koda x restart
-koda s restart
-koda d restart
-
-# Default command — no subcommand needed (when defaults.cmd = raw)
-koda restart          # → koda raw restart
-
-# List all entries that have shortcuts
-koda l -S
-koda l -S --sort-by shortcut
-```
-
-To change or remove a shortcut, open the entry with `edit` — the `shortcut:` field appears in the metadata footer.
-
----
-
-### Tags (`-t` / `--tag`)
-
-Assign one or more tags to an entry at save time; use them to filter across commands.
-
-```bash
-koda a "docker compose up" -t docker,dev     # assign multiple tags at add time
-koda l -t docker                             # filter list by tag substring
-koda l -T archive                            # exclude entries tagged "archive"
-koda d -t tmp                                # delete all entries tagged "tmp"
-koda p -x -t dev                             # pick + exec, pre-filtered by tag
-```
-
-Use `tag` (subcommand) to add or remove tags on existing entries in bulk — see [Tag](#tag).
-
----
-
-### Variable substitution (`-V` / `--var`)
-
-Embed placeholders in a saved entry; fill them in at recall time with `-V`.
-
-| Style | Placeholder | How to pass |
-|---|---|---|
-| Named | `${host}` | `-V KEY=VALUE` |
-| Positional | `$1`, `$2`, ... | `-V value` or `-V val1,val2` (comma-separated, left-to-right) |
-
-```bash
-# Save a template with a positional placeholder
-koda a "gcloud storage cp \$1 gs://my-company-analytics-prod/uploads/" -t gcloud -s upload
-
-# Run with different values — no need to retype the bucket path
-koda x upload -V ./report.csv
-koda x upload -V ./summary.csv
-
-# Named substitution — swap one variable by name
-koda a "aws s3 sync ./dist s3://acme-frontend-\${env}-us-east-1/app/" -t aws -s deploy
-koda x deploy -V env=prod
-koda x deploy -V env=staging
-
-# Multiple positional values
-koda a "rsync -avz \$1 \$2" -t rsync
-koda r 8 -V /src/path -V user@host:/dest
-koda r 8 -V '/src/path,user@host:/dest'    # same result, comma-separated
-
-# Mix named and positional
-koda r 9 -V 'admin,5432' -V host=db.example.com -V name="new york"
-# → connect admin@db.example.com:5432 as new york
-```
-
-Positional values are comma-separated within a single `-V` flag. Use `"..."` inside the flag to include spaces or commas in a value: `-V '"hello world","foo,bar"'`.
 
 ---
 
@@ -746,13 +758,14 @@ shell = "sh"      # shell used by exec — restricted to: sh, bash, zsh, fish
 
 Priority order: **CLI flags > environment variables > config file > built-in defaults**
 
-> **Security**: `exec.shell` is restricted to an allowlist (`sh`, `bash`, `zsh`, `fish`) that must resolve to an installed executable. This prevents a tampered config from redirecting `koda x` to an arbitrary binary. The config file (`config.toml`) and database are created with `0600` permissions and their parent directories with `0700`, so a plaintext Turso token is not world-readable.
+> **Security**: `exec.shell` is restricted to an allowlist (`sh`, `bash`, `zsh`, `fish`) that must resolve to an installed executable. This prevents a misconfigured or tampered config from accidentally redirecting `koda x` to an unexpected binary. The config file (`config.toml`) and database are created with `0600` permissions and their parent directories with `0700`, so a plaintext Turso token is not world-readable.
 
 ## Environment variables
 
 | Variable | Purpose |
 |---|---|
 | `KODA_DB_PATH` | Override database file path |
+| `KODA_DB_PATH_OVERRIDE` | Set to `1` to allow `KODA_DB_PATH` to point outside `~/.local/share/koda` — the explicit escape hatch for CI/tests |
 | `KODA_DEFAULT_CMD` | Override `defaults.cmd` for this session |
 | `KODA_CONFIG_PATH` | Override config file path |
 | `KODA_TURSO_URL`        | Turso database URL (overrides `turso.url` in config) |
@@ -762,6 +775,9 @@ Priority order: **CLI flags > environment variables > config file > built-in def
 | `KODA_GIT_SYNC_FORMAT`  | Sync wire format — `jsonl` (overrides `git.sync_format`) |
 | `KODA_FZF_OPTS`         | Extra flags passed to `fzf` by `pick` (e.g. `--height 40% --layout reverse`) |
 | `EDITOR`                | Editor for `add`, `edit`, and `config edit` (default: `vim`) |
+
+Example: `KODA_DB_PATH=/tmp/ci.db KODA_DB_PATH_OVERRIDE=1 koda l` runs against a
+temporary database outside the data directory.
 
 ## Turso (remote database)
 
@@ -815,6 +831,13 @@ The local SQLite database (`db.path`) and the Turso database are independent —
 
 Koda supports syncing entries across machines using a Git repository (e.g. a private GitHub repo) as a transport. On push, Koda exports the local database as a JSON Lines file (`koda-sync.jsonl`) into a local clone, commits it, and pushes to the remote. On pull, it fetches the latest commit and merges entries into the local database by `uid` and `modified_at` — newer wins, no entry is deleted.
 
+> **Deletions are not synced.** `pull` never deletes entries — removing an
+> entry on one machine does not remove it anywhere else. After a `pull`, a
+> deleted entry can come back (along with any newer synced version of its
+> body). To delete an entry everywhere, remove it on **each** machine. This is
+> a deliberate safe-merge choice: sync never loses data, at the cost of
+> deletions not propagating.
+
 This works independently of the Turso backend. You can use Git sync with the default local SQLite database.
 
 > **Security note**: `koda-sync.jsonl` contains **all entries in plaintext**.
@@ -855,6 +878,13 @@ koda pull   # git pull the clone, merge koda-sync.jsonl into local DB
 ```
 
 `push` does a `git pull --rebase` before writing the payload so the branch stays linear. `pull` merges by `uid` — entries that already exist locally are updated only if the incoming `modified_at` is newer.
+
+The sync payload is uid-sorted, so concurrent edits to *different* entries
+usually merge cleanly at the Git level. If the **same** entry is edited on two
+machines before either pushes, `git pull --rebase` hits a conflict and
+`koda push`/`koda pull` fails with "Resolve conflicts there, then retry".
+Resolution is manual: edit `koda-sync.jsonl` inside the sync clone to keep the
+desired line(s), commit, and re-run the command.
 
 ### Remote trust boundary
 
@@ -981,7 +1011,7 @@ sync remote, the `KODA_*` environment variables, a hand-edited
 
 | Area | Risk | Mitigation |
 |---|---|---|
-| `exec` shell | A tampered `exec.shell` could redirect `koda x` to an arbitrary binary | `exec.shell` is restricted to an allowlist (`sh`, `bash`, `zsh`, `fish`) that must resolve to an absolute executable |
+| `exec` shell | A misconfigured or tampered `exec.shell` could redirect `koda x` to an unexpected binary | `exec.shell` is restricted to an allowlist (`sh`, `bash`, `zsh`, `fish`) that must resolve to an installed executable |
 | Git sync poisoning | A writable remote could rewrite the body of an `exec` entry | `pull`-merged entries are marked `source=remote` and **`koda x` prompts before running them** (review with `koda edit` to trust; `exec.confirm_remote=false` opts out, at the cost of the check); `pull --dry-run` previews changes; the `source` flag is local-only and never synced. See [Remote trust boundary](#remote-trust-boundary) |
 | uid collision | The old 7-char (28-bit) `uid` was collidable (~16k entries) / preimage-attackable, enabling sync poisoning | `uid` is 16 hex chars (64-bit); legacy short uids still resolve via prefix match |
 | `git.payload_file` | A relative path like `.git/hooks/post-merge` could overwrite a git hook that then executes | The validator and `push` reject any path with `..` or a `.git` component, or an absolute path |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koda-cli"
-version = "1.4.0"
+version = "0.4.0"
 description = "A fast CLI memo store and command launcher backed by SQLite or Turso."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/koda/runtime.py
+++ b/src/koda/runtime.py
@@ -206,34 +206,10 @@ def _strip_inline_comment(line: str) -> str:
     return line
 
 
-def _strip_raw_inline_comments(content: str) -> str:
-    lines = content.splitlines(keepends=True)
-    if not lines:
-        return content
-
-    stripped_lines = []
-    for line in lines:
-        newline = ""
-        body = line
-        if line.endswith("\r\n"):
-            newline = "\r\n"
-            body = line[:-2]
-        elif line.endswith("\n") or line.endswith("\r"):
-            newline = line[-1]
-            body = line[:-1]
-        stripped_lines.append(_strip_inline_comment(body) + newline)
-    return "".join(stripped_lines)
-
-
 def emit_raw(ref: str | None, vars: list[str] | None = None) -> None:
     init_db()
     row = resolve_ref(ref)
     content = _apply_vars(row.content if row.content is not None else "", vars)
-    content = _strip_raw_inline_comments(content)
-    # POSIX text files end in a newline; append one when the body is non-empty
-    # and not already newline-terminated so `koda raw | wc -l` and friends work.
-    if content and not content.endswith("\n"):
-        content += "\n"
     sys.stdout.write(content)
 
 

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -1,12 +1,8 @@
-"""`raw` output must be newline-terminated for POSIX tool interop (issue #51)."""
-
-import subprocess
-import sys
+"""`raw` prints the stored body byte-for-byte — no comment stripping, no newline normalization."""
 
 import pytest
 
 import koda.runtime as runtime
-from koda.db import MemoDatabase
 
 
 @pytest.fixture
@@ -28,43 +24,25 @@ def _seed(db, content):
     )
 
 
-def test_appends_newline_when_missing(wired_db, capsys):
-    _seed(wired_db, "no trailing newline")
-    runtime.emit_raw(None)
-    assert capsys.readouterr().out == "no trailing newline\n"
-
-
-def test_does_not_double_newline(wired_db, capsys):
-    _seed(wired_db, "already terminated\n")
-    runtime.emit_raw(None)
-    assert capsys.readouterr().out == "already terminated\n"
-
-
 def test_empty_content_stays_empty(wired_db, capsys):
     _seed(wired_db, "")
     runtime.emit_raw(None)
     assert capsys.readouterr().out == ""
 
 
-def test_raw_subprocess_is_newline_terminated(tmp_path, monkeypatch):
-    """Acceptance criterion: run `raw` as a real process and inspect the tail."""
-    db_path = tmp_path / "raw.db"
-    seed = MemoDatabase(backend="local", path=db_path)
-    seed.init_db()
-    _seed(seed, "subprocess body")
+def test_preserves_missing_newline(wired_db, capsys):
+    _seed(wired_db, "no trailing newline")
+    runtime.emit_raw(None)
+    assert capsys.readouterr().out == "no trailing newline"
 
-    env = {
-        "KODA_DB_PATH": str(db_path),
-        "KODA_DB_PATH_OVERRIDE": "1",  # allow the temp DB path outside the data dir
-        "KODA_CONFIG_PATH": str(tmp_path / "nonexistent.toml"),
-        "PATH": __import__("os").environ.get("PATH", ""),
-    }
-    result = subprocess.run(
-        [sys.executable, "-c", "from koda.main import app; app()", "raw"],
-        capture_output=True,
-        text=True,
-        env=env,
-    )
-    assert result.returncode == 0, result.stderr
-    assert result.stdout.endswith("\n")
-    assert result.stdout.count("\n") == 1  # `koda raw | wc -l` == 1
+
+def test_preserves_inline_comment(wired_db, capsys):
+    _seed(wired_db, "echo hello  # this is a comment")
+    runtime.emit_raw(None)
+    assert capsys.readouterr().out == "echo hello  # this is a comment"
+
+
+def test_preserves_existing_newline(wired_db, capsys):
+    _seed(wired_db, "already terminated\n")
+    runtime.emit_raw(None)
+    assert capsys.readouterr().out == "already terminated\n"


### PR DESCRIPTION
## Summary

Beta release preparation: the version scheme moves to 0.x (the project is pre-1.0/beta).

### Commits
- **feat!** — make `raw` byte-exact; support Python 3.13 (breaking)
- **docs** — fix README errors and caveats, restructure options
- **chore(release)** — bump version to 0.4.0 (beta)

### Highlights
- `koda raw` now prints the stored body **byte-for-byte**: inline-comment stripping and automatic trailing-newline insertion are removed (**breaking change**, see CHANGELOG).
- **Python 3.13** added to the CI matrix, classifiers, and badge (full suite passes on 3.13).
- README overhaul: fixed example errors (group shortcut, progress line), documented sync deletion/conflict and uid-collision caveats, documented CSV escaping for `-V`, merged the standalone Options section into the Command reference, removed the eval example, added Uninstall and `KODA_DB_PATH_OVERRIDE` docs, clarified the `exec.shell` threat model.
- Version renumbered to **0.4.0** (beta); changelog history renumbered 1.x → 0.x. Existing v1.x git tags remain as history.

### Notes
- The `raw` change is breaking → under semver (pre-1.0) this bumps the minor of 0.x.
- CI will run the 3.13 job on this PR; lint/type checks on 3.13 were verified locally.
