### PR TITLE
feat(sync): add koda push --dry-run and koda diff action summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `koda --update` / `koda update` self-update: detects the install method
   (uv tool, pipx, or pip) and runs the matching upgrade command.
+- `koda push --dry-run` (`-n`): previews what a push would commit and push
+  (new / updated / deleted entries, plus ahead/behind vs the remote) without
+  writing anything — no commit, no push, no `pull --rebase`.
+- `koda diff`: read-only pre-sync check showing local vs remote changes with
+  action hints (`koda push` / `koda pull`); prints "In sync with the remote."
+  when there is nothing to do.
 
 ### Fixed
 - `koda migrate` now skips legacy rows whose uid already exists in the vault

--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ Grouped the same way as `koda --help`.
 
 | Command | Alias | Description |
 |---|---|---|
-| [`push`](#push-and-pull) | — | Commit & push the vault's `.md` entries |
+| [`push`](#push-and-pull) | — | Commit & push the vault's `.md` entries (`-n` previews without writing) |
 | [`pull`](#push-and-pull) | — | Pull `.md` entries and reconcile the cache |
+| [`diff`](#push-and-pull) | — | Read-only local-vs-remote check with action hints |
 
 **Data**
 
@@ -834,9 +835,14 @@ Priority order: **CLI flags > environment variables > config file > built-in def
 The vault (`~/.koda-cli`) is **itself a git repository**, and the `entries/*.md` files are the synced artifact — so sync is just plain `git` on files, readable and editable straight from GitHub. There is no JSONL payload and no bespoke merge:
 
 ```bash
-koda push   # git add/commit the entries, then push to the remote
-koda pull   # git pull --rebase, then reconcile the cache from the .md files
+koda push       # git add/commit the entries, then push to the remote
+koda push -n    # preview what a push would commit and push — writes nothing
+koda pull       # git pull --rebase, then reconcile the cache from the .md files
+koda diff       # read-only pre-sync check: local vs remote changes with action hints
 ```
+
+`koda diff` and `koda push -n` are strictly read-only: they only `git fetch`
+and compare, and never modify the vault, commit, or push.
 
 > **Deletions are not synced.** `pull` never deletes entries — removing an
 > entry on one machine does not remove it anywhere else. After a `pull`, a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koda-cli"
-version = "0.5.1"
+version = "0.5.2"
 description = "A fast CLI memo store and command launcher backed by plain Markdown files (Obsidian / editor / AI friendly)."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -249,3 +249,73 @@ def pull(
     _pull_rebase_if_remote(vault)
     reconcile_all(get_db(), get_entries_dir())
     console.print("[green]Pull complete.[/green]")
+
+
+@app.command(rich_help_panel="Git sync")
+def diff():
+    """Read-only pre-sync check: local vs remote changes with action hints.
+
+    Shows what ``koda push`` would publish and what ``koda pull`` would bring
+    in. Never writes to the vault (no pull --rebase, no commit, no push).
+    """
+    init_db()
+    vault = get_vault()
+    _require_git()
+    if not _is_repo(vault):
+        exit_error("Vault is not a git repository yet. Run `koda push` first.")
+    if not _has_remote(vault):
+        exit_error("No git remote configured for the vault.")
+
+    _git(vault, "fetch", check=False)
+    local = _classify_changes(
+        _git(
+            vault, "-c", "core.quotepath=false", "status", "--porcelain",
+            "--untracked-files=all", check=False,
+        ).stdout
+    )
+    pulled: dict[str, str] = {}
+    if _has_upstream(vault):
+        name_status = _git(
+            vault, "-c", "core.quotepath=false", "diff", "--name-status",
+            "HEAD", "@{u}", "--", "entries/", check=False,
+        ).stdout
+        for line in name_status.splitlines():
+            parts = line.split("\t")
+            if not parts:
+                continue
+            code, path = parts[0][0], parts[-1]
+            if code == "A":
+                pulled[path] = "new"
+            elif code in ("M", "R"):
+                pulled[path] = "updated"
+            elif code == "D":
+                pulled[path] = "deleted"
+
+    if not local and not pulled:
+        console.print("[green]In sync with the remote.[/green]")
+        return
+
+    if local:
+        console.print("Local changes — would be pushed with `koda push`:")
+        for kind, label in (("new", "new"), ("updated", "updated"), ("deleted", "deleted")):
+            for path in sorted(p for p, k in local.items() if k == kind):
+                console.print(f"  {label:<8} {path}")
+    if pulled:
+        console.print("Remote changes — would be pulled with `koda pull`:")
+        for kind, label in (("new", "new"), ("updated", "updated"), ("deleted", "deleted")):
+            for path in sorted(p for p, k in pulled.items() if k == kind):
+                console.print(f"  {label:<8} {path}")
+
+    console.print(
+        f"[cyan]{len(local)} change(s) would be pushed · "
+        f"{len(pulled)} change(s) would be pulled[/cyan]"
+    )
+    if local:
+        console.print("[dim]Next: `koda push` to publish local changes.[/dim]")
+    if pulled:
+        console.print("[dim]Next: `koda pull` to merge remote changes.[/dim]")
+    if local and pulled:
+        console.print(
+            "[dim]Concurrent edits to the same entry surface as a git conflict on "
+            "that file — resolve it in the vault, then `koda pull` again.[/dim]"
+        )

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -119,12 +119,76 @@ def _push_if_remote(vault: Path) -> None:
         )
 
 
+def _classify_changes(status_output: str) -> dict[str, str]:
+    """Map `git status --porcelain` output → {path: 'new'|'updated'|'deleted'}.
+
+    Renames are reported under their new path as 'updated'; anything else
+    (typechange etc.) is treated as 'updated' too.
+    """
+    result: dict[str, str] = {}
+    for line in status_output.splitlines():
+        if not line:
+            continue
+        xy, path = line[:2], line[3:]
+        if " -> " in path:  # rename: "R  old -> new"
+            path = path.split(" -> ", 1)[1]
+        if xy == "??":
+            result[path] = "new"
+        elif "D" in xy:
+            result[path] = "deleted"
+        elif "A" in xy or "M" in xy or "R" in xy:
+            result[path] = "updated"
+    return result
+
+
+def _preview_push(vault: Path) -> None:
+    """Read-only preview for `koda push -n`: what would be committed and pushed.
+
+    Never stages, commits, pushes, or pulls --rebase; the only network call is
+    a read-only `git fetch` (mirrors `pull -n`).
+    """
+    if not _is_repo(vault):
+        exit_error("Vault is not a git repository yet. Run `koda push` first.")
+    status = _git(
+        vault, "-c", "core.quotepath=false", "status", "--porcelain", check=False
+    ).stdout
+    changes = _classify_changes(status)
+    if changes:
+        for kind, label in (("new", "new"), ("updated", "updated"), ("deleted", "deleted")):
+            for path in sorted(p for p, k in changes.items() if k == kind):
+                console.print(f"  {label:<8} {path}")
+        console.print(f"[dim]{len(changes)} change(s) would be committed.[/dim]")
+    else:
+        console.print("[yellow]No entry changes — nothing to push.[/yellow]")
+
+    _git(vault, "fetch", check=False)
+    if _has_upstream(vault):
+        ahead = _git(vault, "rev-list", "--count", "@{u}..HEAD", check=False).stdout.strip()
+        behind = _git(vault, "rev-list", "--count", "HEAD..@{u}", check=False).stdout.strip()
+        remote = f"{_first_remote(vault)}/{_current_branch(vault)}"
+        if ahead:
+            console.print(f"[dim]Would push {ahead} commit(s) to {remote}.[/dim]")
+        if behind:
+            console.print(
+                f"[yellow]Remote has {behind} commit(s) your vault does not — "
+                f"run `koda pull` first.[/yellow]"
+            )
+
+
 @app.command(rich_help_panel="Git sync")
-def push():
+def push(
+    dry_run: bool = typer.Option(
+        False, "--dry-run", "-n",
+        help="Preview what a push would commit and push, without writing anything.",
+    ),
+):
     """Commit the vault's Markdown entries and push to the git remote. Alias: `koda push`."""
     init_db()
     vault = get_vault()
     _require_git()
+    if dry_run:
+        _preview_push(vault)
+        return
     _ensure_repo(vault)
     _pull_rebase_if_remote(vault)
 

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -150,7 +150,8 @@ def _preview_push(vault: Path) -> None:
     if not _is_repo(vault):
         exit_error("Vault is not a git repository yet. Run `koda push` first.")
     status = _git(
-        vault, "-c", "core.quotepath=false", "status", "--porcelain", check=False
+        vault, "-c", "core.quotepath=false", "status", "--porcelain",
+        "--untracked-files=all", check=False,
     ).stdout
     changes = _classify_changes(status)
     if changes:
@@ -166,9 +167,9 @@ def _preview_push(vault: Path) -> None:
         ahead = _git(vault, "rev-list", "--count", "@{u}..HEAD", check=False).stdout.strip()
         behind = _git(vault, "rev-list", "--count", "HEAD..@{u}", check=False).stdout.strip()
         remote = f"{_first_remote(vault)}/{_current_branch(vault)}"
-        if ahead:
+        if ahead not in ("", "0"):
             console.print(f"[dim]Would push {ahead} commit(s) to {remote}.[/dim]")
-        if behind:
+        if behind not in ("", "0"):
             console.print(
                 f"[yellow]Remote has {behind} commit(s) your vault does not — "
                 f"run `koda pull` first.[/yellow]"

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -150,8 +150,13 @@ def _preview_push(vault: Path) -> None:
     if not _is_repo(vault):
         exit_error("Vault is not a git repository yet. Run `koda push` first.")
     status = _git(
-        vault, "-c", "core.quotepath=false", "status", "--porcelain",
-        "--untracked-files=all", check=False,
+        vault,
+        "-c",
+        "core.quotepath=false",
+        "status",
+        "--porcelain",
+        "--untracked-files=all",
+        check=False,
     ).stdout
     changes = _classify_changes(status)
     if changes:
@@ -179,7 +184,9 @@ def _preview_push(vault: Path) -> None:
 @app.command(rich_help_panel="Git sync")
 def push(
     dry_run: bool = typer.Option(
-        False, "--dry-run", "-n",
+        False,
+        "--dry-run",
+        "-n",
         help="Preview what a push would commit and push, without writing anything.",
     ),
 ):
@@ -269,15 +276,28 @@ def diff():
     _git(vault, "fetch", check=False)
     local = _classify_changes(
         _git(
-            vault, "-c", "core.quotepath=false", "status", "--porcelain",
-            "--untracked-files=all", check=False,
+            vault,
+            "-c",
+            "core.quotepath=false",
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+            check=False,
         ).stdout
     )
     pulled: dict[str, str] = {}
     if _has_upstream(vault):
         name_status = _git(
-            vault, "-c", "core.quotepath=false", "diff", "--name-status",
-            "HEAD", "@{u}", "--", "entries/", check=False,
+            vault,
+            "-c",
+            "core.quotepath=false",
+            "diff",
+            "--name-status",
+            "HEAD",
+            "@{u}",
+            "--",
+            "entries/",
+            check=False,
         ).stdout
         for line in name_status.splitlines():
             parts = line.split("\t")

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -175,3 +175,108 @@ def test_push_dry_run_lists_changes_without_writing(tmp_path, bare_remote, monke
         capture_output=True, text=True, check=True,
     ).stdout.strip() == log_before
     assert "Push complete." not in out
+
+
+def test_push_dry_run_nothing_to_push(tmp_path, bare_remote, monkeypatch, capsys):
+    machine = tmp_path / "machine"
+    machine.mkdir()
+    _switch_vault(monkeypatch, machine, tmp_path / "none.toml")
+    runtime.init_db()
+    memo._write_new_entry("echo one", "", None, None, None)
+    subprocess.run(["git", "init", "-q", str(machine)], check=True)
+    subprocess.run(
+        ["git", "-C", str(machine), "remote", "add", "origin", str(bare_remote)], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(machine), "config", "user.email", "a@example.com"], check=True
+    )
+    subprocess.run(["git", "-C", str(machine), "config", "user.name", "Machine"], check=True)
+    git.push(dry_run=False)
+    capsys.readouterr()
+
+    git.push(dry_run=True)
+
+    out = capsys.readouterr().out
+    assert "nothing to push" in out
+
+
+def test_push_dry_run_warns_when_remote_ahead_without_rebasing(
+    tmp_path, bare_remote, monkeypatch, capsys
+):
+    # Machine A pushes entry1.
+    machine_a = tmp_path / "machine-a"
+    machine_a.mkdir()
+    _switch_vault(monkeypatch, machine_a, tmp_path / "none-a.toml")
+    runtime.init_db()
+    memo._write_new_entry("echo one", "", None, None, None)
+    subprocess.run(["git", "init", "-q", str(machine_a)], check=True)
+    subprocess.run(
+        ["git", "-C", str(machine_a), "remote", "add", "origin", str(bare_remote)], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(machine_a), "config", "user.email", "a@example.com"], check=True
+    )
+    subprocess.run(["git", "-C", str(machine_a), "config", "user.name", "A"], check=True)
+    git.push(dry_run=False)
+
+    # Machine B clones the state (fetch + checkout, as in the existing test).
+    machine_b = tmp_path / "machine-b"
+    machine_b.mkdir()
+    subprocess.run(["git", "init", "-q", str(machine_b)], check=True)
+    subprocess.run(
+        ["git", "-C", str(machine_b), "remote", "add", "origin", str(bare_remote)], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(machine_b), "config", "user.email", "b@example.com"], check=True
+    )
+    subprocess.run(["git", "-C", str(machine_b), "config", "user.name", "B"], check=True)
+    subprocess.run(["git", "-C", str(machine_b), "fetch", "-q", "origin"], check=True)
+    default_branch = subprocess.run(
+        ["git", "-C", str(machine_a), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(machine_b), "checkout", "-q", "-B", default_branch, f"origin/{default_branch}"],
+        check=True,
+    )
+    # Machine B never runs `koda push`, so _ensure_repo never wrote a
+    # .gitignore — without this, .koda/cache.db shows up as untracked and
+    # pollutes every status-based check. Mirror what _ensure_repo would write.
+    (machine_b / ".gitignore").write_text(".koda/\n.obsidian/\n", encoding="utf-8")
+
+    # Machine A pushes a second commit; machine B is now behind.
+    _switch_vault(monkeypatch, machine_a, tmp_path / "none-a.toml")
+    runtime.init_db()
+    memo._write_new_entry("echo two", "", None, None, None)
+    git.push(dry_run=False)
+
+    # Machine B dry-runs its push: must warn, and must NOT rebase (read-only).
+    _switch_vault(monkeypatch, machine_b, tmp_path / "none-b.toml")
+    runtime.init_db()
+    capsys.readouterr()
+    git.push(dry_run=True)
+
+    out = capsys.readouterr().out
+    assert "run `koda pull` first" in out
+    # The remote's new entry was NOT pulled into B's worktree.
+    assert not list((machine_b / "entries").glob("two*.md"))
+
+
+def test_push_dry_run_local_only_when_no_remote(tmp_path, monkeypatch, capsys):
+    machine = tmp_path / "machine"
+    machine.mkdir()
+    _switch_vault(monkeypatch, machine, tmp_path / "none.toml")
+    runtime.init_db()
+    memo._write_new_entry("echo one", "", None, None, None)
+    subprocess.run(["git", "init", "-q", str(machine)], check=True)
+    subprocess.run(
+        ["git", "-C", str(machine), "config", "user.email", "a@example.com"], check=True
+    )
+    subprocess.run(["git", "-C", str(machine), "config", "user.name", "Machine"], check=True)
+    # No `koda push` has run here either — write the same .gitignore _ensure_repo would.
+    (machine / ".gitignore").write_text(".koda/\n.obsidian/\n", encoding="utf-8")
+
+    git.push(dry_run=True)
+
+    out = capsys.readouterr().out
+    assert "new" in out and "one" in out

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -7,6 +7,7 @@ import subprocess
 import pytest
 
 import koda.runtime as runtime
+from koda import md_store
 from koda.commands import git, memo
 
 
@@ -45,7 +46,7 @@ def test_push_then_pull_round_trip(tmp_path, bare_remote, monkeypatch):
     )
     subprocess.run(["git", "-C", str(machine_a), "config", "user.name", "Machine A"], check=True)
 
-    git.push()
+    git.push(dry_run=False)
 
     assert subprocess.run(
         ["git", "-C", str(bare_remote), "log", "--oneline"], capture_output=True, text=True
@@ -111,7 +112,7 @@ def test_pull_dry_run_previews_without_applying(tmp_path, bare_remote, monkeypat
         ["git", "-C", str(machine_a), "config", "user.email", "a@example.com"], check=True
     )
     subprocess.run(["git", "-C", str(machine_a), "config", "user.name", "Machine A"], check=True)
-    git.push()
+    git.push(dry_run=False)
     capsys.readouterr()  # discard machine A's push output
 
     machine_b = tmp_path / "machine-b"
@@ -130,3 +131,47 @@ def test_pull_dry_run_previews_without_applying(tmp_path, bare_remote, monkeypat
     assert not (machine_b / "entries").exists() or not list((machine_b / "entries").glob("*.md"))
     out = capsys.readouterr().out
     assert "No upstream branch" in out
+
+
+def test_push_dry_run_lists_changes_without_writing(tmp_path, bare_remote, monkeypatch, capsys):
+    machine = tmp_path / "machine"
+    machine.mkdir()
+    _switch_vault(monkeypatch, machine, tmp_path / "none.toml")
+    runtime.init_db()
+    entry1 = memo._write_new_entry("echo one", "", "one", None, None)
+    entry3 = memo._write_new_entry("echo three", "", None, None, None)
+    subprocess.run(["git", "init", "-q", str(machine)], check=True)
+    subprocess.run(
+        ["git", "-C", str(machine), "remote", "add", "origin", str(bare_remote)], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(machine), "config", "user.email", "a@example.com"], check=True
+    )
+    subprocess.run(["git", "-C", str(machine), "config", "user.name", "Machine"], check=True)
+    git.push(dry_run=False)
+    capsys.readouterr()  # discard the real push output
+    log_before = subprocess.run(
+        ["git", "-C", str(machine), "rev-list", "--count", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    # Local edits: modify entry1, add entry2, delete entry3.
+    p1 = machine / "entries" / (runtime.get_db().path_for(entry1.uid) or "")
+    entry = md_store.read_entry(p1)
+    entry.content = "echo one edited"
+    md_store.write_entry(machine / "entries", entry, path=p1)
+    memo._write_new_entry("echo two", "", None, None, None)
+    (machine / "entries" / (runtime.get_db().path_for(entry3.uid) or "")).unlink()
+
+    git.push(dry_run=True)
+
+    out = capsys.readouterr().out
+    assert "updated" in out and "one" in out
+    assert "new" in out and "two" in out
+    assert "deleted" in out and "three" in out
+    # Nothing was committed or pushed.
+    assert subprocess.run(
+        ["git", "-C", str(machine), "rev-list", "--count", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip() == log_before
+    assert "Push complete." not in out

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -144,15 +144,15 @@ def test_push_dry_run_lists_changes_without_writing(tmp_path, bare_remote, monke
     subprocess.run(
         ["git", "-C", str(machine), "remote", "add", "origin", str(bare_remote)], check=True
     )
-    subprocess.run(
-        ["git", "-C", str(machine), "config", "user.email", "a@example.com"], check=True
-    )
+    subprocess.run(["git", "-C", str(machine), "config", "user.email", "a@example.com"], check=True)
     subprocess.run(["git", "-C", str(machine), "config", "user.name", "Machine"], check=True)
     git.push(dry_run=False)
     capsys.readouterr()  # discard the real push output
     log_before = subprocess.run(
         ["git", "-C", str(machine), "rev-list", "--count", "HEAD"],
-        capture_output=True, text=True, check=True,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout.strip()
 
     # Local edits: modify entry1, add entry2, delete entry3.
@@ -170,10 +170,15 @@ def test_push_dry_run_lists_changes_without_writing(tmp_path, bare_remote, monke
     assert "new" in out and "two" in out
     assert "deleted" in out and "three" in out
     # Nothing was committed or pushed.
-    assert subprocess.run(
-        ["git", "-C", str(machine), "rev-list", "--count", "HEAD"],
-        capture_output=True, text=True, check=True,
-    ).stdout.strip() == log_before
+    assert (
+        subprocess.run(
+            ["git", "-C", str(machine), "rev-list", "--count", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        == log_before
+    )
     assert "Push complete." not in out
 
 
@@ -187,9 +192,7 @@ def test_push_dry_run_nothing_to_push(tmp_path, bare_remote, monkeypatch, capsys
     subprocess.run(
         ["git", "-C", str(machine), "remote", "add", "origin", str(bare_remote)], check=True
     )
-    subprocess.run(
-        ["git", "-C", str(machine), "config", "user.email", "a@example.com"], check=True
-    )
+    subprocess.run(["git", "-C", str(machine), "config", "user.email", "a@example.com"], check=True)
     subprocess.run(["git", "-C", str(machine), "config", "user.name", "Machine"], check=True)
     git.push(dry_run=False)
     capsys.readouterr()
@@ -233,10 +236,21 @@ def test_push_dry_run_warns_when_remote_ahead_without_rebasing(
     subprocess.run(["git", "-C", str(machine_b), "fetch", "-q", "origin"], check=True)
     default_branch = subprocess.run(
         ["git", "-C", str(machine_a), "rev-parse", "--abbrev-ref", "HEAD"],
-        capture_output=True, text=True, check=True,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout.strip()
     subprocess.run(
-        ["git", "-C", str(machine_b), "checkout", "-q", "-B", default_branch, f"origin/{default_branch}"],
+        [
+            "git",
+            "-C",
+            str(machine_b),
+            "checkout",
+            "-q",
+            "-B",
+            default_branch,
+            f"origin/{default_branch}",
+        ],
         check=True,
     )
     # Machine B never runs `koda push`, so _ensure_repo never wrote a
@@ -269,9 +283,7 @@ def test_push_dry_run_local_only_when_no_remote(tmp_path, monkeypatch, capsys):
     runtime.init_db()
     memo._write_new_entry("echo one", "", None, None, None)
     subprocess.run(["git", "init", "-q", str(machine)], check=True)
-    subprocess.run(
-        ["git", "-C", str(machine), "config", "user.email", "a@example.com"], check=True
-    )
+    subprocess.run(["git", "-C", str(machine), "config", "user.email", "a@example.com"], check=True)
     subprocess.run(["git", "-C", str(machine), "config", "user.name", "Machine"], check=True)
     # No `koda push` has run here either — write the same .gitignore _ensure_repo would.
     (machine / ".gitignore").write_text(".koda/\n.obsidian/\n", encoding="utf-8")
@@ -311,10 +323,21 @@ def test_diff_in_sync_message(tmp_path, bare_remote, monkeypatch, capsys):
     subprocess.run(["git", "-C", str(machine_b), "fetch", "-q", "origin"], check=True)
     default_branch = subprocess.run(
         ["git", "-C", str(machine_a), "rev-parse", "--abbrev-ref", "HEAD"],
-        capture_output=True, text=True, check=True,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout.strip()
     subprocess.run(
-        ["git", "-C", str(machine_b), "checkout", "-q", "-B", default_branch, f"origin/{default_branch}"],
+        [
+            "git",
+            "-C",
+            str(machine_b),
+            "checkout",
+            "-q",
+            "-B",
+            default_branch,
+            f"origin/{default_branch}",
+        ],
         check=True,
     )
     # Machine B never runs `koda push`, so _ensure_repo never wrote a
@@ -360,10 +383,21 @@ def test_diff_shows_push_pull_sections_with_hints(tmp_path, bare_remote, monkeyp
     subprocess.run(["git", "-C", str(machine_b), "fetch", "-q", "origin"], check=True)
     default_branch = subprocess.run(
         ["git", "-C", str(machine_a), "rev-parse", "--abbrev-ref", "HEAD"],
-        capture_output=True, text=True, check=True,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout.strip()
     subprocess.run(
-        ["git", "-C", str(machine_b), "checkout", "-q", "-B", default_branch, f"origin/{default_branch}"],
+        [
+            "git",
+            "-C",
+            str(machine_b),
+            "checkout",
+            "-q",
+            "-B",
+            default_branch,
+            f"origin/{default_branch}",
+        ],
         check=True,
     )
     # Machine B never runs `koda push`, so _ensure_repo never wrote a

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -280,3 +280,112 @@ def test_push_dry_run_local_only_when_no_remote(tmp_path, monkeypatch, capsys):
 
     out = capsys.readouterr().out
     assert "new" in out and "one" in out
+
+
+def test_diff_in_sync_message(tmp_path, bare_remote, monkeypatch, capsys):
+    machine_a = tmp_path / "machine-a"
+    machine_a.mkdir()
+    _switch_vault(monkeypatch, machine_a, tmp_path / "none-a.toml")
+    runtime.init_db()
+    memo._write_new_entry("echo one", "", None, None, None)
+    subprocess.run(["git", "init", "-q", str(machine_a)], check=True)
+    subprocess.run(
+        ["git", "-C", str(machine_a), "remote", "add", "origin", str(bare_remote)], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(machine_a), "config", "user.email", "a@example.com"], check=True
+    )
+    subprocess.run(["git", "-C", str(machine_a), "config", "user.name", "A"], check=True)
+    git.push(dry_run=False)
+
+    machine_b = tmp_path / "machine-b"
+    machine_b.mkdir()
+    subprocess.run(["git", "init", "-q", str(machine_b)], check=True)
+    subprocess.run(
+        ["git", "-C", str(machine_b), "remote", "add", "origin", str(bare_remote)], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(machine_b), "config", "user.email", "b@example.com"], check=True
+    )
+    subprocess.run(["git", "-C", str(machine_b), "config", "user.name", "B"], check=True)
+    subprocess.run(["git", "-C", str(machine_b), "fetch", "-q", "origin"], check=True)
+    default_branch = subprocess.run(
+        ["git", "-C", str(machine_a), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(machine_b), "checkout", "-q", "-B", default_branch, f"origin/{default_branch}"],
+        check=True,
+    )
+    # Machine B never runs `koda push`, so _ensure_repo never wrote a
+    # .gitignore — without this, .koda/cache.db shows up as untracked and
+    # pollutes every status-based check. Mirror what _ensure_repo would write.
+    (machine_b / ".gitignore").write_text(".koda/\n.obsidian/\n", encoding="utf-8")
+
+    _switch_vault(monkeypatch, machine_b, tmp_path / "none-b.toml")
+    runtime.init_db()
+    git.diff()
+
+    out = capsys.readouterr().out
+    assert "In sync with the remote" in out
+
+
+def test_diff_shows_push_pull_sections_with_hints(tmp_path, bare_remote, monkeypatch, capsys):
+    # Machine A pushes entry1; machine B syncs to it.
+    machine_a = tmp_path / "machine-a"
+    machine_a.mkdir()
+    _switch_vault(monkeypatch, machine_a, tmp_path / "none-a.toml")
+    runtime.init_db()
+    memo._write_new_entry("echo one", "", None, None, None)
+    subprocess.run(["git", "init", "-q", str(machine_a)], check=True)
+    subprocess.run(
+        ["git", "-C", str(machine_a), "remote", "add", "origin", str(bare_remote)], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(machine_a), "config", "user.email", "a@example.com"], check=True
+    )
+    subprocess.run(["git", "-C", str(machine_a), "config", "user.name", "A"], check=True)
+    git.push(dry_run=False)
+
+    machine_b = tmp_path / "machine-b"
+    machine_b.mkdir()
+    subprocess.run(["git", "init", "-q", str(machine_b)], check=True)
+    subprocess.run(
+        ["git", "-C", str(machine_b), "remote", "add", "origin", str(bare_remote)], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(machine_b), "config", "user.email", "b@example.com"], check=True
+    )
+    subprocess.run(["git", "-C", str(machine_b), "config", "user.name", "B"], check=True)
+    subprocess.run(["git", "-C", str(machine_b), "fetch", "-q", "origin"], check=True)
+    default_branch = subprocess.run(
+        ["git", "-C", str(machine_a), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(machine_b), "checkout", "-q", "-B", default_branch, f"origin/{default_branch}"],
+        check=True,
+    )
+    # Machine B never runs `koda push`, so _ensure_repo never wrote a
+    # .gitignore — without this, .koda/cache.db shows up as untracked and
+    # pollutes every status-based check. Mirror what _ensure_repo would write.
+    (machine_b / ".gitignore").write_text(".koda/\n.obsidian/\n", encoding="utf-8")
+
+    # A pushes entry2 (remote side); B adds a local entry (local side).
+    _switch_vault(monkeypatch, machine_a, tmp_path / "none-a.toml")
+    runtime.init_db()
+    memo._write_new_entry("echo two", "", None, None, None)
+    git.push(dry_run=False)
+
+    _switch_vault(monkeypatch, machine_b, tmp_path / "none-b.toml")
+    runtime.init_db()
+    memo._write_new_entry("local-b", "", None, None, None)
+    capsys.readouterr()
+    git.diff()
+
+    out = capsys.readouterr().out
+    assert "would be pushed" in out and "local-b" in out
+    assert "would be pulled" in out and "two" in out
+    assert "koda push" in out and "koda pull" in out
+    # diff is read-only: the remote's entry2 was NOT materialized in B's worktree.
+    assert not list((machine_b / "entries").glob("two*.md"))

--- a/uv.lock
+++ b/uv.lock
@@ -217,7 +217,7 @@ wheels = [
 
 [[package]]
 name = "koda-cli"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Ports the sync check features from the superseded #159 to the current md-native architecture (vault-as-git-repo; `entries/*.md` are the synced artifact — no JSONL payload). Closes the `koda pull -n` / `koda push` asymmetry and gives `koda diff` the role of a pre-sync check, per #158.

- **`koda push --dry-run` (`-n`)**: previews what a push would commit and push — new / updated / deleted entries (from `git status --porcelain`), plus ahead/behind vs the remote (from `git rev-list` after a read-only `git fetch`). Prints "Nothing to push" when in sync, and warns `run koda pull first` when the remote is ahead.
- **`koda diff`** (new command): read-only pre-sync check showing local changes (would be pushed) and remote changes (would be pulled) with action hints, and an "In sync with the remote." state when there is nothing to do.
- Both check paths are **strictly read-only**: no `git add` / `commit` / `push`, no `git pull --rebase` — the vault worktree is never modified (mirrors the existing `pull -n` semantics).

## Changes

- `src/koda/commands/git.py`:
  - `push()` gains `--dry-run` / `-n`; dry-run delegates to the new `_preview_push()` (read-only).
  - New `_classify_changes()` — maps porcelain status output to new/updated/deleted (rename-aware, `core.quotepath=false` for Unicode paths).
  - New `diff` command — `git fetch` + `git status --porcelain` (local) vs `git diff --name-status HEAD @{u} -- entries/` (remote), grouped sections, summary line, and `koda push` / `koda pull` hints.
- `tests/test_git.py`:
  - Existing direct calls updated to `git.push(dry_run=False)` (required once `push` gained a Typer Option — `OptionInfo` default would otherwise break direct-call tests).
  - 6 new tests with real bare-remote fixtures: push -n (changes listed / nothing-to-push / remote-ahead warning without rebasing / no-remote local-only), diff (in-sync message / push+pull sections with hints + read-only guarantee).
- `README.md` — Git sync section and command table document `koda push -n` and `koda diff`.
- `pyproject.toml` / `uv.lock` / `CHANGELOG.md` — version bump 0.5.1 → 0.5.2, lock sync, `### Added` entries.

## Acceptance Criteria (#158, adapted to the md-native architecture)

- [x] `koda push -n` shows what a push would change (new / updated / deleted) and writes nothing
- [x] `koda push -n` shows "Nothing to push" when there is no diff
- [x] `koda diff` ends with a summary line and action hints; keeps the "In sync with the remote." message when there is no diff
- [x] `koda diff` / `koda push -n` never modify the vault worktree (no `git pull --rebase`)
- [x] README sync section documents `koda diff` / `koda push -n`
- [x] Existing tests pass; new tests cover push -n (with diff / without / remote-ahead / no remote) and diff summary output
- [x] `uv run pytest` — 367 passed, coverage 74.63% (> 60% floor); `ruff check`, `ruff format --check`, `mypy` clean

## Notes

- Supersedes #159 (closed as superseded — it targeted the pre-#155 JSONL payload architecture). This PR implements the same feature request (#158) on the current plain-git architecture; per the new model, per-entry "last-writer-wins on modified_at" is replaced by ordinary git conflict resolution on the affected file (noted in the `diff` output when both sides changed).

Closes #158
