### PR TITLE
feat(sync): add koda push --dry-run and koda diff action summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `koda --update` / `koda update` self-update: detects the install method
   (uv tool, pipx, or pip) and runs the matching upgrade command.
+- `koda push --dry-run` (`-n`): previews new/update/delete before pushing,
+  strictly read-only (no pull --rebase, no commit, no push).
+- `koda diff` now ends with an action summary (would-push / would-pull counts
+  and next-command hints) and is read-only — it fetches from the remote
+  instead of running `git pull --rebase` on the sync clone. (#158)
 
 ## [0.4.0] - 2026-08-10
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Grouped the same way as `koda --help`.
 
 | Command | Alias | Description |
 |---|---|---|
-| [`push`](#push-and-pull) | — | Export DB to Git sync repo and push |
+| [`push`](#push-and-pull) | — | Export DB to Git sync repo and push ( `-n` previews) |
 | [`pull`](#push-and-pull) | — | Pull Git sync repo and merge into local DB |
 
 **Data**
@@ -125,7 +125,7 @@ Grouped the same way as `koda --help`.
 |---|---|---|
 | `export` | — | Write all entries as JSON Lines to stdout or a file |
 | `import` | — | Merge a JSONL file into the local database |
-| `diff` | — | Show a uid-level diff against the remote payload |
+| `diff` | — | uid-level diff + would-push/would-pull summary (read-only) |
 | `backup` | — | Write a single-file SQLite snapshot (`VACUUM INTO`) |
 
 **Index**
@@ -881,6 +881,19 @@ koda config get git.sync_format    # → jsonl            (default)
 koda push   # export DB → koda-sync.jsonl, commit, push to remote
 koda pull   # git pull the clone, merge koda-sync.jsonl into local DB
 ```
+
+**Sync checks (read-only, nothing is written):**
+
+- `koda push -n` / `koda push --dry-run` — preview what a push would change
+  (new / update / delete per entry) without touching the clone, the payload
+  file, or the remote. Shows "Nothing to push" when local and remote payloads
+  are in sync.
+- `koda diff` — uid-level diff plus an action summary: how many memos would be
+  pushed (`koda push`) and pulled (`koda pull`), with the next command to run.
+  Entries changed on both sides resolve by `modified_at` — the newer one wins.
+
+Both checks are strictly read-only: they fetch from `origin/<branch>` and never
+run `git pull --rebase`, so the sync clone's working tree is left untouched.
 
 `push` does a `git pull --rebase` before writing the payload so the branch stays linear. `pull` merges by `uid` — entries that already exist locally are updated only if the incoming `modified_at` is newer.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koda-cli"
-version = "0.4.0"
+version = "0.5.0"
 description = "A fast CLI memo store and command launcher backed by SQLite or Turso."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -90,6 +90,41 @@ def _print_merge_plan(data: bytes) -> None:
     )
 
 
+def _print_push_plan(local_data: bytes) -> None:
+    """Show what a push would add/update/delete without writing (`--dry-run`)."""
+    remote_data = _obtain_remote_payload_readonly(None)
+    try:
+        local_rows = git_sync.GitSyncPayload.load(local_data)
+        remote_rows = git_sync.GitSyncPayload.load(remote_data)
+    except Exception as e:
+        exit_error(f"Invalid sync payload: {e}")
+
+    local = {r["uid"]: r for r in local_rows}
+    remote = {r["uid"]: r for r in remote_rows}
+    new = sorted(set(local) - set(remote))
+    deleted = sorted(set(remote) - set(local))
+    updated = sorted(uid for uid in set(local) & set(remote) if local[uid] != remote[uid])
+
+    if not (new or updated or deleted):
+        console.print("[green]Nothing to push — local and remote payloads are in sync.[/green]")
+    for uid in new:
+        console.print(
+            f"[green]+ new[/green]     {uid}  [{local[uid]['idx']}]  {_preview(local[uid]['content'])}"
+        )
+    for uid in updated:
+        console.print(
+            f"[yellow]~ update[/yellow]  {uid}  [{local[uid]['idx']}]  {_preview(local[uid]['content'])}"
+        )
+    for uid in deleted:
+        console.print(
+            f"[red]- delete[/red]   {uid}  [{remote[uid]['idx']}]  {_preview(remote[uid]['content'])}"
+        )
+    console.print(
+        f"[dim]{len(new)} new, {len(updated)} update, {len(deleted)} delete "
+        f"— dry run, no changes written.[/dim]"
+    )
+
+
 def _merge_payload(data: bytes) -> None:
     """Load a JSONL payload and merge it into the local DB, printing a summary."""
     try:
@@ -114,8 +149,17 @@ def push(
     payload_file: Path | None = typer.Option(
         None, "--file", help="Use this JSONL file instead of exporting the local database."
     ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        "-n",
+        help="Show what would be pushed (new/update/delete) without writing anything.",
+    ),
 ):
     """Write memo export (JSON Lines, uid-sorted) into the Git clone, commit, and push.
+
+    Use `-n` to preview what a push would change; nothing is written
+    (no pull, no commit, no push).
 
     Alias: `koda push`.
     """
@@ -138,6 +182,10 @@ def push(
             exit_error(f"Invalid sync payload: {e}")
     else:
         data = git_sync.GitSyncPayload.dump(get_db())
+
+    if dry_run:
+        _print_push_plan(data)
+        return
 
     repo.pull_rebase_if_remote()
 

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -30,6 +30,32 @@ def _obtain_remote_payload(local_payload_path: Path | None) -> bytes:
     return payload_path.read_bytes()
 
 
+def _obtain_remote_payload_readonly(local_payload_path: Path | None) -> bytes:
+    """Return payload bytes for a *check* (diff / push --dry-run): read-only.
+
+    Never mutates the clone worktree — uses ``git fetch`` + ``origin/<branch>``
+    instead of ``pull --rebase``. With no remote, falls back to the worktree
+    payload file (what push would commit locally); missing → empty payload.
+    """
+    git_sync.require_jsonl_format(get_config())
+    if local_payload_path is not None:
+        if not local_payload_path.is_file():
+            exit_error(f"--file does not exist: {local_payload_path}")
+        return local_payload_path.read_bytes()
+    git_sync.require_git_cli()
+    sync_root = git_sync.resolve_sync_root(get_config())
+    repo = git_sync.GitSyncRepo(sync_root)
+    repo.ensure_worktree()
+    payload_path = git_sync.resolve_payload_path(get_config(), sync_root)
+    rel = payload_path.relative_to(sync_root).as_posix()
+    data = repo.fetch_remote_payload(rel)
+    if data is not None:
+        return data
+    if payload_path.is_file():
+        return payload_path.read_bytes()
+    return b""
+
+
 def _preview(content: str, width: int = 50) -> str:
     """First line of ``content``, collapsed and truncated for one-line display."""
     first = (content or "").splitlines()[0] if content else ""
@@ -217,7 +243,7 @@ def diff(
     changed (different content, tags, shortcut, or modified_at).
     """
     init_db()
-    data = _obtain_remote_payload(local_payload_path)
+    data = _obtain_remote_payload_readonly(local_payload_path)
     try:
         remote_rows = git_sync.GitSyncPayload.load(data)
     except Exception as e:

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -109,15 +109,18 @@ def _print_push_plan(local_data: bytes) -> None:
         console.print("[green]Nothing to push — local and remote payloads are in sync.[/green]")
     for uid in new:
         console.print(
-            f"[green]+ new[/green]     {uid}  [{local[uid]['idx']}]  {_preview(local[uid]['content'])}"
+            f"[green]+ new[/green]     {uid}"
+            f"  [{local[uid]['idx']}]  {_preview(local[uid]['content'])}"
         )
     for uid in updated:
         console.print(
-            f"[yellow]~ update[/yellow]  {uid}  [{local[uid]['idx']}]  {_preview(local[uid]['content'])}"
+            f"[yellow]~ update[/yellow]  {uid}"
+            f"  [{local[uid]['idx']}]  {_preview(local[uid]['content'])}"
         )
     for uid in deleted:
         console.print(
-            f"[red]- delete[/red]   {uid}  [{remote[uid]['idx']}]  {_preview(remote[uid]['content'])}"
+            f"[red]- delete[/red]   {uid}"
+            f"  [{remote[uid]['idx']}]  {_preview(remote[uid]['content'])}"
         )
     console.print(
         f"[dim]{len(new)} new, {len(updated)} update, {len(deleted)} delete "

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -329,6 +329,26 @@ def diff(
         f"{len(changed)} changed[/dim]"
     )
 
+    would_push = len(local_only) + len(changed)
+    would_pull = len(remote_only) + len(changed)
+    console.print(
+        f"[bold cyan]{would_push}[/bold cyan] memos would be pushed "
+        f"[dim](koda push)[/dim] — {len(local_only)} new, {len(changed)} changed"
+    )
+    console.print(
+        f"[bold cyan]{would_pull}[/bold cyan] memos would be pulled "
+        f"[dim](koda pull)[/dim] — {len(remote_only)} new, {len(changed)} changed"
+    )
+    if changed:
+        console.print(
+            "[dim]Entries changed on both sides resolve by modified_at — "
+            "the newer one wins (last-writer-wins).[/dim]"
+        )
+    console.print(
+        "[dim]Next: run `koda push` to sync local changes, "
+        "`koda pull` to fetch remote changes.[/dim]"
+    )
+
 
 @app.command(rich_help_panel="Data")
 def backup(

--- a/src/koda/git_sync.py
+++ b/src/koda/git_sync.py
@@ -334,6 +334,45 @@ class GitSyncRepo:
                 console.print(f"[dim]{e.stderr.strip()}[/dim]")
             exit_error("git push failed.")
 
+    def fetch_remote_payload(self, rel_path: str) -> bytes | None:
+        """Return the payload bytes from ``<remote>/<branch>`` without touching
+        the worktree: ``git fetch`` then ``git show`` the blob from the fetched
+        ref. Returns None when the payload file does not exist on the remote
+        (treated as an empty payload by callers). Never runs pull --rebase."""
+        if not self.has_remote():
+            return None
+        remote = self.preferred_remote()
+        if not remote:
+            exit_error("No Git remote resolved for fetch in the sync clone.")
+        branch = self.current_branch()
+        if not branch:
+            exit_error(
+                "Cannot fetch in detached HEAD in the sync clone. "
+                "Check out a branch, then retry."
+            )
+        try:
+            subprocess.run(
+                ["git", "-C", str(self.sync_root), "fetch", remote, branch],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            console.print(
+                "[red]git fetch failed in the sync clone. "
+                "Check the network/remote and retry.[/red]"
+            )
+            if e.stderr:
+                console.print(f"[dim]{e.stderr.strip()}[/dim]")
+            exit_error("git fetch failed.")
+        r = subprocess.run(
+            ["git", "-C", str(self.sync_root), "show", f"{remote}/{branch}:{rel_path}"],
+            capture_output=True,
+        )
+        if r.returncode != 0:
+            return None
+        return r.stdout
+
 
 # ── Merge into local DB ─────────────────────────────────────────────────────
 

--- a/src/koda/git_sync.py
+++ b/src/koda/git_sync.py
@@ -347,8 +347,7 @@ class GitSyncRepo:
         branch = self.current_branch()
         if not branch:
             exit_error(
-                "Cannot fetch in detached HEAD in the sync clone. "
-                "Check out a branch, then retry."
+                "Cannot fetch in detached HEAD in the sync clone. Check out a branch, then retry."
             )
         try:
             subprocess.run(
@@ -359,8 +358,7 @@ class GitSyncRepo:
             )
         except subprocess.CalledProcessError as e:
             console.print(
-                "[red]git fetch failed in the sync clone. "
-                "Check the network/remote and retry.[/red]"
+                "[red]git fetch failed in the sync clone. Check the network/remote and retry.[/red]"
             )
             if e.stderr:
                 console.print(f"[dim]{e.stderr.strip()}[/dim]")

--- a/tests/test_diff_backup.py
+++ b/tests/test_diff_backup.py
@@ -119,3 +119,43 @@ def test_diff_readonly_does_not_pull_rebase(wired_db, tmp_path, monkeypatch, cap
 
     git_cmd.diff(local_payload_path=None)
     assert "in sync" in capsys.readouterr().out
+
+
+"""--- #158: diff action summary ---"""
+
+
+def test_diff_summary_counts_and_hints(wired_db, tmp_path, capsys):
+    _seed(wired_db, 0, "alpha")
+    remote = tmp_path / "remote.jsonl"
+    git_cmd.export(out=remote)
+    # 分岐: local-only(uid0002) / remote-only(uid9999) / changed(uid0001)
+    _seed(wired_db, 2, "gamma")
+    with wired_db.connection() as conn:
+        conn.execute(
+            "UPDATE memos SET tags = ?, modified_at = ? WHERE idx = 0",
+            ("edited", "2026-02-01 00:00:00"),
+        )
+    remote.write_bytes(
+        (
+            remote.read_bytes()
+            + b'{"uid":"uid9999","idx":9,"content":"zeta","tags":"","created_at":'
+            b'"2026-01-01 00:00:00","modified_at":"2026-01-01 00:00:00","title":null}\n'
+        )
+    )
+
+    git_cmd.diff(local_payload_path=remote)
+    out = capsys.readouterr().out
+    assert "2 memos would be pushed" in out  # local-only 1 + changed 1
+    assert "2 memos would be pulled" in out  # remote-only 1 + changed 1
+    assert "koda push" in out and "koda pull" in out
+    assert "modified_at" in out  # last-writer-wins 注記
+
+
+def test_diff_in_sync_has_no_summary(wired_db, tmp_path, capsys):
+    _seed(wired_db, 0, "alpha")
+    remote = tmp_path / "remote.jsonl"
+    git_cmd.export(out=remote)
+    git_cmd.diff(local_payload_path=remote)
+    out = capsys.readouterr().out
+    assert "No differences" in out
+    assert "would be pushed" not in out

--- a/tests/test_diff_backup.py
+++ b/tests/test_diff_backup.py
@@ -1,5 +1,7 @@
 """Tests for the diff and backup commands (#74)."""
 
+import subprocess
+
 import pytest
 
 import koda.runtime as runtime
@@ -77,7 +79,6 @@ def test_backup_refuses_existing(wired_db, tmp_path):
 
 
 """--- #158: diff must not mutate the clone worktree ---"""
-import subprocess
 
 
 def _git(*args, cwd=None):
@@ -135,13 +136,11 @@ def test_diff_summary_counts_and_hints(wired_db, tmp_path, capsys):
             "UPDATE memos SET tags = ?, modified_at = ? WHERE idx = 0",
             ("edited", "2026-02-01 00:00:00"),
         )
-    remote.write_bytes(
-        (
-            remote.read_bytes()
-            + b'{"uid":"uid9999","idx":9,"content":"zeta","tags":"","created_at":'
-            b'"2026-01-01 00:00:00","modified_at":"2026-01-01 00:00:00","title":null}\n'
-        )
+    new_remote_data = (
+        remote.read_bytes() + b'{"uid":"uid9999","idx":9,"content":"zeta","tags":"","created_at":'
+        b'"2026-01-01 00:00:00","modified_at":"2026-01-01 00:00:00","title":null}\n'
     )
+    remote.write_bytes(new_remote_data)
 
     git_cmd.diff(local_payload_path=remote)
     out = capsys.readouterr().out

--- a/tests/test_diff_backup.py
+++ b/tests/test_diff_backup.py
@@ -74,3 +74,48 @@ def test_backup_refuses_existing(wired_db, tmp_path):
     dest.write_text("x")
     with pytest.raises(typer.Exit):
         git_cmd.backup(out=dest)
+
+
+"""--- #158: diff must not mutate the clone worktree ---"""
+import subprocess
+
+
+def _git(*args, cwd=None):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _sync_pair(tmp_path):
+    remote = tmp_path / "remote.git"
+    _git("init", "--bare", str(remote))
+    clone = tmp_path / "clone"
+    _git("clone", str(remote), str(clone))
+    _git("-C", str(clone), "config", "user.name", "Test")
+    _git("-C", str(clone), "config", "user.email", "test@example.com")
+    return remote, clone
+
+
+def _seed_payload(clone, payload_bytes):
+    (clone / "koda-sync.jsonl").write_bytes(payload_bytes)
+    _git("-C", str(clone), "add", "koda-sync.jsonl")
+    _git("-C", str(clone), "commit", "-m", "seed")
+    _git("-C", str(clone), "push", "-u", "origin", "HEAD")
+
+
+def test_diff_readonly_does_not_pull_rebase(wired_db, tmp_path, monkeypatch, capsys):
+    import koda.runtime as runtime
+    from koda.config import Config
+    from koda.git_sync import GitSyncRepo
+
+    _, clone = _sync_pair(tmp_path)
+    _seed_payload(clone, b"")  # remote に空 payload（＝差分なし想定）
+    monkeypatch.setattr(runtime, "_config", Config(git_sync_path=str(clone)))
+    monkeypatch.setattr(runtime, "_db", wired_db)
+
+    # pull --rebase が呼ばれたら即失敗させる（読み取り専用の証明）
+    def _boom(self):
+        raise AssertionError("diff must not call pull_rebase_if_remote")
+
+    monkeypatch.setattr(GitSyncRepo, "pull_rebase_if_remote", _boom)
+
+    git_cmd.diff(local_payload_path=None)
+    assert "in sync" in capsys.readouterr().out

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -1,6 +1,7 @@
 """Tests for GitSyncPayload load/dump round-trips and parsing."""
 
 import json
+import subprocess
 
 import pytest
 import typer
@@ -184,7 +185,6 @@ def test_legacy_payload_line_without_title_parses():
 
 
 """--- #158: read-only remote payload fetch ---"""
-import subprocess
 
 
 def _git(*args, cwd=None):
@@ -245,12 +245,10 @@ def test_fetch_remote_payload_does_not_touch_worktree(tmp_path, sync_pair):
     _git("-C", str(clone), "push", "-f", "origin", "HEAD")
 
     head_before = subprocess.run(
-        ["git", "-C", str(clone), "rev-parse", "HEAD"],
-        capture_output=True, text=True
+        ["git", "-C", str(clone), "rev-parse", "HEAD"], capture_output=True, text=True
     ).stdout.strip()
     status_before = subprocess.run(
-        ["git", "-C", str(clone), "status", "--porcelain"],
-        capture_output=True, text=True
+        ["git", "-C", str(clone), "status", "--porcelain"], capture_output=True, text=True
     ).stdout
     marker_before = marker.read_text()
 
@@ -259,13 +257,11 @@ def test_fetch_remote_payload_does_not_touch_worktree(tmp_path, sync_pair):
     assert marker.read_text() == marker_before
 
     head_after = subprocess.run(
-        ["git", "-C", str(clone), "rev-parse", "HEAD"],
-        capture_output=True, text=True
+        ["git", "-C", str(clone), "rev-parse", "HEAD"], capture_output=True, text=True
     ).stdout.strip()
     assert head_after == head_before
 
     status_after = subprocess.run(
-        ["git", "-C", str(clone), "status", "--porcelain"],
-        capture_output=True, text=True
+        ["git", "-C", str(clone), "status", "--porcelain"], capture_output=True, text=True
     ).stdout
     assert status_after == status_before

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -181,3 +181,91 @@ def test_legacy_payload_line_without_title_parses():
     data = b'{"uid":"uid0001","idx":0,"content":"x"}\n'
     loaded = GitSyncPayload.load(data)
     assert loaded[0]["title"] is None
+
+
+"""--- #158: read-only remote payload fetch ---"""
+import subprocess
+
+
+def _git(*args, cwd=None):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def sync_pair(tmp_path):
+    """bare remote + clone のペアを作る。clone の初期ブランチ名は不問。"""
+    remote = tmp_path / "remote.git"
+    _git("init", "--bare", str(remote))
+    clone = tmp_path / "clone"
+    _git("clone", str(remote), str(clone))
+    _git("-C", str(clone), "config", "user.name", "Test")
+    _git("-C", str(clone), "config", "user.email", "test@example.com")
+    return remote, clone
+
+
+def test_fetch_remote_payload_reads_origin_blob(tmp_path, sync_pair):
+    from koda.git_sync import GitSyncRepo
+
+    _, clone = sync_pair
+    (clone / "koda-sync.jsonl").write_bytes(b'{"uid":"uid0001","idx":0,"content":"x"}\n')
+    _git("-C", str(clone), "add", "koda-sync.jsonl")
+    _git("-C", str(clone), "commit", "-m", "seed")
+    _git("-C", str(clone), "push", "-u", "origin", "HEAD")
+
+    data = GitSyncRepo(clone).fetch_remote_payload("koda-sync.jsonl")
+    assert data == b'{"uid":"uid0001","idx":0,"content":"x"}\n'
+
+
+def test_fetch_remote_payload_missing_file_returns_none(tmp_path, sync_pair):
+    from koda.git_sync import GitSyncRepo
+
+    _, clone = sync_pair
+    (clone / "other.txt").write_text("hello")
+    _git("-C", str(clone), "add", "other.txt")
+    _git("-C", str(clone), "commit", "-m", "seed")
+    _git("-C", str(clone), "push", "-u", "origin", "HEAD")
+    assert GitSyncRepo(clone).fetch_remote_payload("koda-sync.jsonl") is None
+
+
+def test_fetch_remote_payload_does_not_touch_worktree(tmp_path, sync_pair):
+    from koda.git_sync import GitSyncRepo
+
+    _, clone = sync_pair
+
+    marker = clone / "dirty.txt"
+    marker.write_text("dirty")
+
+    (clone / "koda-sync.jsonl").write_bytes(b'{"uid":"uid0001","idx":0,"content":"x"}\n')
+    _git("-C", str(clone), "add", ".")
+    _git("-C", str(clone), "commit", "-m", "seed")
+    _git("-C", str(clone), "push", "-u", "origin", "HEAD")
+
+    # Amend local commit and force-push to advance remote beyond clone's HEAD
+    _git("-C", str(clone), "commit", "--allow-empty", "-m", "advance", "--amend")
+    _git("-C", str(clone), "push", "-f", "origin", "HEAD")
+
+    head_before = subprocess.run(
+        ["git", "-C", str(clone), "rev-parse", "HEAD"],
+        capture_output=True, text=True
+    ).stdout.strip()
+    status_before = subprocess.run(
+        ["git", "-C", str(clone), "status", "--porcelain"],
+        capture_output=True, text=True
+    ).stdout
+    marker_before = marker.read_text()
+
+    GitSyncRepo(clone).fetch_remote_payload("koda-sync.jsonl")
+
+    assert marker.read_text() == marker_before
+
+    head_after = subprocess.run(
+        ["git", "-C", str(clone), "rev-parse", "HEAD"],
+        capture_output=True, text=True
+    ).stdout.strip()
+    assert head_after == head_before
+
+    status_after = subprocess.run(
+        ["git", "-C", str(clone), "status", "--porcelain"],
+        capture_output=True, text=True
+    ).stdout
+    assert status_after == status_before

--- a/tests/test_push_dry_run.py
+++ b/tests/test_push_dry_run.py
@@ -1,0 +1,127 @@
+"""koda push --dry-run (#158): preview only, never writes."""
+
+import json
+import subprocess
+
+import pytest
+
+import koda.runtime as runtime
+from koda.commands import git as git_cmd
+from koda.config import Config
+from koda.git_sync import GitSyncRepo
+
+
+def _git(*args, cwd=None):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _line(uid, idx, content, modified="2026-01-01 00:00:00"):
+    return json.dumps(
+        {
+            "uid": uid,
+            "idx": idx,
+            "shortcut": None,
+            "content": content,
+            "tags": "",
+            "created_at": "2026-01-01 00:00:00",
+            "modified_at": modified,
+            "title": None,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+@pytest.fixture
+def wired(db, monkeypatch):
+    monkeypatch.setattr(runtime, "_db", db)
+    return db
+
+
+@pytest.fixture
+def sync_env(wired, tmp_path, monkeypatch):
+    remote = tmp_path / "remote.git"
+    _git("init", "--bare", str(remote))
+    clone = tmp_path / "clone"
+    _git("clone", str(remote), str(clone))
+    _git("-C", str(clone), "config", "user.name", "Test")
+    _git("-C", str(clone), "config", "user.email", "test@example.com")
+    monkeypatch.setattr(runtime, "_config", Config(git_sync_path=str(clone)))
+    return clone
+
+
+def _seed_remote(clone, lines):
+    (clone / "koda-sync.jsonl").write_bytes(("\n".join(lines) + "\n").encode())
+    _git("-C", str(clone), "add", "koda-sync.jsonl")
+    _git("-C", str(clone), "commit", "-m", "seed")
+    _git("-C", str(clone), "push", "-u", "origin", "HEAD")
+
+
+def test_push_dry_run_lists_new_update_delete(sync_env, capsys):
+    # remote: uidA(同値) / uidB(更新される) / uidC(削除される)
+    _seed_remote(
+        sync_env,
+        [
+            _line("uidA", 0, "alpha"),
+            _line("uidB", 1, "beta-old"),
+            _line("uidC", 2, "charlie"),
+        ],
+    )
+    # local: uidA(同値) / uidB(変更) / uidD(新規)
+    runtime.get_db().add_memo("uidA", 0, None, "alpha", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+    runtime.get_db().add_memo("uidB", 1, None, "beta-new", "", "2026-02-01 00:00:00", "2026-02-01 00:00:00")
+    runtime.get_db().add_memo("uidD", 3, None, "delta", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+
+    git_cmd.push(payload_file=None, dry_run=True)
+    out = capsys.readouterr().out
+    assert "+ new" in out and "uidD" in out
+    assert "~ update" in out and "uidB" in out
+    assert "- delete" in out and "uidC" in out
+    assert "1 new, 1 update, 1 delete" in out
+    assert "dry run" in out
+
+
+def test_push_dry_run_nothing_to_push(sync_env, capsys):
+    _seed_remote(sync_env, [_line("uidA", 0, "alpha")])
+    runtime.get_db().add_memo("uidA", 0, None, "alpha", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+
+    git_cmd.push(payload_file=None, dry_run=True)
+    assert "Nothing to push" in capsys.readouterr().out
+
+
+def test_push_dry_run_writes_nothing(sync_env, capsys):
+    _seed_remote(sync_env, [_line("uidA", 0, "alpha")])
+    runtime.get_db().add_memo("uidB", 0, None, "beta", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+    payload_before = (sync_env / "koda-sync.jsonl").read_bytes()
+    head_before = subprocess.run(
+        ["git", "-C", str(sync_env), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+    ).stdout
+
+    git_cmd.push(payload_file=None, dry_run=True)
+    assert (sync_env / "koda-sync.jsonl").read_bytes() == payload_before  # ファイル不変
+    head_after = subprocess.run(
+        ["git", "-C", str(sync_env), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert head_after == head_before  # コミットなし
+    assert "koda: sync memo payload" not in subprocess.run(
+        ["git", "-C", str(sync_env), "log", "--oneline"],
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def test_push_dry_run_never_pulls_or_pushes(sync_env, monkeypatch, capsys):
+    def _boom(self):
+        raise AssertionError("dry-run must not pull --rebase")
+
+    monkeypatch.setattr(GitSyncRepo, "pull_rebase_if_remote", _boom)
+
+    _seed_remote(sync_env, [_line("uidA", 0, "alpha")])
+    runtime.get_db().add_memo("uidB", 0, None, "beta", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+    git_cmd.push(payload_file=None, dry_run=True)  # ここが通れば pull_rebase_if_remote は呼ばれていない
+    assert "1 new" in capsys.readouterr().out

--- a/tests/test_push_dry_run.py
+++ b/tests/test_push_dry_run.py
@@ -69,9 +69,15 @@ def test_push_dry_run_lists_new_update_delete(sync_env, capsys):
         ],
     )
     # local: uidA(同値) / uidB(変更) / uidD(新規)
-    runtime.get_db().add_memo("uidA", 0, None, "alpha", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
-    runtime.get_db().add_memo("uidB", 1, None, "beta-new", "", "2026-02-01 00:00:00", "2026-02-01 00:00:00")
-    runtime.get_db().add_memo("uidD", 3, None, "delta", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+    runtime.get_db().add_memo(
+        "uidA", 0, None, "alpha", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00"
+    )
+    runtime.get_db().add_memo(
+        "uidB", 1, None, "beta-new", "", "2026-02-01 00:00:00", "2026-02-01 00:00:00"
+    )
+    runtime.get_db().add_memo(
+        "uidD", 3, None, "delta", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00"
+    )
 
     git_cmd.push(payload_file=None, dry_run=True)
     out = capsys.readouterr().out
@@ -84,7 +90,9 @@ def test_push_dry_run_lists_new_update_delete(sync_env, capsys):
 
 def test_push_dry_run_nothing_to_push(sync_env, capsys):
     _seed_remote(sync_env, [_line("uidA", 0, "alpha")])
-    runtime.get_db().add_memo("uidA", 0, None, "alpha", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+    runtime.get_db().add_memo(
+        "uidA", 0, None, "alpha", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00"
+    )
 
     git_cmd.push(payload_file=None, dry_run=True)
     assert "Nothing to push" in capsys.readouterr().out
@@ -92,7 +100,9 @@ def test_push_dry_run_nothing_to_push(sync_env, capsys):
 
 def test_push_dry_run_writes_nothing(sync_env, capsys):
     _seed_remote(sync_env, [_line("uidA", 0, "alpha")])
-    runtime.get_db().add_memo("uidB", 0, None, "beta", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
+    runtime.get_db().add_memo(
+        "uidB", 0, None, "beta", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00"
+    )
     payload_before = (sync_env / "koda-sync.jsonl").read_bytes()
     head_before = subprocess.run(
         ["git", "-C", str(sync_env), "rev-parse", "HEAD"],
@@ -108,11 +118,14 @@ def test_push_dry_run_writes_nothing(sync_env, capsys):
         text=True,
     ).stdout
     assert head_after == head_before  # コミットなし
-    assert "koda: sync memo payload" not in subprocess.run(
-        ["git", "-C", str(sync_env), "log", "--oneline"],
-        capture_output=True,
-        text=True,
-    ).stdout
+    assert (
+        "koda: sync memo payload"
+        not in subprocess.run(
+            ["git", "-C", str(sync_env), "log", "--oneline"],
+            capture_output=True,
+            text=True,
+        ).stdout
+    )
 
 
 def test_push_dry_run_never_pulls_or_pushes(sync_env, monkeypatch, capsys):
@@ -122,6 +135,10 @@ def test_push_dry_run_never_pulls_or_pushes(sync_env, monkeypatch, capsys):
     monkeypatch.setattr(GitSyncRepo, "pull_rebase_if_remote", _boom)
 
     _seed_remote(sync_env, [_line("uidA", 0, "alpha")])
-    runtime.get_db().add_memo("uidB", 0, None, "beta", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00")
-    git_cmd.push(payload_file=None, dry_run=True)  # ここが通れば pull_rebase_if_remote は呼ばれていない
+    runtime.get_db().add_memo(
+        "uidB", 0, None, "beta", "", "2026-01-01 00:00:00", "2026-01-01 00:00:00"
+    )
+    git_cmd.push(
+        payload_file=None, dry_run=True
+    )  # ここが通れば pull_rebase_if_remote は呼ばれていない
     assert "1 new" in capsys.readouterr().out

--- a/uv.lock
+++ b/uv.lock
@@ -217,7 +217,7 @@ wheels = [
 
 [[package]]
 name = "koda-cli"
-version = "1.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary

- Add `koda push --dry-run` (`-n`): previews what a push would change (new / update / delete per memo) without writing anything — no pull, no commit, no push.
- Extend `koda diff` with an action-oriented summary: would-push / would-pull counts plus next-command hints, so it works as the pre-sync check.
- Make both check commands strictly read-only: they now `git fetch` and compare against `origin/<branch>` instead of running `git pull --rebase` on the sync clone.

## Motivation

Closes #158. `koda pull -n` existed but `koda push` had no dry-run (asymmetry), and `koda diff` was the only check — but it (a) showed only a uid-level list with no action summary and (b) mutated the sync clone's worktree via `git pull --rebase`. Per the issue's agreed direction, no new command (`status`/`fetch`) is introduced.

## Changes

- `src/koda/git_sync.py`: new `GitSyncRepo.fetch_remote_payload()` — read-only remote payload retrieval via `git fetch` + `git show <remote>/<branch>:<payload>`; returns `None` when the payload file does not exist on the remote.
- `src/koda/commands/git.py`:
  - `push` gains `--dry-run` / `-n` → `_print_push_plan()` lists new / update / delete against the remote payload, prints "Nothing to push" when in sync, and never pulls, commits, or pushes.
  - `diff` now uses `_obtain_remote_payload_readonly()` (fetch-based) and appends a would-push / would-pull summary with command hints and a last-writer-wins note on `modified_at`.
- `README.md`: new "Sync checks (read-only, nothing is written)" subsection in the Push and pull section.
- `CHANGELOG.md`: entries added under [Unreleased] → Added.
- Version bumped 0.4.0 → 0.5.0; `uv.lock` re-synced (it was stale at 1.4.0 while pyproject.toml was already 0.4.0).
- Tests: new `tests/test_push_dry_run.py` (with real bare-remote/clone fixtures in tmp_path — a first for this repo), plus read-only assertions added to `tests/test_diff_backup.py` and `tests/test_git_sync.py`.

## Test Plan

- [x] `uv run pytest tests/ -q` → **403 passed** (coverage 71.37%, threshold 60%)
- [x] `uv run ruff check src tests` → All checks passed
- [x] `uv run ruff format --check src tests` → 55 files already formatted
- [x] New tests cover: `push -n` (new/update/delete, nothing-to-push, zero writes, never calls `pull_rebase_if_remote`), diff action summary, and worktree non-mutation for both check paths

## Notes for Reviewers

- `pull` behavior is unchanged (still `git pull --rebase`); only the check paths (`diff`, `push -n`) are read-only.
- `push -n` compares full payload records (uid, idx, shortcut, content, tags, created_at, modified_at, title) — an idx-only change (e.g. after `koda move`) is reported as "update", matching exactly what git would see as a payload diff. The existing `diff` "changed" classification (content/tags/shortcut/modified_at) is intentionally left as-is; it is the pull-oriented view.
- `git fetch` requires network: when offline, `diff` / `push -n` fail with a clear error (symmetric with `pull`).
- All acceptance criteria from #158 are implemented (see the issue checklist).

Closes #158
