### PR TITLE
feat: add koda --update / koda update self-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `koda --update` / `koda update` self-update: detects the install method
+  (uv tool, pipx, or pip) and runs the matching upgrade command.
+
 ## [1.4.0] - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Grouped the same way as `koda --help`.
 | Command | Alias | Description |
 |---|---|---|
 | [`config`](#configuration-config) | `g` | Read/write configuration |
+| [`update`](#update) | — | Update koda to the latest version (uv / pipx / pip) |
 
 Single-letter aliases are reserved and cannot be used as entry shortcuts.
 
@@ -174,6 +175,10 @@ pipx install "git+https://github.com/ngt22/koda-cli.git" --pip-args ".[turso]"
 ```
 
 ## Update
+
+koda can update itself — `koda --update` (or `koda update`) detects how it was
+installed (uv tool, pipx, or pip) and runs the matching upgrade command. The
+commands below are the manual equivalent and remain available as a fallback.
 
 ```bash
 # uv

--- a/src/koda/commands/update.py
+++ b/src/koda/commands/update.py
@@ -1,0 +1,10 @@
+"""Self-update command: ``koda update``."""
+
+from ..main import app
+from ..runtime import run_update
+
+
+@app.command(rich_help_panel="Config")
+def update() -> None:
+    """Update koda to the latest version (detects uv / pipx / pip)."""
+    run_update()

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -15,6 +15,7 @@ from .runtime import (
     get_config,
     init_db,
     resolve_ref,
+    update_callback,
     version_callback,
 )
 
@@ -82,6 +83,13 @@ def main(
         is_eager=True,
         help="Print version and exit.",
     ),
+    update: bool | None = typer.Option(
+        None,
+        "--update",
+        is_eager=True,
+        callback=update_callback,
+        help="Update koda to the latest version and exit.",
+    ),
 ):
     """Default: run the default command (see `koda config get defaults.cmd`)."""
     if ctx.invoked_subcommand is None:
@@ -103,6 +111,7 @@ def main(
 # RESERVED_SHORTCUTS, which the command modules import from here).
 from .commands import exec as _exec  # noqa: E402,F401
 from .commands import git, index, memo  # noqa: E402,F401
+from .commands import update as _update  # noqa: E402,F401
 
 if __name__ == "__main__":
     app()

--- a/src/koda/runtime.py
+++ b/src/koda/runtime.py
@@ -10,6 +10,7 @@ use.
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 from importlib.metadata import version
@@ -252,3 +253,59 @@ def _validate_list_columns(columns: list[str], source: str) -> None:
         ConfigManager.validate("list.columns", columns)
     except ValidationError:
         exit_error(f"Invalid {source}: {ConfigManager.error_message('list.columns')}")
+
+
+def detect_install_method() -> str | None:
+    """Detect how koda was installed: 'uv', 'pipx', 'venv-pip', 'pip', or None."""
+    uv = shutil.which("uv")
+    if uv:
+        try:
+            out = subprocess.run([uv, "tool", "list"], capture_output=True, text=True, timeout=10)
+            if "koda-cli" in out.stdout:
+                return "uv"
+        except (OSError, subprocess.SubprocessError):
+            pass
+    pipx = shutil.which("pipx")
+    if pipx:
+        try:
+            out = subprocess.run([pipx, "list"], capture_output=True, text=True, timeout=10)
+            if "koda-cli" in out.stdout:
+                return "pipx"
+        except (OSError, subprocess.SubprocessError):
+            pass
+    if sys.prefix != sys.base_prefix:
+        return "venv-pip"
+    if shutil.which("python3"):
+        return "pip"
+    return None
+
+
+def run_update() -> None:
+    """Update koda to the latest version using the detected install method."""
+    method = detect_install_method()
+    if method is None:
+        console.print("[yellow]Could not detect how koda was installed.[/yellow]")
+        console.print("Update manually with one of:")
+        console.print("  uv tool upgrade koda-cli")
+        console.print("  pipx upgrade koda-cli")
+        console.print("  python3 -m pip install --upgrade koda-cli")
+        raise typer.Exit(code=1)
+    cmd = {
+        "uv": ["uv", "tool", "upgrade", "koda-cli"],
+        "pipx": ["pipx", "upgrade", "koda-cli"],
+        "venv-pip": [sys.executable, "-m", "pip", "install", "--upgrade", "koda-cli"],
+        "pip": ["python3", "-m", "pip", "install", "--upgrade", "koda-cli"],
+    }[method]
+    console.print(f"[cyan]Detected install: {method}[/cyan] — running: {' '.join(cmd)}")
+    try:
+        result = subprocess.run(cmd)
+    except OSError as exc:
+        console.print(f"[red]Failed to run update: {exc}[/red]")
+        raise typer.Exit(code=1)
+    raise typer.Exit(code=result.returncode)
+
+
+def update_callback(value: bool) -> None:
+    """Typer eager callback for ``--update``."""
+    if value:
+        run_update()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,192 @@
+"""Self-update tests: ``detect_install_method``, ``run_update``, CLI flags."""
+
+import subprocess
+import sys
+
+import pytest
+import typer
+
+import koda.runtime as runtime
+from koda.commands import update as _update  # noqa: F401  -- register subcommand
+from koda.main import app
+
+# -- helpers -------------------------------------------------------------------
+
+
+def _which_uv(name):
+    return "/usr/bin/uv" if name == "uv" else None
+
+
+def _which_pipx(name):
+    return "/usr/bin/pipx" if name == "pipx" else None
+
+
+def _which_python3(name):
+    return "/usr/bin/python3" if name == "python3" else None
+
+
+# -- detect_install_method ----------------------------------------------------
+
+
+class TestDetectInstallMethod:
+    def test_detects_uv(self, monkeypatch):
+        monkeypatch.setattr(runtime.shutil, "which", _which_uv)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["/usr/bin/uv", "tool"]:
+                stdout = "koda-cli v1.0\nother-tool"
+                return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(runtime.subprocess, "run", fake_run)
+        assert runtime.detect_install_method() == "uv"
+
+    def test_detects_pipx(self, monkeypatch):
+        monkeypatch.setattr(runtime.shutil, "which", _which_pipx)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "/usr/bin/pipx":
+                stdout = "koda-cli 1.0\nother-pkg"
+                return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(runtime.subprocess, "run", fake_run)
+        assert runtime.detect_install_method() == "pipx"
+
+    def test_detects_venv(self, monkeypatch):
+        monkeypatch.setattr(runtime.shutil, "which", lambda _: None)
+        monkeypatch.setattr(runtime.sys, "prefix", "/opt/venv")
+        monkeypatch.setattr(runtime.sys, "base_prefix", "/usr")
+        assert runtime.detect_install_method() == "venv-pip"
+
+    def test_detects_pip(self, monkeypatch):
+        monkeypatch.setattr(runtime.shutil, "which", _which_python3)
+        monkeypatch.setattr(runtime.sys, "prefix", runtime.sys.base_prefix)
+        assert runtime.detect_install_method() == "pip"
+
+    def test_detects_none(self, monkeypatch):
+        monkeypatch.setattr(runtime.shutil, "which", lambda _: None)
+        monkeypatch.setattr(runtime.sys, "prefix", runtime.sys.base_prefix)
+        assert runtime.detect_install_method() is None
+
+
+# -- run_update ---------------------------------------------------------------
+
+
+class TestRunUpdate:
+    def test_runs_uv_upgrade(self, monkeypatch, capsys):
+        monkeypatch.setattr(runtime, "detect_install_method", lambda: "uv")
+        captured = None
+
+        def fake_run(cmd):
+            nonlocal captured
+            captured = cmd
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(runtime.subprocess, "run", fake_run)
+        with pytest.raises(typer.Exit) as exc:
+            runtime.run_update()
+        assert exc.value.exit_code == 0
+        assert captured == ["uv", "tool", "upgrade", "koda-cli"]
+
+    def test_unknown_method_exits_1(self, monkeypatch, capsys):
+        monkeypatch.setattr(runtime, "detect_install_method", lambda: None)
+        with pytest.raises(typer.Exit) as exc:
+            runtime.run_update()
+        assert exc.value.exit_code == 1
+        out = capsys.readouterr().out
+        assert "Could not detect" in out
+
+    def test_pipx_upgrade(self, monkeypatch):
+        monkeypatch.setattr(runtime, "detect_install_method", lambda: "pipx")
+        captured = None
+
+        def fake_run(cmd):
+            nonlocal captured
+            captured = cmd
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(runtime.subprocess, "run", fake_run)
+        with pytest.raises(typer.Exit):
+            runtime.run_update()
+        assert captured == ["pipx", "upgrade", "koda-cli"]
+
+    def test_venv_pip_upgrade(self, monkeypatch):
+        monkeypatch.setattr(runtime, "detect_install_method", lambda: "venv-pip")
+        captured = None
+
+        def fake_run(cmd):
+            nonlocal captured
+            captured = cmd
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(runtime.subprocess, "run", fake_run)
+        with pytest.raises(typer.Exit):
+            runtime.run_update()
+        assert captured[:3] == [sys.executable, "-m", "pip"]
+        assert "--upgrade" in captured
+        assert "koda-cli" in captured
+
+    def test_subprocess_oserror_handled(self, monkeypatch, capsys):
+        monkeypatch.setattr(runtime, "detect_install_method", lambda: "uv")
+
+        def fake_run(_cmd):
+            raise OSError("no such binary")
+
+        monkeypatch.setattr(runtime.subprocess, "run", fake_run)
+        with pytest.raises(typer.Exit) as exc:
+            runtime.run_update()
+        assert exc.value.exit_code == 1
+        out = capsys.readouterr().out
+        assert "Failed to run update" in out
+
+
+# -- CLI level: --update flag ------------------------------------------------
+
+
+class TestUpdateFlag:
+    def test_update_flag_triggers(self, monkeypatch, capsys):
+        monkeypatch.setattr(runtime, "detect_install_method", lambda: "uv")
+        called = False
+
+        def fake_run(_cmd):
+            nonlocal called
+            called = True
+            return subprocess.CompletedProcess([], 0)
+
+        monkeypatch.setattr(runtime.subprocess, "run", fake_run)
+        # app() in standalone mode converts typer.Exit -> SystemExit
+        with pytest.raises(SystemExit):
+            app(["--update"])
+        assert called
+        out = capsys.readouterr().out
+        assert "uv" in out
+
+
+# -- CLI level: update subcommand --------------------------------------------
+
+
+def test_update_subcommand_registered_without_side_effect_import():
+    """main.py の末尾 import だけで update が登録されること(回帰テスト)."""
+    import koda.main as main_mod
+
+    callbacks = {c.callback.__name__ for c in main_mod.app.registered_commands if c.callback}
+    assert "update" in callbacks
+
+
+class TestUpdateSubcommand:
+    def test_update_subcommand_triggers(self, monkeypatch, capsys):
+        monkeypatch.setattr(runtime, "detect_install_method", lambda: "uv")
+        called = False
+
+        def fake_run(_cmd):
+            nonlocal called
+            called = True
+            return subprocess.CompletedProcess([], 0)
+
+        monkeypatch.setattr(runtime.subprocess, "run", fake_run)
+        with pytest.raises(SystemExit):
+            app(["update"])
+        assert called
+        out = capsys.readouterr().out
+        assert "uv" in out


### PR DESCRIPTION
## Summary

Adds a self-update command to koda: `koda --update` (flag) and `koda update` (subcommand).

### What it does
- Detects how koda was installed, in order:
  1. `uv tool list` contains koda-cli → runs `uv tool upgrade koda-cli`
  2. `pipx list` contains koda-cli → runs `pipx upgrade koda-cli`
  3. Running inside a venv → `python -m pip install --upgrade koda-cli`
  4. `python3` on PATH → `python3 -m pip install --upgrade koda-cli`
- If nothing can be detected, prints manual upgrade instructions and exits non-zero.
- `--update` is an eager flag (same pattern as `--version`); `koda update` is a regular subcommand in the Config panel.

### Implementation notes
- Detection lives in `koda.runtime` (`detect_install_method` / `run_update` / `update_callback`); both entry points call the same `run_update`.
- The `update` command module is registered via `main.py`'s bottom import. It is imported on its **own** line because ruff's isort auto-fix (I001) drops an aliased import (`update as _update`) when combined into the multi-name import line — a regression test guards this.
- README Update section and the Quick reference table updated; CHANGELOG entry added under Unreleased.

### Tests
- New `tests/test_update.py`: 13 tests (detection for uv/pipx/venv/pip/none, upgrade command selection, OSError handling, CLI flag + subcommand triggering, registration regression test).
- Full suite: **393 passed**, coverage 69.7%, ruff clean (Python 3.13.5).
