### PR TITLE
fix(store): migrate skips existing uid rows and records a skip list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `koda --update` / `koda update` self-update: detects the install method
   (uv tool, pipx, or pip) and runs the matching upgrade command.
 
+### Fixed
+- `koda migrate` now skips legacy rows whose uid already exists in the vault
+  instead of writing a duplicate `.md` file. Skipped rows are recorded as a
+  koda entry (tag: `migrate`) and listed in the command output — nothing is
+  overwritten or deleted.
+- `reconcile`: when two `entries/*.md` files share a uid, the cache now
+  deterministically reflects the last file (filename order) on every run
+  instead of flip-flopping between the two (mtime-gate skip no longer
+  overrides a same-scan duplicate).
+
 ## [0.4.0] - 2026-08-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koda-cli"
-version = "0.5.0"
+version = "0.5.1"
 description = "A fast CLI memo store and command launcher backed by plain Markdown files (Obsidian / editor / AI friendly)."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/koda/commands/manage.py
+++ b/src/koda/commands/manage.py
@@ -102,7 +102,9 @@ def migrate(
             f"[dim]Open {get_entries_dir().parent} in Obsidian, or `koda list` to verify.[/dim]"
         )
     else:
-        console.print(f"[dim]Open {get_entries_dir().parent} in Obsidian, or `koda list` to verify.[/dim]")
+        console.print(
+            f"[dim]Open {get_entries_dir().parent} in Obsidian, or `koda list` to verify.[/dim]"
+        )
 
 
 def _record_skipped(skipped: list[dict]) -> None:
@@ -121,10 +123,7 @@ def _record_skipped(skipped: list[dict]) -> None:
             f"| {s['uid']} | {s['idx'] if s['idx'] is not None else ''} | "
             f"{s['shortcut'] or ''} | {s['title'] or ''} |"
         )
-    title = (
-        f"migrate: skipped {len(skipped)} duplicate "
-        f"entr{'y' if len(skipped) == 1 else 'ies'}"
-    )
+    title = f"migrate: skipped {len(skipped)} duplicate entr{'y' if len(skipped) == 1 else 'ies'}"
     _write_new_entry("\n".join(lines), tags="migrate", shortcut=None, title=title)
 
 

--- a/src/koda/commands/manage.py
+++ b/src/koda/commands/manage.py
@@ -82,11 +82,50 @@ def migrate(
         write_entry(entries_dir, entry)
         count += 1
 
+    if skipped:
+        _record_skipped(skipped)
+
     reconcile_all(get_db(), entries_dir, force=True)
     console.print(
-        f"[green]Migrated {count} entr{'y' if count == 1 else 'ies'} to {entries_dir}.[/green]\n"
-        f"[dim]Open {get_entries_dir().parent} in Obsidian, or `koda list` to verify.[/dim]"
+        f"[green]Migrated {count} entr{'y' if count == 1 else 'ies'} to {entries_dir}.[/green]"
     )
+    for s in skipped:
+        console.print(
+            f"[yellow]Skipped {s['uid']}[/yellow] "
+            f"(idx {s['idx'] if s['idx'] is not None else '-'}): "
+            f"uid already exists in the vault — no file written."
+        )
+    if skipped:
+        console.print(
+            f"[dim]Skipped {len(skipped)} duplicate entr{'y' if len(skipped) == 1 else 'ies'} "
+            f"recorded as a koda entry (tag: migrate).[/dim]\n"
+            f"[dim]Open {get_entries_dir().parent} in Obsidian, or `koda list` to verify.[/dim]"
+        )
+    else:
+        console.print(f"[dim]Open {get_entries_dir().parent} in Obsidian, or `koda list` to verify.[/dim]")
+
+
+def _record_skipped(skipped: list[dict]) -> None:
+    from .memo import _write_new_entry
+
+    lines = [
+        "These koda.db rows were skipped by `koda migrate` because the vault",
+        "already has an entry with the same uid. Nothing was overwritten or",
+        "deleted.",
+        "",
+        "| uid | idx | shortcut | title |",
+        "| --- | --- | --- | --- |",
+    ]
+    for s in skipped:
+        lines.append(
+            f"| {s['uid']} | {s['idx'] if s['idx'] is not None else ''} | "
+            f"{s['shortcut'] or ''} | {s['title'] or ''} |"
+        )
+    title = (
+        f"migrate: skipped {len(skipped)} duplicate "
+        f"entr{'y' if len(skipped) == 1 else 'ies'}"
+    )
+    _write_new_entry("\n".join(lines), tags="migrate", shortcut=None, title=title)
 
 
 @app.command(rich_help_panel="Data")

--- a/src/koda/commands/manage.py
+++ b/src/koda/commands/manage.py
@@ -51,12 +51,24 @@ def migrate(
     finally:
         conn.close()
 
+    existing_uids = set(get_db().manifest().keys())
     count = 0
+    skipped: list[dict] = []
     for row in rows:
         d = dict(zip(cols, row))
         content = d.get("content") or ""
         created_at = d.get("created_at")
         uid = d.get("uid") or compute_uid(content, created_at or "")
+        if uid in existing_uids:
+            skipped.append(
+                {
+                    "uid": uid,
+                    "idx": d.get("idx"),
+                    "shortcut": d.get("shortcut"),
+                    "title": d.get("title"),
+                }
+            )
+            continue
         entry = MdEntry(
             content=content,
             uid=uid,

--- a/src/koda/reconcile.py
+++ b/src/koda/reconcile.py
@@ -112,9 +112,14 @@ def reconcile_all(db: MemoDatabase, entries_dir: Path, *, force: bool = False) -
         present.add(rel)
         mtime = path.stat().st_mtime
         prior_uid = by_path.get(rel)
-        if not force and prior_uid and manifest.get(prior_uid, {}).get("mtime") == mtime:
-            seen_uids.add(prior_uid)  # unchanged
-            continue
+        if (
+            not force
+            and prior_uid
+            and manifest.get(prior_uid, {}).get("mtime") == mtime
+            and prior_uid not in seen_uids
+        ):
+            seen_uids.add(prior_uid)  # unchanged — but if a same-uid file already
+            continue  # won this scan, fall through so the LAST file wins
 
         entry = read_entry(path)
         if _normalize(entry, entries_dir, path, now, next_idx):
@@ -127,8 +132,9 @@ def reconcile_all(db: MemoDatabase, entries_dir: Path, *, force: bool = False) -
         if entry.uid in seen_uids:
             stderr_console.print(
                 f"[yellow]Warning: {rel!r} has the same uid ({entry.uid}) as another "
-                f"entries/*.md file already scanned this run — only the last one wins "
-                f"in the cache. Give one of them a fresh uid.[/yellow]"
+                f"entries/*.md file already scanned this run — only the last one "
+                f"(by filename order) wins in the cache. "
+                f"Give one of them a fresh uid.[/yellow]"
             )
         source, blessed = _resolve_source(db, entry, manifest)
         _upsert(db, entry, rel, mtime, source, blessed)

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -146,3 +146,19 @@ def test_migrate_without_title_column(tmp_path, db):
     row = db.get_memo_by_uid("notitle000000001")
     assert row.content == "no title body"
     assert row.title is None
+
+
+def test_migrate_skips_rows_with_existing_uid(tmp_path, db, write_md):
+    """migrate -f must not write a duplicate .md for a uid already in the vault,
+    and must not overwrite the existing file (no irreversible writes)."""
+    write_md("vault edited version", idx=0, uid="legacyuid0000001", title="First entry")
+
+    legacy = tmp_path / "koda.db"
+    _make_legacy_db(legacy, [LEGACY_ROWS[0]])
+
+    manage.migrate(db_path=legacy, force=True)
+
+    entries = runtime.get_entries_dir()
+    uids = [md_store.read_entry(p).uid for p in entries.glob("*.md")]
+    assert uids.count("legacyuid0000001") == 1
+    assert db.get_memo_by_uid("legacyuid0000001").content == "vault edited version"

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -162,3 +162,20 @@ def test_migrate_skips_rows_with_existing_uid(tmp_path, db, write_md):
     uids = [md_store.read_entry(p).uid for p in entries.glob("*.md")]
     assert uids.count("legacyuid0000001") == 1
     assert db.get_memo_by_uid("legacyuid0000001").content == "vault edited version"
+
+
+def test_migrate_records_skipped_rows_as_koda_entry_and_prints_them(tmp_path, db, write_md, capsys):
+    write_md("vault edited version", idx=0, uid="legacyuid0000001", title="First entry")
+    legacy = tmp_path / "koda.db"
+    _make_legacy_db(legacy, LEGACY_ROWS)
+
+    manage.migrate(db_path=legacy, force=True)
+
+    skip_rows = [r for r in db.get_memos(limit=None) if r.tags == "migrate"]
+    assert len(skip_rows) == 1
+    assert "legacyuid0000001" in skip_rows[0].content
+    assert "First entry" in skip_rows[0].content
+
+    out = capsys.readouterr().out
+    assert "Skipped" in out
+    assert "legacyuid0000001" in out

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -150,3 +150,26 @@ def test_reconcile_reads_files_written_directly(db):
     assert row.content == "pulled body"
     assert row.tags == "synced"
     assert row.source == "remote"  # not authored locally
+
+
+def test_duplicate_uid_last_file_wins_deterministically(db, seed):
+    """Two entries/*.md files sharing a uid must resolve to the LAST file in
+    filename order, stably across consecutive runs (no mtime-gate flip-flop)."""
+    row = seed("original body")
+    uid = row.uid
+    entries_dir = _entries_dir()
+    dup_path = entries_dir / "zzz-duplicate.md"
+    dup = MdEntry(
+        content="duplicate body",
+        uid=uid,
+        idx=row.idx,
+        created_at="2026-01-01 00:00:00",
+        modified_at="2026-01-01 00:00:00",
+    )
+    md_store.write_entry(entries_dir, dup, path=dup_path)
+
+    reconcile_all(db, entries_dir)  # run 1
+    reconcile_all(db, entries_dir)  # run 2 — must not flip back to "original body"
+
+    assert db.get_memo_by_uid(uid).content == "duplicate body"
+    assert db.path_for(uid) == "zzz-duplicate.md"

--- a/uv.lock
+++ b/uv.lock
@@ -217,7 +217,7 @@ wheels = [
 
 [[package]]
 name = "koda-cli"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

`koda migrate` (added in #155) unconditionally wrote one new `.md` file per legacy `koda.db` row via `write_entry()`, which always allocates a fresh path through `unique_path()`. It never checked whether the vault already had an entry with that row's `uid`. Re-running `migrate -f` against a vault that was already migrated produced duplicate files sharing a `uid` (26 pairs in the field), which in turn made the reconcile cache flip-flop between the two files on consecutive runs — `koda list` could show stale shortcuts/content.

This PR makes `migrate` idempotent and non-destructive:

- Rows whose `uid` already exists in the vault are **skipped** — no new file is created and nothing is overwritten (no irreversible writes).
- Skipped rows are recorded as a **koda entry** (tag: `migrate`) so the audit trail lives in the vault and can be reviewed (`koda list --tag migrate`) or removed.
- Skipped rows are also listed in the `migrate` command output.

It also fixes the underlying cache-correctness issue in `reconcile`:

- When two `entries/*.md` files share a `uid`, the cache now deterministically reflects the last file (by filename order) on every run, instead of flip-flopping between the two — the mtime-gate skip no longer overrides a same-scan duplicate.

## Changes

- `src/koda/commands/manage.py` — `migrate` checks `db.manifest()` for existing uids, skips matching rows, records them via `_record_skipped()`, and prints them in the command summary.
- `src/koda/reconcile.py` — the mtime-gate skip now only applies when the uid was not already seen in the same scan (`prior_uid not in seen_uids`), making last-file-wins deterministic; the duplicate-uid warning text now matches the actual behavior ("last one by filename order").
- `tests/test_migrate.py` — 2 new tests: migrate skips rows with an existing uid without writing a duplicate `.md` or overwriting the vault file; skipped rows are recorded as a koda entry (tag `migrate`) and printed.
- `tests/test_reconcile.py` — 1 new test: two files sharing a uid resolve to the last file (filename order), stably across consecutive runs.
- `pyproject.toml` / `uv.lock` / `CHANGELOG.md` — version bump to 0.5.1, lock file sync, `### Fixed` entries.

## Acceptance Criteria

- [x] `migrate -f` re-run does not create multiple `.md` files with the same uid
- [x] Skipped rows appear both as a koda entry (tag: `migrate`) and in the command output
- [x] Existing files' content and uid are never modified (no overwrite)
- [x] `koda list` output is stable across runs when duplicate uids exist
- [x] `uv run pytest` passes (361 passed, coverage 73.98% > 60% floor); `ruff check`, `ruff format --check`, and `mypy` are clean

Closes #157
