### PR TITLE
feat(sync): resolve duplicate idx conflicts across machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `koda diff`: read-only pre-sync check showing local vs remote changes with
   action hints (`koda push` / `koda pull`); prints "In sync with the remote."
   when there is nothing to do.
+- `koda resolve`: resolves duplicate display indices across machines. When
+  `koda push`/`koda pull` detects two entries sharing an `idx`, sync pauses
+  (exit code 5) and the conflict is recorded instead of being silently
+  resolved; `koda resolve` keeps a chosen winner (interactive fzf / numbered
+  prompt, or `--ours`/`--theirs` for non-interactive) and moves the rejected
+  side to the next free index. `koda push` then publishes the resolved version
+  so every machine converges.
 
 ### Fixed
 - `koda migrate` now skips legacy rows whose uid already exists in the vault

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Grouped the same way as `koda --help`.
 | [`push`](#push-and-pull) | — | Commit & push the vault's `.md` entries (`-n` previews without writing) |
 | [`pull`](#push-and-pull) | — | Pull `.md` entries and reconcile the cache |
 | [`diff`](#push-and-pull) | — | Read-only local-vs-remote check with action hints |
+| [`resolve`](#push-and-pull) | — | Resolve duplicate display indices from a sync conflict |
 
 **Data**
 
@@ -839,6 +840,7 @@ koda push       # git add/commit the entries, then push to the remote
 koda push -n    # preview what a push would commit and push — writes nothing
 koda pull       # git pull --rebase, then reconcile the cache from the .md files
 koda diff       # read-only pre-sync check: local vs remote changes with action hints
+koda resolve    # resolve duplicate idx conflicts, then push the resolved version
 ```
 
 `koda diff` and `koda push -n` are strictly read-only: they only `git fetch`
@@ -854,6 +856,8 @@ and compare, and never modify the vault, commit, or push.
 `push` runs `git pull --rebase` first (when an upstream exists) so the branch stays linear, then commits `entries/*.md` and pushes. `pull` rebases the latest commits in and reconciles the cache. The `.koda/` cache directory is **git-ignored automatically** — koda adds it to `.gitignore` on first push, so the disposable cache never ends up in the repo.
 
 Concurrent edits to the *same* entry surface as an **ordinary git file conflict** on that one `.md` — resolve it with your usual git workflow, then run any `koda` command to reconcile.
+
+When two machines each add an entry that lands on the same display index, `koda push`/`koda pull` detect the duplicate `idx`, skip auto-resolution, and pause with exit code 5. `koda resolve` walks you through each conflict — pick which entry keeps the index (interactive fzf/numbered prompt, or `--ours`/`--theirs` non-interactively) and the rejected side is moved to the next free index. Run `koda push` again to publish the resolved version; the other machines then converge on `koda pull` (entries that changed index are reported as moved).
 
 > **Security note**: entries are stored as **plaintext `.md` files** committed to the repo.
 > Any passwords, tokens, or secrets stored in koda will be committed to the sync

--- a/src/koda/cli_utils.py
+++ b/src/koda/cli_utils.py
@@ -17,6 +17,7 @@ class ExitCode(IntEnum):
     NOT_FOUND = 2
     CANCELLED = 3
     DB_ERROR = 4
+    CONFLICT = 5
 
 
 def exit_error(

--- a/src/koda/cmd_helpers/display.py
+++ b/src/koda/cmd_helpers/display.py
@@ -31,3 +31,27 @@ def print_memo(
         title_line.append(title)
         console.print(title_line)
     console.print(f"Tags: [magenta]{tags}[/magenta]\n" + "-" * 20 + f"\n{content}")
+
+
+def format_conflict_entry(e: dict) -> Text:
+    """Render one idx-conflict entry (side + shortcut + label + move hint).
+
+    Returns a :class:`Text` so the user-controlled ``title``/first content line
+    is appended literally and never interpreted as Rich markup (mirrors the
+    comment in :func:`print_memo`).
+    """
+    t = Text()
+    if e.get("side") == "ours":
+        t.append("OURS   ", style="bold blue")
+    elif e.get("side") == "theirs":
+        t.append("THEIRS ", style="bold magenta")
+    else:
+        t.append("? ", style="dim")
+    if e.get("shortcut"):
+        t.append(e["shortcut"] + " ", style="bold green")
+    label = e.get("title") or ((e.get("content") or "").splitlines() or [""])[0]
+    t.append(label)
+    prev = e.get("prev_idx")
+    if prev is not None and prev != e.get("idx"):
+        t.append(f" (was {prev})", style="dim")
+    return t

--- a/src/koda/commands/git.py
+++ b/src/koda/commands/git.py
@@ -12,10 +12,19 @@ import subprocess
 from pathlib import Path
 
 import typer
+from rich.text import Text
 
-from ..cli_utils import exit_error
+from ..cli_utils import ExitCode, exit_error
+from ..cmd_helpers.display import format_conflict_entry
+from ..conflicts import load_conflicts, save_conflicts
 from ..main import app
-from ..reconcile import reconcile_all
+from ..reconcile import (
+    annotate_groups,
+    compute_sync_diff,
+    find_conflicts,
+    reconcile_all,
+    snapshot_idx,
+)
 from ..runtime import console, get_db, get_entries_dir, get_vault, init_db
 
 # Kept out of sync: the local cache/trust ledger, and Obsidian's per-machine app
@@ -119,6 +128,63 @@ def _push_if_remote(vault: Path) -> None:
         )
 
 
+def _report_conflicts(groups: list[dict]) -> None:
+    console.print("[bold red]idx conflicts detected — not auto-resolved.[/bold red]")
+    console.print("These entries share a display index; koda skips them and asks you to choose.")
+    for g in groups:
+        console.print(f"\n  [bold cyan]idx {g['idx']}[/bold cyan]")
+        for e in g["entries"]:
+            console.print(Text.assemble("    ", format_conflict_entry(e)))
+    console.print(
+        "\n[dim]Resolve with `koda resolve` (interactive) or `koda resolve --ours|--theirs`, "
+        "then `koda push`.[/dim]"
+    )
+
+
+def _report_sync(diff: dict) -> None:
+    added, removed, moved = diff["added"], diff["removed"], diff["moved"]
+    parts = []
+    if added:
+        parts.append(f"[green]+{len(added)} added[/green]")
+    if removed:
+        parts.append(f"[red]-{len(removed)} removed[/red]")
+    if moved:
+        parts.append(f"[yellow]{len(moved)} moved[/yellow]")
+    if parts:
+        console.print("Sync: " + ", ".join(parts))
+    for uid, old, new in moved:
+        console.print(f"  [yellow]{old} → {new}[/yellow] {uid}")
+
+
+def _existing_conflicts(vault: Path, db) -> list[dict]:
+    """Return unresolved conflicts already present locally (from the ledger, or
+    freshly detected on disk), annotating and persisting the latter."""
+    groups = load_conflicts(vault)
+    if groups:
+        return groups
+    groups = find_conflicts(db)
+    if groups:
+        annotate_groups(groups, snapshot_idx(db))
+        save_conflicts(vault, groups)
+    return groups
+
+
+def _reconcile_after_pull(vault: Path, db, before: dict[str, int]) -> tuple[dict, list[dict]]:
+    """Reconcile the cache after a pull, then detect/record new conflicts.
+
+    Returns ``(diff, groups)`` where ``diff`` classifies added/removed/moved and
+    ``groups`` is the list of freshly recorded conflict groups (``[]`` if none).
+    """
+    reconcile_all(db, get_entries_dir())
+    after = snapshot_idx(db)
+    diff = compute_sync_diff(before, after)
+    groups = find_conflicts(db)
+    if groups:
+        annotate_groups(groups, before)
+        save_conflicts(vault, groups)
+    return diff, groups
+
+
 def _classify_changes(status_output: str) -> dict[str, str]:
     """Map `git status --porcelain` output → {path: 'new'|'updated'|'deleted'}.
 
@@ -193,13 +259,21 @@ def push(
     """Commit the vault's Markdown entries and push to the git remote. Alias: `koda push`."""
     init_db()
     vault = get_vault()
+    db = get_db()
     _require_git()
     if dry_run:
         _preview_push(vault)
         return
     _ensure_repo(vault)
-    _pull_rebase_if_remote(vault)
 
+    if _existing_conflicts(vault, db):
+        exit_error(
+            "Unresolved idx conflicts present — run `koda resolve` first.",
+            code=ExitCode.CONFLICT,
+        )
+
+    # Commit local changes first so `git pull --rebase` has a clean tree
+    # (koda resolve / edit / move / swap rewrite tracked files).
     try:
         _git(vault, "add", "-A")
     except subprocess.CalledProcessError as e:
@@ -207,19 +281,28 @@ def push(
         if e.stderr:
             console.print(f"[dim]{e.stderr.strip()}[/dim]")
         raise typer.Exit(code=1)
-    if _git(vault, "diff", "--cached", "--quiet", check=False).returncode == 0:
-        console.print("[yellow]No entry changes — nothing to commit.[/yellow]")
-        _push_if_remote(vault)
-        console.print("[green]Push complete.[/green]")
-        return
 
-    try:
-        _git(vault, "commit", "-m", "koda: sync entries")
-    except subprocess.CalledProcessError as e:
-        console.print("[red]git commit failed. Resolve issues in the vault and retry.[/red]")
-        if e.stderr:
-            console.print(f"[dim]{e.stderr.strip()}[/dim]")
-        raise typer.Exit(code=1)
+    if _git(vault, "diff", "--cached", "--quiet", check=False).returncode != 0:
+        try:
+            _git(vault, "commit", "-m", "koda: sync entries")
+        except subprocess.CalledProcessError as e:
+            console.print("[red]git commit failed. Resolve issues in the vault and retry.[/red]")
+            if e.stderr:
+                console.print(f"[dim]{e.stderr.strip()}[/dim]")
+            raise typer.Exit(code=1)
+
+    before = snapshot_idx(db)
+    _pull_rebase_if_remote(vault)
+    diff, groups = _reconcile_after_pull(vault, db, before)
+
+    if groups:
+        _report_sync(diff)
+        _report_conflicts(groups)
+        exit_error(
+            "Not pushing — resolve idx conflicts first (`koda resolve`).",
+            code=ExitCode.CONFLICT,
+        )
+
     _push_if_remote(vault)
     console.print("[green]Push complete.[/green]")
 
@@ -238,6 +321,7 @@ def pull(
     """
     init_db()
     vault = get_vault()
+    db = get_db()
     _require_git()
     if not _is_repo(vault):
         exit_error("Vault is not a git repository yet. Run `koda push` first.")
@@ -253,8 +337,25 @@ def pull(
         console.print(diff or "[green]Up to date with the remote.[/green]")
         return
 
+    if _existing_conflicts(vault, db):
+        exit_error(
+            "Unresolved idx conflicts present — run `koda resolve` first.",
+            code=ExitCode.CONFLICT,
+        )
+
+    before = snapshot_idx(db)
     _pull_rebase_if_remote(vault)
-    reconcile_all(get_db(), get_entries_dir())
+    diff, groups = _reconcile_after_pull(vault, db, before)
+
+    if groups:
+        _report_sync(diff)
+        _report_conflicts(groups)
+        exit_error(
+            "Sync paused on idx conflicts — run `koda resolve`, then `koda push`.",
+            code=ExitCode.CONFLICT,
+        )
+
+    _report_sync(diff)
     console.print("[green]Pull complete.[/green]")
 
 

--- a/src/koda/commands/memo.py
+++ b/src/koda/commands/memo.py
@@ -20,7 +20,7 @@ from ..db import compute_uid
 from ..main import RESERVED_SHORTCUTS, app
 from ..md_store import MdEntry, read_entry, write_entry
 from ..models import MemoRow
-from ..reconcile import sync_path
+from ..reconcile import find_conflicts, sync_path
 from ..runtime import (
     _read_stdin_refs,
     _validate_list_columns,
@@ -452,6 +452,13 @@ def _list_memos_impl(
     display: str | None = None,
 ) -> None:
     init_db()
+
+    conflicts = find_conflicts(get_db())
+    if conflicts:
+        console.print(
+            f"[bold yellow]Warning: {len(conflicts)} unresolved idx conflict(s) — "
+            f"run `koda resolve`.[/bold yellow]"
+        )
 
     if columns is None:
         columns = get_config().list_columns

--- a/src/koda/commands/resolve.py
+++ b/src/koda/commands/resolve.py
@@ -1,0 +1,169 @@
+"""Resolve duplicate display indices (idx conflicts).
+
+A conflict is two or more entries sharing the same ``idx``. This command lets
+the user pick a winner (keeps the idx) and moves the losers to the next free
+idx automatically. Interactive mode uses fzf when available (falling back to a
+numbered prompt); ``--ours``/``--theirs`` resolve non-interactively.
+"""
+
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+
+import typer
+from rich.text import Text
+
+from ..cli_utils import ExitCode, exit_error
+from ..cmd_helpers.display import format_conflict_entry
+from ..conflicts import clear_conflicts, load_conflicts
+from ..main import app
+from ..reconcile import annotate_groups, find_conflicts, snapshot_idx
+from ..runtime import console, get_db, get_vault, init_db
+from .index import _apply_idx
+
+
+def _pick_winner_fzf(entries: list[dict]) -> str | None:
+    lines = []
+    for e in entries:
+        first = ((e["content"] or "").splitlines() or [""])[0].replace("\t", " ")
+        label = (e["title"] or first).replace("\t", " ")
+        prev = e.get("prev_idx")
+        prev_s = f"was:{prev}" if prev is not None else "-"
+        lines.append(
+            f"{e['uid']}\t{e['side'] or '?'}\t{e['shortcut'] or '-'}\t"
+            f"{e['tags'] or '-'}\t{prev_s}\t{label}"
+        )
+    cmd = [
+        "fzf",
+        "--delimiter",
+        "\t",
+        "--with-nth",
+        "2,3,4,5,6",
+        "--prompt",
+        "keep> ",
+        "--preview",
+        "printf '%s\\n' '{6}'",
+        "--no-multi",
+    ]
+    extra = os.environ.get("KODA_FZF_OPTS", "").strip()
+    if extra:
+        cmd.extend(shlex.split(extra))
+    proc = subprocess.run(cmd, input="\n".join(lines), text=True, stdout=subprocess.PIPE)
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    return proc.stdout.strip().split("\t", 1)[0]
+
+
+def _pick_winner(idx: int, entries: list[dict]) -> str:
+    """Interactively choose which entry keeps ``idx``; returns the winning uid."""
+    console.print(f"\n[bold cyan]idx {idx}[/bold cyan] is held by {len(entries)} entries:")
+    for i, e in enumerate(entries, 1):
+        console.print(Text.assemble(f"  {i}. ", format_conflict_entry(e)))
+
+    if shutil.which("fzf") and sys.stdin.isatty():
+        uid = _pick_winner_fzf(entries)
+        if uid:
+            return uid
+        console.print("[dim](fzf cancelled — falling back to numbered prompt)[/dim]")
+
+    if not sys.stdin.isatty():
+        exit_error(
+            "Not a TTY: use `koda resolve --ours` or `--theirs` to resolve non-interactively.",
+            code=ExitCode.CANCELLED,
+        )
+    while True:
+        try:
+            raw = input("Keep which entry at this idx? (1..N, or q to abort): ").strip()
+        except EOFError:
+            exit_error("Aborted.", code=ExitCode.CANCELLED)
+        if raw.lower() in ("q", "quit"):
+            exit_error("Aborted.", code=ExitCode.CANCELLED)
+        if raw.isdigit() and 1 <= int(raw) <= len(entries):
+            return entries[int(raw) - 1]["uid"]
+        console.print("[yellow]Invalid choice — enter a number from the list.[/yellow]")
+
+
+@app.command(rich_help_panel="Git sync")
+def resolve(
+    ours: bool = typer.Option(
+        False, "--ours", help="Keep the local (ours) entry at each conflicted idx; move theirs."
+    ),
+    theirs: bool = typer.Option(
+        False,
+        "--theirs",
+        help="Keep the incoming (theirs) entry at each conflicted idx; move ours.",
+    ),
+):
+    """Resolve duplicate display indices and move the rejected side to a free idx.
+
+    Runs interactively (fzf / numbered prompt) by default. Use ``--ours`` or
+    ``--theirs`` to resolve every group non-interactively. After resolving, run
+    ``koda push`` to publish the resolved version so other machines converge.
+    """
+    if ours and theirs:
+        exit_error("Use only one of --ours or --theirs.", code=ExitCode.INVALID_ARG)
+
+    init_db()
+    vault = get_vault()
+    db = get_db()
+
+    groups = load_conflicts(vault)
+    if not groups:
+        groups = find_conflicts(db)
+        if groups:
+            annotate_groups(groups, snapshot_idx(db))
+    if not groups:
+        console.print("[green]No conflicts to resolve.[/green]")
+        return
+
+    next_free = db.allocate_idx()
+    changes: dict[str, int] = {}
+    report: list[tuple[int, dict, int]] = []
+
+    for g in groups:
+        idx = g["idx"]
+        entries = g["entries"]
+
+        if ours or theirs:
+            want = "ours" if ours else "theirs"
+            winners = [e for e in entries if e["side"] == want]
+            if not winners:
+                exit_error(
+                    f"idx {idx}: no '{want}' side to keep — resolve this group "
+                    f"interactively (`koda resolve`).",
+                    code=ExitCode.INVALID_ARG,
+                )
+            winner = winners[0]
+        else:
+            winner_uid = _pick_winner(idx, entries)
+            winner = next(e for e in entries if e["uid"] == winner_uid)
+
+        for e in entries:
+            if e["uid"] == winner["uid"]:
+                report.append((idx, e, idx))  # kept
+                continue
+            new_idx = next_free
+            next_free += 1
+            changes[e["uid"]] = new_idx
+            report.append((idx, e, new_idx))
+
+    _apply_idx(changes)
+    clear_conflicts(vault)
+
+    for idx, e, new_idx in report:
+        if new_idx == idx:
+            console.print(
+                Text.assemble(
+                    f"  idx {idx}: ", Text("kept ", style="green"), format_conflict_entry(e)
+                )
+            )
+        else:
+            console.print(
+                Text.assemble(
+                    f"  idx {idx} → {new_idx}: ", format_conflict_entry(e), f" (uid {e['uid']})"
+                )
+            )
+    console.print(f"\n[green]Resolved {len(groups)} conflict group(s).[/green]")
+    console.print("[dim]Now run `koda push` to publish the resolved version.[/dim]")

--- a/src/koda/conflicts.py
+++ b/src/koda/conflicts.py
@@ -1,0 +1,58 @@
+"""Local-only ledger for unresolved idx conflicts.
+
+A conflict is two (or more) distinct entries sharing the same display ``idx``.
+They are detected during ``koda pull``/``koda push`` and recorded here so
+``koda resolve`` can present an "ours vs theirs" choice. The file lives under
+``<vault>/.koda/`` (gitignored, mode 700) — like the cache and the trust ledger,
+it is never synced.
+
+Schema::
+
+    {
+      "groups": [
+        {
+          "idx": 32,
+          "entries": [
+            {
+              "uid": "…", "path": "z.md", "side": "ours",
+              "shortcut": "z", "tags": "cmd", "title": "Z",
+              "content": "…", "created_at": "…", "prev_idx": 32
+            },
+            …
+          ]
+        }
+      ]
+    }
+"""
+
+import json
+import os
+from pathlib import Path
+
+
+def conflicts_path(vault: Path) -> Path:
+    return vault / ".koda" / "conflicts.json"
+
+
+def load_conflicts(vault: Path) -> list[dict]:
+    """Return the recorded conflict groups (``[]`` when none or unreadable)."""
+    p = conflicts_path(vault)
+    if not p.exists():
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+    groups = data.get("groups", [])
+    return groups if isinstance(groups, list) else []
+
+
+def save_conflicts(vault: Path, groups: list[dict]) -> None:
+    p = conflicts_path(vault)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"groups": groups}, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.chmod(p, 0o600)
+
+
+def clear_conflicts(vault: Path) -> None:
+    conflicts_path(vault).unlink(missing_ok=True)

--- a/src/koda/main.py
+++ b/src/koda/main.py
@@ -111,7 +111,7 @@ def main(
 # every subcommand on ``app``. These imports must follow ``app`` (and ALIASES /
 # RESERVED_SHORTCUTS, which the command modules import from here).
 from .commands import exec as _exec  # noqa: E402,F401
-from .commands import git, index, manage, memo  # noqa: E402,F401
+from .commands import git, index, manage, memo, resolve  # noqa: E402,F401
 from .commands import update as _update  # noqa: E402,F401
 
 if __name__ == "__main__":

--- a/src/koda/reconcile.py
+++ b/src/koda/reconcile.py
@@ -167,3 +167,78 @@ def sync_path(db: MemoDatabase, entries_dir: Path, path: Path, *, blessed: bool)
 def remove_path(db: MemoDatabase, path: Path) -> None:
     """Drop the cache row for a file koda just deleted."""
     db.delete_by_path(path.name)
+
+
+# --------------------------------------------------------------------------- #
+# idx-conflict detection and sync diff (used by push/pull/resolve)
+# --------------------------------------------------------------------------- #
+def snapshot_idx(db: MemoDatabase) -> dict[str, int]:
+    """Return ``{uid: idx}`` for every cached entry — the sync-diff baseline."""
+    with db.connection() as conn:
+        rows = conn.execute("SELECT uid, idx FROM memos").fetchall()
+    return {uid: idx for uid, idx in rows if idx is not None}
+
+
+def compute_sync_diff(before: dict[str, int], after: dict[str, int]) -> dict[str, list]:
+    """Classify a uid→idx change between two snapshots.
+
+    Returns ``{"added": [uid], "removed": [uid], "moved": [(uid, old, new)]}``.
+    """
+    added = [uid for uid in after if uid not in before]
+    removed = [uid for uid in before if uid not in after]
+    moved = [
+        (uid, before[uid], after[uid])
+        for uid in before
+        if uid in after and before[uid] != after[uid]
+    ]
+    return {"added": added, "removed": removed, "moved": moved}
+
+
+def find_conflicts(db: MemoDatabase) -> list[dict]:
+    """Return ``[{idx, entries: [entry_dict]}]`` for every idx held by >1 entry.
+
+    Each ``entry_dict`` is JSON-serializable and carries ``side``/``prev_idx``
+    placeholders (filled by :func:`annotate_groups`).
+    """
+    by_idx: dict[int, list] = {}
+    for row in db.get_memos(sort_by="idx"):
+        by_idx.setdefault(row.idx, []).append(row)
+    groups = []
+    for idx, rows in sorted(by_idx.items()):
+        if len(rows) <= 1:
+            continue
+        entries = [
+            {
+                "uid": row.uid,
+                "path": db.path_for(row.uid) or "",
+                "idx": idx,
+                "shortcut": row.shortcut or "",
+                "tags": row.tags or "",
+                "title": row.title or "",
+                "content": row.content or "",
+                "created_at": row.created_at or "",
+                "side": None,
+                "prev_idx": None,
+            }
+            for row in rows
+        ]
+        groups.append({"idx": idx, "entries": entries})
+    return groups
+
+
+def annotate_groups(groups: list[dict], before: dict[str, int]) -> list[dict]:
+    """Attach ``side``/``prev_idx`` to each conflict entry given the pre-pull
+    ``{uid: idx}`` snapshot. ``ours`` = held this idx before; ``theirs`` =
+    incoming (brand-new, or moved from a different idx). Mutates and returns
+    ``groups``."""
+    for group in groups:
+        idx = group["idx"]
+        for e in group["entries"]:
+            uid = e["uid"]
+            if before.get(uid) == idx:
+                e["side"] = "ours"
+                e["prev_idx"] = idx
+            else:
+                e["side"] = "theirs"
+                e["prev_idx"] = before.get(uid)
+    return groups

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,0 +1,252 @@
+"""Tests for idx-conflict detection and `koda resolve`.
+
+Covers the reconcile-level helpers (``snapshot_idx`` / ``compute_sync_diff`` /
+``find_conflicts`` / ``annotate_groups``), the ``resolve`` command's
+``--ours``/``--theirs`` behavior, and an end-to-end two-machine convergence
+test (concurrent adds → conflict → resolve → push → pull).
+"""
+
+import subprocess
+
+import pytest
+import typer
+
+import koda.runtime as runtime
+from koda import conflicts as conflicts_mod
+from koda.commands import git, memo
+from koda.commands import resolve as resolve_cmd
+from koda.reconcile import (
+    annotate_groups,
+    compute_sync_diff,
+    find_conflicts,
+    snapshot_idx,
+)
+
+# ── reconcile helpers ────────────────────────────────────────────────────────
+
+
+def test_snapshot_idx_returns_uid_to_idx_map(db, seed):
+    a = seed("alpha")
+    b = seed("beta")
+    assert snapshot_idx(db) == {a.uid: a.idx, b.uid: b.idx}
+
+
+def test_compute_sync_diff_classifies_added_removed_moved():
+    diff = compute_sync_diff(
+        {"a": 0, "b": 1, "c": 2},
+        {"a": 0, "c": 5, "d": 6},
+    )
+    assert diff["added"] == ["d"]
+    assert diff["removed"] == ["b"]
+    assert diff["moved"] == [("c", 2, 5)]
+
+
+def test_find_conflicts_detects_duplicate_idx(db, write_md):
+    write_md("first", idx=3, uid="first-uid-000001")
+    write_md("second", idx=3, uid="second-uid-00001")
+    write_md("solo", idx=7, uid="solo-uid-0000001")
+
+    groups = find_conflicts(db)
+    assert len(groups) == 1
+    assert groups[0]["idx"] == 3
+    uids = {e["uid"] for e in groups[0]["entries"]}
+    assert uids == {"first-uid-000001", "second-uid-00001"}
+
+
+def test_find_conflicts_empty_when_unique(db, seed):
+    seed("alpha")
+    seed("beta")
+    assert find_conflicts(db) == []
+
+
+def test_annotate_groups_marks_ours_vs_theirs():
+    groups = [
+        {
+            "idx": 2,
+            "entries": [
+                {"uid": "ours-uid", "idx": 2, "side": None, "prev_idx": None},
+                {"uid": "moved-in", "idx": 2, "side": None, "prev_idx": None},
+                {"uid": "new-in", "idx": 2, "side": None, "prev_idx": None},
+            ],
+        }
+    ]
+    # Before the pull: ours held idx 2, moved-in held idx 9, new-in didn't exist.
+    annotate_groups(groups, {"ours-uid": 2, "moved-in": 9})
+    by_uid = {e["uid"]: e for e in groups[0]["entries"]}
+    assert by_uid["ours-uid"]["side"] == "ours"
+    assert by_uid["ours-uid"]["prev_idx"] == 2
+    assert by_uid["moved-in"]["side"] == "theirs"
+    assert by_uid["moved-in"]["prev_idx"] == 9
+    assert by_uid["new-in"]["side"] == "theirs"
+    assert by_uid["new-in"]["prev_idx"] is None
+
+
+# ── resolve command ──────────────────────────────────────────────────────────
+
+
+def _saved_groups():
+    return [
+        {
+            "idx": 2,
+            "entries": [
+                {
+                    "uid": "local-uid-000001",
+                    "path": "local.md",
+                    "idx": 2,
+                    "shortcut": "",
+                    "tags": "",
+                    "title": "",
+                    "content": "local entry",
+                    "created_at": "2026-01-01 00:00:00",
+                    "side": "ours",
+                    "prev_idx": 2,
+                },
+                {
+                    "uid": "remote-uid-0001",
+                    "path": "remote.md",
+                    "idx": 2,
+                    "shortcut": "",
+                    "tags": "",
+                    "title": "",
+                    "content": "remote entry",
+                    "created_at": "2026-01-01 00:00:00",
+                    "side": "theirs",
+                    "prev_idx": None,
+                },
+            ],
+        }
+    ]
+
+
+def test_resolve_ours_keeps_local_moves_theirs(vault, db, write_md):
+    write_md("local entry", idx=2, uid="local-uid-000001")
+    write_md("remote entry", idx=2, uid="remote-uid-0001", source="remote")
+    conflicts_mod.save_conflicts(vault, _saved_groups())
+
+    resolve_cmd.resolve(ours=True, theirs=False)
+
+    assert db.get_memo_by_uid("local-uid-000001").idx == 2
+    assert db.get_memo_by_uid("remote-uid-0001").idx == 3
+    assert conflicts_mod.load_conflicts(vault) == []
+
+
+def test_resolve_theirs_keeps_remote_moves_ours(vault, db, write_md):
+    write_md("local entry", idx=2, uid="local-uid-000001")
+    write_md("remote entry", idx=2, uid="remote-uid-0001", source="remote")
+    conflicts_mod.save_conflicts(vault, _saved_groups())
+
+    resolve_cmd.resolve(ours=False, theirs=True)
+
+    assert db.get_memo_by_uid("remote-uid-0001").idx == 2
+    assert db.get_memo_by_uid("local-uid-000001").idx == 3
+    assert conflicts_mod.load_conflicts(vault) == []
+
+
+def test_resolve_rejects_both_flags(vault, db, write_md):
+    write_md("local entry", idx=2, uid="local-uid-000001")
+    write_md("remote entry", idx=2, uid="remote-uid-0001", source="remote")
+    conflicts_mod.save_conflicts(vault, _saved_groups())
+
+    with pytest.raises(typer.Exit) as e:
+        resolve_cmd.resolve(ours=True, theirs=True)
+    assert e.value.exit_code == 1
+
+
+def test_resolve_no_conflicts_is_noop(vault, db, seed, capsys):
+    seed("just one")
+    resolve_cmd.resolve(ours=True, theirs=False)
+    out = capsys.readouterr().out
+    assert "No conflicts to resolve" in out
+
+
+# ── end-to-end two-machine convergence ───────────────────────────────────────
+
+
+def _switch_vault(monkeypatch, vault_dir, config_path):
+    monkeypatch.setenv("KODA_VAULT_PATH", str(vault_dir))
+    monkeypatch.setenv("KODA_DB_PATH_OVERRIDE", "1")
+    monkeypatch.setenv("KODA_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr(runtime, "_config", None)
+    monkeypatch.setattr(runtime, "_config_sources", None)
+    monkeypatch.setattr(runtime, "_config_manager", None)
+    monkeypatch.setattr(runtime, "_db", None)
+
+
+@pytest.fixture
+def bare_remote(tmp_path):
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", "-q", str(remote)], check=True)
+    return remote
+
+
+def _configure_git(vault, remote, email, name):
+    subprocess.run(["git", "init", "-q", str(vault)], check=True)
+    subprocess.run(["git", "-C", str(vault), "remote", "add", "origin", str(remote)], check=True)
+    subprocess.run(["git", "-C", str(vault), "config", "user.email", email], check=True)
+    subprocess.run(["git", "-C", str(vault), "config", "user.name", name], check=True)
+
+
+def _checkout_from_remote(vault, remote, ref_machine):
+    subprocess.run(["git", "-C", str(vault), "fetch", "-q", "origin"], check=True)
+    branch = subprocess.run(
+        ["git", "-C", str(ref_machine), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(vault), "checkout", "-q", "-B", branch, f"origin/{branch}"],
+        check=True,
+    )
+
+
+def test_concurrent_add_conflict_resolve_then_converge(tmp_path, bare_remote, monkeypatch, capsys):
+    machine_a = tmp_path / "machine-a"
+    machine_a.mkdir()
+    _switch_vault(monkeypatch, machine_a, tmp_path / "a.toml")
+    runtime.init_db()
+    memo._write_new_entry("entry one", "", None, None, None)
+    memo._write_new_entry("entry two", "", None, None, None)
+    _configure_git(machine_a, bare_remote, "a@example.com", "A")
+    git.push(dry_run=False)
+
+    machine_b = tmp_path / "machine-b"
+    machine_b.mkdir()
+    _configure_git(machine_b, bare_remote, "b@example.com", "B")
+    _checkout_from_remote(machine_b, bare_remote, machine_a)
+
+    # A adds X (idx 2) and pushes.
+    _switch_vault(monkeypatch, machine_a, tmp_path / "a.toml")
+    runtime.init_db()
+    x = memo._write_new_entry("X from A", "", None, None, None)
+    git.push(dry_run=False)
+
+    # B adds Y (idx 2) without pulling.
+    _switch_vault(monkeypatch, machine_b, tmp_path / "b.toml")
+    runtime.init_db()
+    y = memo._write_new_entry("Y from B", "", None, None, None)
+
+    # B push → blocked by conflict (exit code 5).
+    with pytest.raises(typer.Exit) as e:
+        git.push(dry_run=False)
+    assert e.value.exit_code == 5
+    capsys.readouterr()
+
+    groups = conflicts_mod.load_conflicts(machine_b)
+    assert len(groups) == 1 and groups[0]["idx"] == 2
+    sides = {entry["uid"]: entry["side"] for entry in groups[0]["entries"]}
+    assert sides[y.uid] == "ours"
+    assert sides[x.uid] == "theirs"
+
+    # B resolves --ours, keeping Y@2 and moving X@3, then pushes.
+    resolve_cmd.resolve(ours=True, theirs=False)
+    assert runtime.get_db().get_memo_by_uid(y.uid).idx == 2
+    assert runtime.get_db().get_memo_by_uid(x.uid).idx == 3
+    git.push(dry_run=False)
+
+    # A pulls and converges to the same idx mapping.
+    _switch_vault(monkeypatch, machine_a, tmp_path / "a.toml")
+    runtime.init_db()
+    git.pull(dry_run=False)
+    assert runtime.get_db().get_memo_by_uid(x.uid).idx == 3
+    assert runtime.get_db().get_memo_by_uid(y.uid).idx == 2


### PR DESCRIPTION
## Summary

Concurrent `koda add` on two machines can land two different entries on the same display index. Previously they collided silently and `koda list` showed a duplicate `idx`. This PR makes sync detect and surface that case.

- `koda push` / `koda pull` now detect duplicate `idx` values, skip auto-resolution, and pause with a new exit code `5` (a clear report shows the colliding entries with their `OURS` / `THEIRS` side).
- New `koda resolve` command: keep a chosen winner (interactive fzf / numbered prompt, or `--ours` / `--theirs` for non-interactive use) and move the rejected side to the next free index. `koda push` then publishes the resolved version so every machine converges on `pull` (entries whose index moved are reported as `N → M`).
- Unresolved conflicts block both `push` and `pull` until resolved; `koda list` shows a warning banner.
- `push` now commits local changes before `git pull --rebase`, so resolve / edit / move / swap (which rewrite tracked files) no longer fail on a dirty tree.

## Implementation notes

- `reconcile.py`: `snapshot_idx`, `compute_sync_diff`, `find_conflicts`, `annotate_groups` — the sync-diff and duplicate-idx detection primitives.
- `conflicts.py`: a local-only `.koda/conflicts.json` ledger (git-ignored, never synced) that records each conflict group with `ours`/`theirs` sides and the pre-pull index.
- `git.py`: both sync commands report added/removed/moved entries and record conflicts; `_existing_conflicts` guards the pre-existing conflict case.
- The moved index is reflected in each entry's Markdown frontmatter (the source of truth), so other machines pick it up naturally on the next reconcile.

## Checklist

- [x] `uv run ruff check src tests` passes
- [x] `uv run ruff format --check src tests` passes
- [x] `uv run pytest` passes (377 passed)
- [x] New behavior has tests (`tests/test_resolve.py`, 10 tests including a two-machine convergence E2E)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] `README.md` updated

Closes #
